### PR TITLE
Migrate node-mapper API from ICamelElementLookupResult to NodeIdentity

### DIFF
--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -308,8 +308,10 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     const fromNode = await NodeMapperService.getVizNode(
       `${this.getRootPath()}.from`,
       {
-        processorName: 'from' as keyof ProcessorDefinition,
-        componentName: CamelComponentSchemaService.getComponentNameFromUri(this.getRootUri()!),
+        primaryNodeId: {
+          name: 'from' as keyof ProcessorDefinition,
+          catalogKind: CatalogKind.Entity,
+        } satisfies NodeIdentity,
       },
       this.entityDef,
     );

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
@@ -5,6 +5,7 @@ import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
+import { NodeIdentity } from '../node-identity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
@@ -95,7 +96,12 @@ export class CamelInterceptFromVisualEntity
   async toVizNode(): Promise<IVisualizationNode<IVisualizationNodeData>> {
     const interceptFromGroupNode = await NodeMapperService.getVizNode(
       CamelInterceptFromVisualEntity.ROOT_PATH,
-      { processorName: CamelInterceptFromVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      {
+        primaryNodeId: {
+          name: CamelInterceptFromVisualEntity.ROOT_PATH as keyof ProcessorDefinition,
+          catalogKind: CatalogKind.Entity,
+        } satisfies NodeIdentity,
+      },
       this.interceptFromDef,
     );
     interceptFromGroupNode.data.entity = this;

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
@@ -5,6 +5,7 @@ import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
+import { NodeIdentity } from '../node-identity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
@@ -107,7 +108,12 @@ export class CamelInterceptSendToEndpointVisualEntity
   async toVizNode(): Promise<IVisualizationNode<IVisualizationNodeData>> {
     const interceptSendToEndpointGroupNode = await NodeMapperService.getVizNode(
       CamelInterceptSendToEndpointVisualEntity.ROOT_PATH,
-      { processorName: CamelInterceptSendToEndpointVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      {
+        primaryNodeId: {
+          name: CamelInterceptSendToEndpointVisualEntity.ROOT_PATH as keyof ProcessorDefinition,
+          catalogKind: CatalogKind.Entity,
+        } satisfies NodeIdentity,
+      },
       this.interceptSendToEndpointDef,
     );
     interceptSendToEndpointGroupNode.data.entity = this;

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
@@ -5,6 +5,7 @@ import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
+import { NodeIdentity } from '../node-identity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
@@ -78,7 +79,12 @@ export class CamelInterceptVisualEntity
   async toVizNode(): Promise<IVisualizationNode<IVisualizationNodeData>> {
     const interceptGroupNode = await NodeMapperService.getVizNode(
       CamelInterceptVisualEntity.ROOT_PATH,
-      { processorName: CamelInterceptVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      {
+        primaryNodeId: {
+          name: CamelInterceptVisualEntity.ROOT_PATH as keyof ProcessorDefinition,
+          catalogKind: CatalogKind.Entity,
+        } satisfies NodeIdentity,
+      },
       this.interceptDef,
     );
     interceptGroupNode.data.entity = this;

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
@@ -5,6 +5,7 @@ import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
+import { NodeIdentity } from '../node-identity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
@@ -80,7 +81,12 @@ export class CamelOnCompletionVisualEntity
   async toVizNode(): Promise<IVisualizationNode<IVisualizationNodeData>> {
     const onCompletionGroupNode = await NodeMapperService.getVizNode(
       CamelOnCompletionVisualEntity.ROOT_PATH,
-      { processorName: CamelOnCompletionVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      {
+        primaryNodeId: {
+          name: CamelOnCompletionVisualEntity.ROOT_PATH as keyof ProcessorDefinition,
+          catalogKind: CatalogKind.Entity,
+        } satisfies NodeIdentity,
+      },
       this.onCompletionDef,
     );
     onCompletionGroupNode.data.entity = this;

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -5,6 +5,7 @@ import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData, NodeInteraction } from '../base-visual-entity';
+import { NodeIdentity } from '../node-identity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
@@ -80,7 +81,12 @@ export class CamelOnExceptionVisualEntity
   async toVizNode(): Promise<IVisualizationNode<IVisualizationNodeData>> {
     const onExceptionGroupNode = await NodeMapperService.getVizNode(
       CamelOnExceptionVisualEntity.ROOT_PATH,
-      { processorName: CamelOnExceptionVisualEntity.ROOT_PATH as keyof ProcessorDefinition },
+      {
+        primaryNodeId: {
+          name: CamelOnExceptionVisualEntity.ROOT_PATH as keyof ProcessorDefinition,
+          catalogKind: CatalogKind.Entity,
+        } satisfies NodeIdentity,
+      },
       this.onExceptionDef,
     );
     onExceptionGroupNode.data.entity = this;

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
@@ -269,7 +269,6 @@ describe('CamelRouteConfigurationVisualEntity', () => {
         name: 'routeConfiguration',
         isGroup: true,
         path: 'routeConfiguration',
-        processorName: 'routeConfiguration',
         primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity },
         iconAlt: 'Entity icon',
         iconUrl: '/src/assets/components/generic-component.png',

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -18,6 +18,7 @@ import {
   IVisualizationNodeIds,
   NodeInteraction,
 } from '../base-visual-entity';
+import { NodeIdentity } from '../node-identity';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
@@ -168,7 +169,12 @@ export class CamelRouteConfigurationVisualEntity
   async toVizNode(): Promise<IVisualizationNode> {
     const routeConfigurationGroupNode = await NodeMapperService.getVizNode(
       this.getRootPath(),
-      { processorName: this.getRootPath() as keyof ProcessorDefinition },
+      {
+        primaryNodeId: {
+          name: this.getRootPath() as keyof ProcessorDefinition,
+          catalogKind: CatalogKind.Entity,
+        } satisfies NodeIdentity,
+      },
       this.routeConfigurationDef,
     );
     routeConfigurationGroupNode.data.entity = this;

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.test.ts
@@ -1,14 +1,13 @@
-import { ProcessorDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
-import { ICamelElementLookupResult } from '../../support/camel-component-types';
 import { RootNodeMapper } from '../root-node-mapper';
 import { BaseNodeMapper } from './base-node-mapper';
 
 describe('BaseNodeMapper', () => {
   let mapper: BaseNodeMapper;
   let path: string;
-  let componentLookup: ICamelElementLookupResult;
+  let componentLookup: { primaryNodeId: { name: string; catalogKind: CatalogKind } };
   let entityDefinition: unknown;
 
   beforeEach(() => {
@@ -16,12 +15,11 @@ describe('BaseNodeMapper', () => {
     mapper = new BaseNodeMapper(rootNodeMapper);
     rootNodeMapper.registerDefaultMapper(mapper);
 
-    path = 'from';
+    path = 'to';
     componentLookup = {
-      processorName: 'from' as keyof ProcessorDefinition,
-      componentName: 'timer',
+      primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
     };
-    entityDefinition = { uri: 'timer', parameters: { timerName: 'timerName' }, steps: [] };
+    entityDefinition = { to: { uri: 'timer', parameters: { timerName: 'timerName' } } };
   });
 
   describe('getVizNodeFromProcessor', () => {
@@ -32,17 +30,15 @@ describe('BaseNodeMapper', () => {
       expect(vizNode.data).toMatchObject({
         path,
         name: 'timer',
-        processorName: 'from',
-        componentName: 'timer',
       });
-      expect(vizNode.data.primaryNodeId).toEqual({ name: 'from', catalogKind: CatalogKind.Pattern });
+      expect(vizNode.data.primaryNodeId).toEqual({ name: 'to', catalogKind: CatalogKind.Pattern });
       expect(vizNode.data.secondaryNodeId).toEqual({ name: 'timer', catalogKind: CatalogKind.Component });
       expect(vizNode.data.tertiaryNodeId).toBeUndefined();
     });
 
     it('should set only primaryNodeId when there is no componentName (processor-only)', async () => {
-      const processorOnlyLookup: ICamelElementLookupResult = {
-        processorName: 'log' as keyof ProcessorDefinition,
+      const processorOnlyLookup = {
+        primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
       };
 
       const vizNode = await mapper.getVizNodeFromProcessor('route.log', processorOnlyLookup, {});
@@ -63,7 +59,11 @@ describe('BaseNodeMapper', () => {
         },
       };
 
-      const vizNode = await mapper.getVizNodeFromProcessor(path, componentLookup, routeDefinition);
+      const fromComponentLookup = {
+        primaryNodeId: { name: 'from', catalogKind: CatalogKind.Pattern },
+      };
+
+      const vizNode = await mapper.getVizNodeFromProcessor('from', fromComponentLookup, routeDefinition);
       expect(vizNode.getChildren()).toHaveLength(3);
       expect(vizNode.getChildren()?.[0].data.path).toBe('from.steps.0.log');
       expect(vizNode.getChildren()?.[1].data.path).toBe('from.steps.1.to');
@@ -88,7 +88,11 @@ describe('BaseNodeMapper', () => {
         },
       };
 
-      const vizNode = await mapper.getVizNodeFromProcessor(path, componentLookup, routeDefinition);
+      const fromComponentLookup = {
+        primaryNodeId: { name: 'from', catalogKind: CatalogKind.Pattern },
+      };
+
+      const vizNode = await mapper.getVizNodeFromProcessor('from', fromComponentLookup, routeDefinition);
       expect(vizNode.getChildren()).toHaveLength(2);
       expect(vizNode.getChildren()?.[0].data.path).toBe('from.steps.0.doTry');
       expect(vizNode.getChildren()?.[1].data.isPlaceholder).toBe(true);
@@ -104,13 +108,16 @@ describe('BaseNodeMapper', () => {
     });
 
     it('should handle kamelet components correctly', async () => {
-      const kameletComponentLookup: ICamelElementLookupResult = {
-        processorName: 'to' as keyof ProcessorDefinition,
-        componentName: 'kamelet:postgresql-sink',
+      const kameletComponentLookup = {
+        primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
       };
       const kameletEntityDefinition = {
-        uri: 'kamelet:postgresql-sink',
-        parameters: { serverName: 'localhost' },
+        route: {
+          to: {
+            uri: 'kamelet:postgresql-sink',
+            parameters: { serverName: 'localhost' },
+          },
+        },
       };
 
       const vizNode = await mapper.getVizNodeFromProcessor('route.to', kameletComponentLookup, kameletEntityDefinition);
@@ -119,12 +126,32 @@ describe('BaseNodeMapper', () => {
       expect(vizNode.data).toMatchObject({
         path: 'route.to',
         name: 'postgresql-sink', // Should strip 'kamelet:' prefix
-        processorName: 'to',
-        componentName: 'kamelet:postgresql-sink',
       });
       expect(vizNode.data.primaryNodeId).toEqual({ name: 'to', catalogKind: CatalogKind.Pattern });
       expect(vizNode.data.secondaryNodeId).toEqual({ name: 'kamelet', catalogKind: CatalogKind.Component });
       expect(vizNode.data.tertiaryNodeId).toEqual({ name: 'postgresql-sink', catalogKind: CatalogKind.Kamelet });
+    });
+
+    it('should handle a bare "kamelet" URI (no specific kamelet selected yet)', async () => {
+      const toWithBareKameletLookup = {
+        primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+      };
+      const entityDefinition = {
+        route: {
+          to: {
+            uri: 'kamelet',
+          },
+        },
+      };
+
+      const vizNode = await mapper.getVizNodeFromProcessor('route.to', toWithBareKameletLookup, entityDefinition);
+
+      expect(vizNode).toBeDefined();
+      // Should label the node as 'kamelet' (the component), not 'to' (the processor)
+      expect(vizNode.data.name).toBe('kamelet');
+      expect(vizNode.data.primaryNodeId).toEqual({ name: 'to', catalogKind: CatalogKind.Pattern });
+      expect(vizNode.data.secondaryNodeId).toEqual({ name: 'kamelet', catalogKind: CatalogKind.Component });
+      expect(vizNode.data.tertiaryNodeId).toBeUndefined();
     });
   });
 });

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
@@ -1,68 +1,42 @@
 import { DoCatch, ProcessorDefinition, When1 } from '@kaoto/camel-catalog/types';
+import { safeGetValue } from '@kaoto/forms';
 
-import { getValue } from '../../../../../utils';
+import { CamelUriHelper, getValue } from '../../../../../utils';
 import { CatalogKind } from '../../../../catalog-kind';
 import { PlaceholderType } from '../../../../placeholder.constants';
 import { SPECIAL_PROCESSORS_PARENTS_MAP } from '../../../../special-processors.constants';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
 import { CamelComponentSchemaService } from '../../support/camel-component-schema.service';
-import {
-  CamelProcessorStepsProperties,
-  CamelRouteVisualEntityData,
-  ICamelElementLookupResult,
-} from '../../support/camel-component-types';
+import { CamelProcessorStepsProperties } from '../../support/camel-component-types';
 import { INodeMapper } from '../node-mapper';
+
+const URI_PROCESSORS = new Set<string>(['to', 'toD', 'poll']);
 
 export class BaseNodeMapper implements INodeMapper {
   constructor(protected readonly rootNodeMapper: INodeMapper) {}
 
   async getVizNodeFromProcessor(
     path: string,
-    componentLookup: ICamelElementLookupResult,
+    componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
-    let name: string;
-    if (componentLookup.componentName?.startsWith('kamelet:')) {
-      // For Kamelets, remove the 'kamelet:' prefix from the name
-      // The resolvers will use the clean name to look up in the catalog
-      name = componentLookup.componentName.replace('kamelet:', '');
-    } else if (componentLookup.componentName) {
-      name = componentLookup.componentName;
-    } else {
-      name = componentLookup.processorName;
-    }
-    const primaryNodeId: NodeIdentity = {
-      name: componentLookup.processorName,
-      catalogKind: CatalogKind.Pattern,
-    };
+    const { componentName, kameletName } = this.getComponentAndKameletNames(
+      componentLookup.primaryNodeId,
+      entityDefinition,
+      path,
+    );
 
-    if (
-      SPECIAL_PROCESSORS_PARENTS_MAP['routeConfiguration'].includes(
-        primaryNodeId.name as (typeof SPECIAL_PROCESSORS_PARENTS_MAP)['routeConfiguration'][number],
-      )
-    ) {
-      primaryNodeId.catalogKind = CatalogKind.Entity;
-    }
-    let secondaryNodeId: NodeIdentity | undefined;
-    let tertiaryNodeId: NodeIdentity | undefined;
+    const { name, primaryNodeId, secondaryNodeId, tertiaryNodeId } = this.getCatalogAndNodeIds(
+      componentLookup.primaryNodeId?.name,
+      componentName,
+      kameletName,
+    );
 
-    if (componentLookup.componentName?.startsWith('kamelet:')) {
-      secondaryNodeId = { name: 'kamelet', catalogKind: CatalogKind.Component };
-      tertiaryNodeId = {
-        name: componentLookup.componentName.replace('kamelet:', ''),
-        catalogKind: CatalogKind.Kamelet,
-      };
-    } else if (componentLookup.componentName) {
-      secondaryNodeId = { name: componentLookup.componentName, catalogKind: CatalogKind.Component };
-    }
-
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name,
       path,
-      processorName: componentLookup.processorName,
-      componentName: componentLookup.componentName,
       isPlaceholder: false,
       isGroup: false,
       iconUrl: '',
@@ -77,7 +51,7 @@ export class BaseNodeMapper implements INodeMapper {
     const vizNode = createVisualizationNode(path, data);
 
     const childrenStepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-      componentLookup.processorName,
+      componentLookup.primaryNodeId?.name as keyof ProcessorDefinition,
     );
 
     if (childrenStepsProperties.length > 0) {
@@ -93,6 +67,78 @@ export class BaseNodeMapper implements INodeMapper {
     }
 
     return vizNode;
+  }
+
+  private getComponentAndKameletNames(
+    primaryNodeId: NodeIdentity | undefined,
+    entityDefinition: unknown,
+    path: string,
+  ): { componentName?: string; kameletName?: string } {
+    if (!primaryNodeId || !URI_PROCESSORS.has(primaryNodeId.name)) {
+      return {};
+    }
+    const definition = safeGetValue(entityDefinition, path);
+    const uri = CamelUriHelper.getUriString(definition);
+    if (!uri) {
+      return {};
+    }
+    const names = CamelUriHelper.getComponentAndKameletName(uri);
+    if ('kameletName' in names) {
+      return { componentName: names.componentName, kameletName: names.kameletName };
+    }
+    if (names.componentName !== undefined) {
+      return { componentName: names.componentName };
+    }
+    const scheme = uri.split(':')[0].trim();
+    if (scheme) {
+      return { componentName: scheme };
+    }
+    return {};
+  }
+
+  private getCatalogAndNodeIds(
+    primaryNodeIdName: string | undefined,
+    componentName?: string,
+    kameletName?: string,
+  ): {
+    name: string;
+    primaryNodeId: NodeIdentity;
+    secondaryNodeId?: NodeIdentity;
+    tertiaryNodeId?: NodeIdentity;
+  } {
+    let name: string;
+    if (kameletName) {
+      name = kameletName;
+    } else if (componentName) {
+      name = componentName;
+    } else {
+      name = primaryNodeIdName ?? '';
+    }
+
+    const primaryNodeId: NodeIdentity = {
+      name: primaryNodeIdName ?? '',
+      catalogKind: CatalogKind.Pattern,
+    };
+
+    if (
+      SPECIAL_PROCESSORS_PARENTS_MAP['routeConfiguration'].includes(
+        primaryNodeIdName as (typeof SPECIAL_PROCESSORS_PARENTS_MAP)['routeConfiguration'][number],
+      )
+    ) {
+      primaryNodeId.catalogKind = CatalogKind.Entity;
+    }
+
+    let secondaryNodeId: NodeIdentity | undefined;
+    let tertiaryNodeId: NodeIdentity | undefined;
+
+    if (kameletName) {
+      secondaryNodeId = { name: 'kamelet', catalogKind: CatalogKind.Component };
+      tertiaryNodeId = { name: kameletName, catalogKind: CatalogKind.Kamelet };
+    } else if (componentName) {
+      secondaryNodeId = { name: componentName, catalogKind: CatalogKind.Component };
+    }
+
+    return { name, primaryNodeId, secondaryNodeId, tertiaryNodeId };
   }
 
   protected async getVizNodesFromChildren(
@@ -125,10 +171,9 @@ export class BaseNodeMapper implements INodeMapper {
       const step = stepsList[index];
       const singlePropertyName = Object.keys(step)[0];
       const childPath = `${path}.${index}.${singlePropertyName}`;
-      const childComponentLookup = CamelComponentSchemaService.getCamelComponentLookup(
-        childPath,
-        getValue(step, singlePropertyName),
-      );
+      const childComponentLookup = {
+        primaryNodeId: { name: singlePropertyName, catalogKind: CatalogKind.Pattern } satisfies NodeIdentity,
+      };
 
       const vizNode = await this.rootNodeMapper.getVizNodeFromProcessor(
         childPath,
@@ -170,10 +215,13 @@ export class BaseNodeMapper implements INodeMapper {
   }
 
   protected async getChildrenFromSingleClause(path: string, entityDefinition: unknown): Promise<IVisualizationNode[]> {
-    const childComponentLookup = CamelComponentSchemaService.getCamelComponentLookup(path, entityDefinition);
-
     /** If the single-clause property is not defined, return a placeholder */
     if (getValue(entityDefinition, path) === undefined) return [this.getPlaceHolderNodeForProcessor(path)];
+
+    const processorName = path.split('.').pop() as keyof ProcessorDefinition;
+    const childComponentLookup = {
+      primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern } satisfies NodeIdentity,
+    };
 
     const singleClauseVizNode = await this.rootNodeMapper.getVizNodeFromProcessor(
       path,
@@ -191,7 +239,9 @@ export class BaseNodeMapper implements INodeMapper {
     for (let index = 0; index < expressionList.length; index++) {
       let childPath = `${path}.${index}`;
       const processorName = path.split('.').pop() as keyof ProcessorDefinition;
-      const childComponentLookup = { processorName };
+      const childComponentLookup = {
+        primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern } satisfies NodeIdentity,
+      };
 
       if (
         SPECIAL_PROCESSORS_PARENTS_MAP['routeConfiguration'].includes(

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/choice-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/choice-node-mapper.test.ts
@@ -44,21 +44,33 @@ describe('ChoiceNodeMapper', () => {
   });
 
   it('should return children', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'choice' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     // When placeholder (first) + 2 when nodes + otherwise = 4 children
     expect(vizNode.getChildren()).toHaveLength(4);
   });
 
   it('should populate primaryNodeId', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'choice' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.data.primaryNodeId).toEqual({ name: 'choice', catalogKind: CatalogKind.Pattern });
     expect(vizNode.data.secondaryNodeId).toBeUndefined();
   });
 
   it('should return when placeholder first, then `when` nodes as children', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'choice' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.getChildren()?.[0].data.path).toBe('from.steps.0.choice.when');
     expect(vizNode.getChildren()?.[0].data.isPlaceholder).toBe(true);
@@ -67,7 +79,11 @@ describe('ChoiceNodeMapper', () => {
   });
 
   it('should return an `otherwise` node if defined', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'choice' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.getChildren()?.[3].data.path).toBe('from.steps.0.choice.otherwise');
     expect(vizNode.getChildren()?.[3].data.isPlaceholder).toBe(false);
@@ -76,7 +92,11 @@ describe('ChoiceNodeMapper', () => {
   it('should return an `otherwise` placeholder if not defined', async () => {
     routeDefinition.from.steps[0].choice!.otherwise = undefined;
 
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'choice' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'choice', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     // When placeholder + 2 when nodes + otherwise placeholder = 4 children
     expect(vizNode.getChildren()).toHaveLength(4);

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/choice-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/choice-node-mapper.ts
@@ -1,24 +1,22 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class ChoiceNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName: keyof ProcessorDefinition = 'choice';
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName,
       isPlaceholder: false,
       isGroup: true,
       iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.test.ts
@@ -41,26 +41,42 @@ describe('CircuitBreakerNodeMapper', () => {
   });
 
   it('should return children', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'circuitBreaker', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.getChildren()).toHaveLength(3);
     expect(vizNode.getChildren()?.[1].data.isPlaceholder).toBe(true);
   });
 
   it('should populate primaryNodeId', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'circuitBreaker', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.data.primaryNodeId).toEqual({ name: 'circuitBreaker', catalogKind: CatalogKind.Pattern });
   });
 
   it('should return step nodes as children', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'circuitBreaker', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.getChildren()?.[0].data.path).toBe('from.steps.0.circuitBreaker.steps.0.log');
   });
 
   it('should return an `onFallback` node if defined', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'circuitBreaker', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.getChildren()?.[2].data.path).toBe('from.steps.0.circuitBreaker.onFallback');
   });
@@ -68,7 +84,11 @@ describe('CircuitBreakerNodeMapper', () => {
   it('should not return an `onFallback` node if not defined', async () => {
     routeDefinition.from.steps[0].circuitBreaker!.onFallback = undefined;
 
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'circuitBreaker' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'circuitBreaker', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.getChildren()).toHaveLength(3);
     expect(vizNode.getChildren()?.[0].data.path).toBe('from.steps.0.circuitBreaker.steps.0.log');

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/circuit-breaker-node-mapper.ts
@@ -1,24 +1,22 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class CircuitBreakerNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName: keyof ProcessorDefinition = 'circuitBreaker';
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName,
       isPlaceholder: false,
       isGroup: true,
       iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.test.ts
@@ -29,13 +29,21 @@ describe('DataMapperNodeMapper', () => {
 
   describe('getVizNodeFromProcessor', () => {
     it('should not return any children', async () => {
-      const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'step' }, routeDefinition);
+      const vizNode = await mapper.getVizNodeFromProcessor(
+        path,
+        { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
+        routeDefinition,
+      );
 
       expect(vizNode.getChildren()).toBeUndefined();
     });
 
     it('should populate primaryNodeId with CatalogKind.Pattern so the schema is resolved from the patterns catalog', async () => {
-      const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'step' }, routeDefinition);
+      const vizNode = await mapper.getVizNodeFromProcessor(
+        path,
+        { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
+        routeDefinition,
+      );
 
       expect(vizNode.data.primaryNodeId).toEqual({ name: DATAMAPPER_ID_PREFIX, catalogKind: CatalogKind.Pattern });
     });
@@ -43,12 +51,12 @@ describe('DataMapperNodeMapper', () => {
     it('should assign an unique ID for each DataMapper steps', async () => {
       const firstVizNode = await mapper.getVizNodeFromProcessor(
         firstDataMapperPath,
-        { processorName: 'step' },
+        { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
         twoDataMapperRouteDefinition,
       );
       const secondVizNode = await mapper.getVizNodeFromProcessor(
         secondDataMapperPath,
-        { processorName: 'step' },
+        { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
         twoDataMapperRouteDefinition,
       );
 

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/datamapper-node-mapper.ts
@@ -2,24 +2,22 @@ import { Step } from '@kaoto/camel-catalog/types';
 
 import { DATAMAPPER_ID_PREFIX, isDataMapperNode } from '../../../../../utils';
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class DataMapperNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     _entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName = DATAMAPPER_ID_PREFIX;
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName: DATAMAPPER_ID_PREFIX,
       isPlaceholder: false,
       isGroup: false,
       iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.test.ts
@@ -15,7 +15,7 @@ describe('FromNodeMapper', () => {
   let vizNode: IVisualizationNode;
   const path = 'route.from';
   const FROM_ENTITY = 'from' as keyof ProcessorDefinition;
-  const PROCESSOR_OPTIONS = { processorName: FROM_ENTITY };
+  const PROCESSOR_OPTIONS = { primaryNodeId: { name: FROM_ENTITY, catalogKind: CatalogKind.Entity } };
 
   beforeEach(async () => {
     rootNodeMapper = new RootNodeMapper();

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/from-node-mapper.ts
@@ -4,16 +4,15 @@ import { safeGetValue } from '@kaoto/forms';
 import { CamelUriHelper } from '../../../../../utils';
 import { isFromDefinition } from '../../../../../utils/is-from-definition';
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class FromNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName: keyof ProcessorDefinition = 'from' as keyof ProcessorDefinition;
@@ -31,11 +30,9 @@ export class FromNodeMapper extends BaseNodeMapper {
       }
     }
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: kameletName || componentName || processorName,
       path,
-      processorName,
-      componentName,
       isPlaceholder: false,
       isGroup: false,
       iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.test.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
 import { RootNodeMapper } from '../root-node-mapper';
@@ -39,7 +39,7 @@ describe('OnFallbackNodeMapper', () => {
   it('should return children', async () => {
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'onFallback' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'onFallback', catalogKind: CatalogKind.Pattern } },
       routeDefinition,
     );
 
@@ -49,7 +49,7 @@ describe('OnFallbackNodeMapper', () => {
   it('should populate primaryNodeId', async () => {
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'onFallback' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'onFallback', catalogKind: CatalogKind.Pattern } },
       routeDefinition,
     );
 

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/on-fallback-node-mapper.ts
@@ -1,24 +1,22 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class OnFallbackNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName = 'onFallback' as keyof ProcessorDefinition;
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName,
       isPlaceholder: false,
       isGroup: true,
       iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/otherwise-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/otherwise-node-mapper.test.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
 import { RootNodeMapper } from '../root-node-mapper';
@@ -40,7 +40,7 @@ describe('OtherwiseNodeMapper', () => {
   it('should return children', async () => {
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'otherwise' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern } },
       routeDefinition,
     );
 
@@ -51,7 +51,7 @@ describe('OtherwiseNodeMapper', () => {
   it('should populate primaryNodeId', async () => {
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'otherwise' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'otherwise', catalogKind: CatalogKind.Pattern } },
       routeDefinition,
     );
 

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/otherwise-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/otherwise-node-mapper.ts
@@ -1,24 +1,22 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class OtherwiseNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName = 'otherwise' as keyof ProcessorDefinition;
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName,
       isPlaceholder: false,
       isGroup: true,
       iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/parallel-processor-base-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/parallel-processor-base-node-mapper.test.ts
@@ -1,7 +1,4 @@
-import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
-
 import { CatalogKind } from '../../../../catalog-kind';
-import { ICamelElementLookupResult } from '../../support/camel-component-types';
 import { RootNodeMapper } from '../root-node-mapper';
 import { LoadBalanceNodeMapper } from './loadbalance-node-mapper';
 import { MulticastNodeMapper } from './multicast-node-mapper';
@@ -43,7 +40,7 @@ describe('ParallelProcessorBaseNodeMapper', () => {
         };
         const vizNode = await mapper.getVizNodeFromProcessor(
           path,
-          { processorName: processorName as keyof ProcessorDefinition } as ICamelElementLookupResult,
+          { primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern } },
           routeDefinition,
         );
 
@@ -51,7 +48,6 @@ describe('ParallelProcessorBaseNodeMapper', () => {
         expect(vizNode.data).toMatchObject({
           path,
           name: processorName,
-          processorName,
           isGroup: true,
         });
         // catalogKind is not set when lookup doesn't have componentName
@@ -91,7 +87,11 @@ describe('ParallelProcessorBaseNodeMapper', () => {
           },
         };
 
-        const vizNode = await mapper.getVizNodeFromProcessor(path, {} as ICamelElementLookupResult, routeDefinition);
+        const vizNode = await mapper.getVizNodeFromProcessor(
+          path,
+          { primaryNodeId: { name: processorName, catalogKind: CatalogKind.Pattern } },
+          routeDefinition,
+        );
         expect(vizNode.getChildren()).toHaveLength(3);
         expect(vizNode.getChildren()?.[0].getNextNode()).toBeUndefined();
         expect(vizNode.getChildren()?.[1].getPreviousNode()).toBeUndefined();

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/parallel-processor-base-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/parallel-processor-base-node-mapper.ts
@@ -1,10 +1,9 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export abstract class ParallelProcessorBaseNodeMapper extends BaseNodeMapper {
@@ -12,15 +11,14 @@ export abstract class ParallelProcessorBaseNodeMapper extends BaseNodeMapper {
 
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName = this.getProcessorName();
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName,
       isPlaceholder: false,
       isGroup: true,
       iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/route-configuration-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/route-configuration-node-mapper.test.ts
@@ -21,7 +21,7 @@ describe('RouteConfigurationNodeMapper', () => {
     const entityDef = { routeConfiguration: {} };
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
@@ -34,11 +34,11 @@ describe('RouteConfigurationNodeMapper', () => {
     const entityDef = { routeConfiguration: {} };
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
-    expect(vizNode.data.primaryNodeId).toEqual({ name: 'routeConfiguration', catalogKind: CatalogKind.Processor });
+    expect(vizNode.data.primaryNodeId).toEqual({ name: 'routeConfiguration', catalogKind: CatalogKind.Entity });
     expect(vizNode.data.secondaryNodeId).toBeUndefined();
   });
 
@@ -46,7 +46,7 @@ describe('RouteConfigurationNodeMapper', () => {
     const entityDef = { routeConfiguration: {} };
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
@@ -66,7 +66,7 @@ describe('RouteConfigurationNodeMapper', () => {
 
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
@@ -86,7 +86,7 @@ describe('RouteConfigurationNodeMapper', () => {
 
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
@@ -111,7 +111,7 @@ describe('RouteConfigurationNodeMapper', () => {
 
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
@@ -134,7 +134,7 @@ describe('RouteConfigurationNodeMapper', () => {
 
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
@@ -153,7 +153,7 @@ describe('RouteConfigurationNodeMapper', () => {
 
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
@@ -172,7 +172,7 @@ describe('RouteConfigurationNodeMapper', () => {
 
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 
@@ -194,7 +194,7 @@ describe('RouteConfigurationNodeMapper', () => {
 
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'routeConfiguration' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'routeConfiguration', catalogKind: CatalogKind.Entity } },
       entityDef,
     );
 

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/route-configuration-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/route-configuration-node-mapper.ts
@@ -2,30 +2,28 @@ import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
 import { SPECIAL_PROCESSORS_PARENTS_MAP } from '../../../../special-processors.constants';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class RouteConfigurationNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName = 'routeConfiguration' as keyof ProcessorDefinition;
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName,
       isPlaceholder: false,
       isGroup: true,
       iconUrl: '',
       title: '',
       description: '',
-      primaryNodeId: { name: processorName, catalogKind: CatalogKind.Processor } satisfies NodeIdentity,
+      primaryNodeId: { name: processorName, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
     };
 
     const vizNode = createVisualizationNode(path, data);

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/step-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/step-node-mapper.test.ts
@@ -44,25 +44,41 @@ describe('StepNodeMapper', () => {
   });
 
   it('should populate primaryNodeId for non-DataMapper step', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'step' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.data.primaryNodeId).toEqual({ name: 'step', catalogKind: CatalogKind.Pattern });
     expect(vizNode.data.secondaryNodeId).toBeUndefined();
   });
 
   it('should return children', async () => {
-    const vizNode = await mapper.getVizNodeFromProcessor(path, { processorName: 'step' }, routeDefinition);
+    const vizNode = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(vizNode.getChildren()).toHaveLength(2);
     expect(vizNode.getChildren()?.[1].data.isPlaceholder).toBe(true);
   });
 
   it('should use path for viz node ID for non DataMapper step node', async () => {
-    const vizNode1 = await mapper.getVizNodeFromProcessor(path, { processorName: 'step' }, routeDefinition);
+    const vizNode1 = await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
     expect(vizNode1.id).toBe('from.steps.0.step');
     expect(vizNode1.getChildren()).toHaveLength(2);
     expect(vizNode1.getChildren()?.[1].data.isPlaceholder).toBe(true);
-    const vizNode2 = await mapper.getVizNodeFromProcessor(path2, { processorName: 'step' }, routeDefinition);
+    const vizNode2 = await mapper.getVizNodeFromProcessor(
+      path2,
+      { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
     expect(vizNode2.id).toBe('from.steps.1.step');
     expect(vizNode2.getChildren()).toHaveLength(2);
     expect(vizNode2.getChildren()?.[1].data.isPlaceholder).toBe(true);
@@ -71,7 +87,11 @@ describe('StepNodeMapper', () => {
   it('should verify if this step node is a Kaoto DataMapper one', async () => {
     const dataMapperNodeSpy = vi.spyOn(DataMapperNodeMapper, 'isDataMapperNode');
 
-    await mapper.getVizNodeFromProcessor(path, { processorName: 'step' }, routeDefinition);
+    await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
     expect(dataMapperNodeSpy).toHaveBeenCalledWith(routeDefinition.from.steps[0].step);
   });
@@ -81,8 +101,16 @@ describe('StepNodeMapper', () => {
     const dataMapperNodeSpy = vi.spyOn(DataMapperNodeMapper, 'isDataMapperNode');
     dataMapperNodeSpy.mockReturnValue(true);
 
-    await mapper.getVizNodeFromProcessor(path, { processorName: 'step' }, routeDefinition);
+    await mapper.getVizNodeFromProcessor(
+      path,
+      { primaryNodeId: { name: 'step', catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
 
-    expect(rootNodeMapperSpy).toHaveBeenCalledWith(path, { processorName: DATAMAPPER_ID_PREFIX }, routeDefinition);
+    expect(rootNodeMapperSpy).toHaveBeenCalledWith(
+      path,
+      { primaryNodeId: { name: DATAMAPPER_ID_PREFIX, catalogKind: CatalogKind.Pattern } },
+      routeDefinition,
+    );
   });
 });

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/step-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/step-node-mapper.ts
@@ -2,25 +2,23 @@ import { ProcessorDefinition, Step } from '@kaoto/camel-catalog/types';
 
 import { DATAMAPPER_ID_PREFIX, getValue } from '../../../../../utils';
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 import { DataMapperNodeMapper } from './datamapper-node-mapper';
 
 export class StepNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName: keyof ProcessorDefinition = 'step';
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName,
       isPlaceholder: false,
       isGroup: true,
       iconUrl: '',
@@ -33,9 +31,7 @@ export class StepNodeMapper extends BaseNodeMapper {
     if (DataMapperNodeMapper.isDataMapperNode(stepDefinition)) {
       return this.rootNodeMapper.getVizNodeFromProcessor(
         path,
-        {
-          processorName: DATAMAPPER_ID_PREFIX,
-        },
+        { primaryNodeId: { name: DATAMAPPER_ID_PREFIX, catalogKind: CatalogKind.Pattern } satisfies NodeIdentity },
         entityDefinition,
       );
     }

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/testing/noop-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/testing/noop-node-mapper.ts
@@ -1,13 +1,9 @@
+import { IVisualizationNodeIds } from '../../../../base-visual-entity';
 import { createVisualizationNode } from '../../../../visualization-node';
-import { ICamelElementLookupResult } from '../../../support/camel-component-types';
 import { INodeMapper } from '../../node-mapper';
 
 export const noopNodeMapper: INodeMapper = {
-  getVizNodeFromProcessor: async (
-    path: string,
-    componentLookup: ICamelElementLookupResult,
-    entityDefinition: unknown,
-  ) => {
+  getVizNodeFromProcessor: async (path: string, componentLookup: IVisualizationNodeIds, entityDefinition: unknown) => {
     return createVisualizationNode('noop', {
       name: 'noop',
       path,

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/when-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/when-node-mapper.test.ts
@@ -1,4 +1,4 @@
-import { ProcessorDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
 import { RootNodeMapper } from '../root-node-mapper';
@@ -43,7 +43,7 @@ describe('WhenNodeMapper', () => {
   it('should return children', async () => {
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'when' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern } },
       routeDefinition,
     );
 
@@ -54,7 +54,7 @@ describe('WhenNodeMapper', () => {
   it('should populate primaryNodeId', async () => {
     const vizNode = await mapper.getVizNodeFromProcessor(
       path,
-      { processorName: 'when' as keyof ProcessorDefinition },
+      { primaryNodeId: { name: 'when', catalogKind: CatalogKind.Pattern } },
       routeDefinition,
     );
 

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/when-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/when-node-mapper.ts
@@ -1,24 +1,22 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { CatalogKind } from '../../../../catalog-kind';
-import { IVisualizationNode } from '../../../base-visual-entity';
+import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelRouteVisualEntityData, ICamelElementLookupResult } from '../../support/camel-component-types';
 import { BaseNodeMapper } from './base-node-mapper';
 
 export class WhenNodeMapper extends BaseNodeMapper {
   async getVizNodeFromProcessor(
     path: string,
-    _componentLookup: ICamelElementLookupResult,
+    _componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     const processorName = 'when' as keyof ProcessorDefinition;
 
-    const data: CamelRouteVisualEntityData = {
+    const data: IVisualizationNodeData = {
       name: processorName,
       path,
-      processorName,
       isPlaceholder: false,
       isGroup: true,
       iconUrl: '',

--- a/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.test.ts
@@ -1,4 +1,5 @@
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
+import { CatalogKind } from '../../../catalog-kind';
 import { BaseNodeMapper } from './mappers/base-node-mapper';
 import { ChoiceNodeMapper } from './mappers/choice-node-mapper';
 import { CircuitBreakerNodeMapper } from './mappers/circuit-breaker-node-mapper';
@@ -19,7 +20,11 @@ describe('NodeMapperService', () => {
     const registerDefaultMapperSpy = vi.spyOn(RootNodeMapper.prototype, 'registerDefaultMapper');
     const registerMapperSpy = vi.spyOn(RootNodeMapper.prototype, 'registerMapper');
 
-    await NodeMapperService.getVizNode('path', { processorName: 'log' }, {});
+    await NodeMapperService.getVizNode(
+      'path',
+      { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern } },
+      {},
+    );
 
     expect(registerDefaultMapperSpy).toHaveBeenCalledWith(expect.any(BaseNodeMapper));
     expect(registerMapperSpy).toHaveBeenCalledWith('from', expect.any(FromNodeMapper));

--- a/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-mapper.service.ts
@@ -1,8 +1,7 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
-import { IVisualizationNode } from '../../base-visual-entity';
-import { ICamelElementLookupResult } from '../support/camel-component-types';
+import { IVisualizationNode, IVisualizationNodeIds } from '../../base-visual-entity';
 import { BaseNodeMapper } from './mappers/base-node-mapper';
 import { ChoiceNodeMapper } from './mappers/choice-node-mapper';
 import { CircuitBreakerNodeMapper } from './mappers/circuit-breaker-node-mapper';
@@ -23,7 +22,7 @@ export class NodeMapperService {
 
   static async getVizNode(
     path: string,
-    componentLookup: ICamelElementLookupResult,
+    componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
     return this.getInstance().getVizNodeFromProcessor(path, componentLookup, entityDefinition);

--- a/packages/ui/src/models/visualization/flows/nodes/node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-mapper.ts
@@ -1,10 +1,9 @@
-import { IVisualizationNode } from '../../base-visual-entity';
-import { ICamelElementLookupResult } from '../support/camel-component-types';
+import { IVisualizationNode, IVisualizationNodeIds } from '../../base-visual-entity';
 
 export interface INodeMapper {
   getVizNodeFromProcessor(
     path: string,
-    componentLookup: ICamelElementLookupResult,
+    componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode>;
 }

--- a/packages/ui/src/models/visualization/flows/nodes/root-node-mapper.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/root-node-mapper.test.ts
@@ -1,3 +1,4 @@
+import { CatalogKind } from '../../../catalog-kind';
 import { noopNodeMapper } from './mappers/testing/noop-node-mapper';
 import { RootNodeMapper } from './root-node-mapper';
 
@@ -7,7 +8,13 @@ describe('RootNodeMapper', () => {
 
     rootNodeMapper.registerMapper('log', noopNodeMapper);
 
-    await expect(rootNodeMapper.getVizNodeFromProcessor('path', { processorName: 'log' }, {})).resolves.toBeDefined();
+    await expect(
+      rootNodeMapper.getVizNodeFromProcessor(
+        'path',
+        { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern } },
+        {},
+      ),
+    ).resolves.toBeDefined();
   });
 
   it('should allow consumers to register a default mapper', async () => {
@@ -15,15 +22,25 @@ describe('RootNodeMapper', () => {
 
     rootNodeMapper.registerDefaultMapper(noopNodeMapper);
 
-    await expect(rootNodeMapper.getVizNodeFromProcessor('path', { processorName: 'log' }, {})).resolves.toBeDefined();
+    await expect(
+      rootNodeMapper.getVizNodeFromProcessor(
+        'path',
+        { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern } },
+        {},
+      ),
+    ).resolves.toBeDefined();
   });
 
   it('should throw an error when no mapper is found', async () => {
     const rootNodeMapper = new RootNodeMapper();
 
-    await expect(rootNodeMapper.getVizNodeFromProcessor('path', { processorName: 'log' }, {})).rejects.toThrow(
-      'No mapper found for processor: log',
-    );
+    await expect(
+      rootNodeMapper.getVizNodeFromProcessor(
+        'path',
+        { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern } },
+        {},
+      ),
+    ).rejects.toThrow('No mapper found for processor: log');
   });
 
   describe('getVizNodeFromProcessor', () => {
@@ -32,9 +49,10 @@ describe('RootNodeMapper', () => {
       rootNodeMapper.registerDefaultMapper(noopNodeMapper);
       vi.spyOn(noopNodeMapper, 'getVizNodeFromProcessor');
 
-      const vizNode = await rootNodeMapper.getVizNodeFromProcessor('path', { processorName: 'log' }, {});
+      const componentLookup = { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern } };
+      const vizNode = await rootNodeMapper.getVizNodeFromProcessor('path', componentLookup, {});
 
-      expect(noopNodeMapper.getVizNodeFromProcessor).toHaveBeenCalledWith('path', { processorName: 'log' }, {});
+      expect(noopNodeMapper.getVizNodeFromProcessor).toHaveBeenCalledWith('path', componentLookup, {});
       expect(vizNode).toBeDefined();
     });
 
@@ -43,9 +61,10 @@ describe('RootNodeMapper', () => {
       rootNodeMapper.registerMapper('log', noopNodeMapper);
       vi.spyOn(noopNodeMapper, 'getVizNodeFromProcessor');
 
-      const vizNode = await rootNodeMapper.getVizNodeFromProcessor('path', { processorName: 'log' }, {});
+      const componentLookup = { primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern } };
+      const vizNode = await rootNodeMapper.getVizNodeFromProcessor('path', componentLookup, {});
 
-      expect(noopNodeMapper.getVizNodeFromProcessor).toHaveBeenCalledWith('path', { processorName: 'log' }, {});
+      expect(noopNodeMapper.getVizNodeFromProcessor).toHaveBeenCalledWith('path', componentLookup, {});
       expect(vizNode).toBeDefined();
     });
   });

--- a/packages/ui/src/models/visualization/flows/nodes/root-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/root-node-mapper.ts
@@ -1,7 +1,6 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
-import { IVisualizationNode } from '../../base-visual-entity';
-import { ICamelElementLookupResult } from '../support/camel-component-types';
+import { IVisualizationNode, IVisualizationNodeIds } from '../../base-visual-entity';
 import { INodeMapper } from './node-mapper';
 
 export class RootNodeMapper implements INodeMapper {
@@ -18,13 +17,14 @@ export class RootNodeMapper implements INodeMapper {
 
   async getVizNodeFromProcessor(
     path: string,
-    componentLookup: ICamelElementLookupResult,
+    componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
-    const mapper = this.mappers.get(componentLookup.processorName) || this.defaultMapper;
+    const mapper =
+      this.mappers.get(componentLookup.primaryNodeId?.name as keyof ProcessorDefinition) || this.defaultMapper;
 
     if (!mapper) {
-      throw new Error(`No mapper found for processor: ${componentLookup.processorName}`);
+      throw new Error(`No mapper found for processor: ${componentLookup.primaryNodeId?.name}`);
     }
 
     return mapper.getVizNodeFromProcessor(path, componentLookup, entityDefinition);

--- a/packages/ui/src/tests/__snapshots__/nodes-edges.test.ts.snap
+++ b/packages/ui/src/tests/__snapshots__/nodes-edges.test.ts.snap
@@ -18,7 +18,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
         },
         "children": [],
         "data": {
-          "componentName": "timer",
           "description": "timer: timer",
           "iconAlt": "component icon",
           "iconUrl": "/src/assets/components/timer.svg",
@@ -31,7 +30,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             "name": "from",
           },
           "processorIconTooltip": "",
-          "processorName": "from",
           "schema": undefined,
           "secondaryNodeId": {
             "catalogKind": "component",
@@ -109,7 +107,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "setHeader: setHeader",
                     "iconAlt": "pattern icon",
                     "iconUrl": "/src/assets/eip/setheader.png",
@@ -122,7 +119,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "setHeader",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "setHeader",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -208,7 +204,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "setHeader: setHeader",
                       "iconAlt": "pattern icon",
                       "iconUrl": "/src/assets/eip/setheader.png",
@@ -221,7 +216,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "setHeader",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "setHeader",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -248,7 +242,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "when",
                 },
                 "processorIconTooltip": "",
-                "processorName": "when",
                 "schema": undefined,
                 "title": "when",
               },
@@ -283,7 +276,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "log: log",
                     "iconAlt": "pattern icon",
                     "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -296,7 +288,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "log",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "log",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -382,7 +373,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "log: log",
                       "iconAlt": "pattern icon",
                       "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -395,7 +385,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "log",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "log",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -422,7 +411,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "otherwise",
                 },
                 "processorIconTooltip": "",
-                "processorName": "otherwise",
                 "schema": undefined,
                 "title": "otherwise",
               },
@@ -446,7 +434,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "choice",
             },
             "processorIconTooltip": "",
-            "processorName": "choice",
             "schema": undefined,
             "title": "choice",
           },
@@ -465,7 +452,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": undefined,
             "data": {
-              "componentName": "sql",
               "description": "sql: sql",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/sql_db.png",
@@ -478,7 +464,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "to",
               },
               "processorIconTooltip": "",
-              "processorName": "to",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -776,7 +761,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -789,7 +773,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -878,7 +861,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -891,7 +873,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -1072,7 +1053,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -1085,7 +1065,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -1171,7 +1150,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -1184,7 +1162,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -1211,7 +1188,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "when",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "when",
                     "schema": undefined,
                     "title": "when",
                   },
@@ -1246,7 +1222,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -1259,7 +1234,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -1345,7 +1319,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -1358,7 +1331,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -1385,7 +1357,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "otherwise",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "otherwise",
                     "schema": undefined,
                     "title": "otherwise",
                   },
@@ -1409,7 +1380,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -1428,7 +1398,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -1441,7 +1410,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -1503,7 +1471,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -1516,7 +1483,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -1628,7 +1594,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -1641,7 +1606,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -1727,7 +1691,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -1740,7 +1703,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -1767,7 +1729,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "when",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "when",
                       "schema": undefined,
                       "title": "when",
                     },
@@ -1802,7 +1763,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -1815,7 +1775,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -1901,7 +1860,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -1914,7 +1872,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -1941,7 +1898,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "otherwise",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "otherwise",
                       "schema": undefined,
                       "title": "otherwise",
                     },
@@ -1965,7 +1921,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "choice",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "choice",
                   "schema": undefined,
                   "title": "choice",
                 },
@@ -2019,7 +1974,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -2032,7 +1986,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -2113,7 +2066,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -2126,7 +2078,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -2212,7 +2163,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             },
                             "children": undefined,
                             "data": {
-                              "componentName": undefined,
                               "description": "setHeader: setHeader",
                               "iconAlt": "pattern icon",
                               "iconUrl": "/src/assets/eip/setheader.png",
@@ -2225,7 +2175,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                                 "name": "setHeader",
                               },
                               "processorIconTooltip": "",
-                              "processorName": "setHeader",
                               "schema": undefined,
                               "secondaryNodeId": undefined,
                               "tertiaryNodeId": undefined,
@@ -2252,7 +2201,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "when",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "when",
                         "schema": undefined,
                         "title": "when",
                       },
@@ -2287,7 +2235,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -2300,7 +2247,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -2386,7 +2332,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             },
                             "children": undefined,
                             "data": {
-                              "componentName": undefined,
                               "description": "log: log",
                               "iconAlt": "pattern icon",
                               "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -2399,7 +2344,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                                 "name": "log",
                               },
                               "processorIconTooltip": "",
-                              "processorName": "log",
                               "schema": undefined,
                               "secondaryNodeId": undefined,
                               "tertiaryNodeId": undefined,
@@ -2426,7 +2370,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "otherwise",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "otherwise",
                         "schema": undefined,
                         "title": "otherwise",
                       },
@@ -2450,7 +2393,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "choice",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "choice",
                     "schema": undefined,
                     "title": "choice",
                   },
@@ -2624,7 +2566,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "setHeader: setHeader",
                     "iconAlt": "pattern icon",
                     "iconUrl": "/src/assets/eip/setheader.png",
@@ -2637,7 +2578,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "setHeader",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "setHeader",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -2723,7 +2663,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "setHeader: setHeader",
                       "iconAlt": "pattern icon",
                       "iconUrl": "/src/assets/eip/setheader.png",
@@ -2736,7 +2675,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "setHeader",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "setHeader",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -2763,7 +2701,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "when",
                 },
                 "processorIconTooltip": "",
-                "processorName": "when",
                 "schema": undefined,
                 "title": "when",
               },
@@ -2798,7 +2735,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "log: log",
                     "iconAlt": "pattern icon",
                     "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -2811,7 +2747,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "log",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "log",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -2897,7 +2832,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "log: log",
                       "iconAlt": "pattern icon",
                       "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -2910,7 +2844,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "log",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "log",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -2937,7 +2870,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "otherwise",
                 },
                 "processorIconTooltip": "",
-                "processorName": "otherwise",
                 "schema": undefined,
                 "title": "otherwise",
               },
@@ -2961,7 +2893,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "choice",
             },
             "processorIconTooltip": "",
-            "processorName": "choice",
             "schema": undefined,
             "title": "choice",
           },
@@ -2980,7 +2911,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": undefined,
             "data": {
-              "componentName": "sql",
               "description": "sql: sql",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/sql_db.png",
@@ -2993,7 +2923,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "to",
               },
               "processorIconTooltip": "",
-              "processorName": "to",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -3058,7 +2987,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -3071,7 +2999,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -3197,7 +3124,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -3210,7 +3136,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -3367,7 +3292,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -3380,7 +3304,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -3408,7 +3331,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -3421,7 +3343,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -3510,7 +3431,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -3523,7 +3443,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -3634,7 +3553,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": [],
             "data": {
-              "componentName": "timer",
               "description": "timer: timer",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/timer.svg",
@@ -3647,7 +3565,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "from",
               },
               "processorIconTooltip": "",
-              "processorName": "from",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -3685,7 +3602,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -3698,7 +3614,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -3787,7 +3702,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -3800,7 +3714,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -3928,7 +3841,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
         },
         "children": undefined,
         "data": {
-          "componentName": undefined,
           "description": "setHeader: setHeader",
           "iconAlt": "pattern icon",
           "iconUrl": "/src/assets/eip/setheader.png",
@@ -3941,7 +3853,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             "name": "setHeader",
           },
           "processorIconTooltip": "",
-          "processorName": "setHeader",
           "schema": undefined,
           "secondaryNodeId": undefined,
           "tertiaryNodeId": undefined,
@@ -4006,7 +3917,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "when",
               },
               "processorIconTooltip": "",
-              "processorName": "when",
               "schema": undefined,
               "title": "when",
             },
@@ -4082,7 +3992,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -4095,7 +4004,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -4181,7 +4089,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -4194,7 +4101,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -4221,7 +4127,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "otherwise",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "otherwise",
                     "schema": undefined,
                     "title": "otherwise",
                   },
@@ -4245,7 +4150,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -4264,7 +4168,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -4277,7 +4180,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -4342,7 +4244,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": [],
                         "data": {
-                          "componentName": "timer",
                           "description": "timer: timer",
                           "iconAlt": "component icon",
                           "iconUrl": "/src/assets/components/timer.svg",
@@ -4355,7 +4256,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "from",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "from",
                           "schema": undefined,
                           "secondaryNodeId": {
                             "catalogKind": "component",
@@ -4481,7 +4381,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": [],
                       "data": {
-                        "componentName": "timer",
                         "description": "timer: timer",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/timer.svg",
@@ -4494,7 +4393,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "from",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "from",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -4651,7 +4549,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -4664,7 +4561,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -4692,7 +4588,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -4705,7 +4600,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -4794,7 +4688,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -4807,7 +4700,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -4918,7 +4810,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -4931,7 +4822,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -4969,7 +4859,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -4982,7 +4871,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -5071,7 +4959,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": "sql",
                           "description": "sql: sql",
                           "iconAlt": "component icon",
                           "iconUrl": "/src/assets/components/sql_db.png",
@@ -5084,7 +4971,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "to",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "to",
                           "schema": undefined,
                           "secondaryNodeId": {
                             "catalogKind": "component",
@@ -5248,7 +5134,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "when",
             },
             "processorIconTooltip": "",
-            "processorName": "when",
             "schema": undefined,
             "title": "when",
           },
@@ -5324,7 +5209,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "log: log",
                       "iconAlt": "pattern icon",
                       "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -5337,7 +5221,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "log",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "log",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -5423,7 +5306,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -5436,7 +5318,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -5463,7 +5344,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "otherwise",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "otherwise",
                   "schema": undefined,
                   "title": "otherwise",
                 },
@@ -5487,7 +5367,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "choice",
               },
               "processorIconTooltip": "",
-              "processorName": "choice",
               "schema": undefined,
               "title": "choice",
             },
@@ -5506,7 +5385,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -5519,7 +5397,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -5584,7 +5461,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": [],
                       "data": {
-                        "componentName": "timer",
                         "description": "timer: timer",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/timer.svg",
@@ -5597,7 +5473,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "from",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "from",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -5723,7 +5598,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -5736,7 +5610,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -5893,7 +5766,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -5906,7 +5778,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -5934,7 +5805,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -5947,7 +5817,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -6036,7 +5905,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -6049,7 +5917,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -6160,7 +6027,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -6173,7 +6039,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -6211,7 +6076,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -6224,7 +6088,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -6313,7 +6176,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -6326,7 +6188,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -6497,7 +6358,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": undefined,
                 "description": "setHeader: setHeader",
                 "iconAlt": "pattern icon",
                 "iconUrl": "/src/assets/eip/setheader.png",
@@ -6510,7 +6370,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "setHeader",
                 },
                 "processorIconTooltip": "",
-                "processorName": "setHeader",
                 "schema": undefined,
                 "secondaryNodeId": undefined,
                 "tertiaryNodeId": undefined,
@@ -6537,7 +6396,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "when",
             },
             "processorIconTooltip": "",
-            "processorName": "when",
             "schema": undefined,
             "title": "when",
           },
@@ -6613,7 +6471,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "log: log",
                       "iconAlt": "pattern icon",
                       "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -6626,7 +6483,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "log",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "log",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -6712,7 +6568,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -6725,7 +6580,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -6752,7 +6606,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "otherwise",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "otherwise",
                   "schema": undefined,
                   "title": "otherwise",
                 },
@@ -6776,7 +6629,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "choice",
               },
               "processorIconTooltip": "",
-              "processorName": "choice",
               "schema": undefined,
               "title": "choice",
             },
@@ -6795,7 +6647,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -6808,7 +6659,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -6873,7 +6723,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": [],
                       "data": {
-                        "componentName": "timer",
                         "description": "timer: timer",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/timer.svg",
@@ -6886,7 +6735,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "from",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "from",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -7012,7 +6860,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -7025,7 +6872,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -7182,7 +7028,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -7195,7 +7040,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -7223,7 +7067,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -7236,7 +7079,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -7325,7 +7167,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -7338,7 +7179,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -7449,7 +7289,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -7462,7 +7301,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -7500,7 +7338,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -7513,7 +7350,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -7602,7 +7438,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -7615,7 +7450,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -7731,7 +7565,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
           },
           "children": undefined,
           "data": {
-            "componentName": undefined,
             "description": "setHeader: setHeader",
             "iconAlt": "pattern icon",
             "iconUrl": "/src/assets/eip/setheader.png",
@@ -7744,7 +7577,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "setHeader",
             },
             "processorIconTooltip": "",
-            "processorName": "setHeader",
             "schema": undefined,
             "secondaryNodeId": undefined,
             "tertiaryNodeId": undefined,
@@ -7781,7 +7613,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "when",
               },
               "processorIconTooltip": "",
-              "processorName": "when",
               "schema": undefined,
               "title": "when",
             },
@@ -7857,7 +7688,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -7870,7 +7700,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -7956,7 +7785,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -7969,7 +7797,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -7996,7 +7823,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "otherwise",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "otherwise",
                     "schema": undefined,
                     "title": "otherwise",
                   },
@@ -8020,7 +7846,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -8039,7 +7864,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -8052,7 +7876,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -8117,7 +7940,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": [],
                         "data": {
-                          "componentName": "timer",
                           "description": "timer: timer",
                           "iconAlt": "component icon",
                           "iconUrl": "/src/assets/components/timer.svg",
@@ -8130,7 +7952,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "from",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "from",
                           "schema": undefined,
                           "secondaryNodeId": {
                             "catalogKind": "component",
@@ -8256,7 +8077,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": [],
                       "data": {
-                        "componentName": "timer",
                         "description": "timer: timer",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/timer.svg",
@@ -8269,7 +8089,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "from",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "from",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -8426,7 +8245,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -8439,7 +8257,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -8467,7 +8284,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -8480,7 +8296,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -8569,7 +8384,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -8582,7 +8396,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -8693,7 +8506,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -8706,7 +8518,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -8744,7 +8555,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -8757,7 +8567,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -8846,7 +8655,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": "sql",
                           "description": "sql: sql",
                           "iconAlt": "component icon",
                           "iconUrl": "/src/assets/components/sql_db.png",
@@ -8859,7 +8667,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "to",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "to",
                           "schema": undefined,
                           "secondaryNodeId": {
                             "catalogKind": "component",
@@ -9005,7 +8812,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": undefined,
             "data": {
-              "componentName": undefined,
               "description": "setHeader: setHeader",
               "iconAlt": "pattern icon",
               "iconUrl": "/src/assets/eip/setheader.png",
@@ -9018,7 +8824,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "setHeader",
               },
               "processorIconTooltip": "",
-              "processorName": "setHeader",
               "schema": undefined,
               "secondaryNodeId": undefined,
               "tertiaryNodeId": undefined,
@@ -9104,7 +8909,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": undefined,
                 "description": "setHeader: setHeader",
                 "iconAlt": "pattern icon",
                 "iconUrl": "/src/assets/eip/setheader.png",
@@ -9117,7 +8921,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "setHeader",
                 },
                 "processorIconTooltip": "",
-                "processorName": "setHeader",
                 "schema": undefined,
                 "secondaryNodeId": undefined,
                 "tertiaryNodeId": undefined,
@@ -9144,7 +8947,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             "name": "when",
           },
           "processorIconTooltip": "",
-          "processorName": "when",
           "schema": undefined,
           "title": "when",
         },
@@ -9220,7 +9022,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "log: log",
                     "iconAlt": "pattern icon",
                     "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -9233,7 +9034,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "log",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "log",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -9319,7 +9119,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "log: log",
                       "iconAlt": "pattern icon",
                       "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -9332,7 +9131,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "log",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "log",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -9359,7 +9157,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "otherwise",
                 },
                 "processorIconTooltip": "",
-                "processorName": "otherwise",
                 "schema": undefined,
                 "title": "otherwise",
               },
@@ -9383,7 +9180,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "choice",
             },
             "processorIconTooltip": "",
-            "processorName": "choice",
             "schema": undefined,
             "title": "choice",
           },
@@ -9402,7 +9198,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": undefined,
             "data": {
-              "componentName": "sql",
               "description": "sql: sql",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/sql_db.png",
@@ -9415,7 +9210,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "to",
               },
               "processorIconTooltip": "",
-              "processorName": "to",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -9480,7 +9274,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -9493,7 +9286,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -9619,7 +9411,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -9632,7 +9423,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -9789,7 +9579,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -9802,7 +9591,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -9830,7 +9618,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -9843,7 +9630,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -9932,7 +9718,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -9945,7 +9730,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -10056,7 +9840,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": [],
             "data": {
-              "componentName": "timer",
               "description": "timer: timer",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/timer.svg",
@@ -10069,7 +9852,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "from",
               },
               "processorIconTooltip": "",
-              "processorName": "from",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -10107,7 +9889,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -10120,7 +9901,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -10209,7 +9989,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -10222,7 +10001,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -10351,7 +10129,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
         },
         "children": undefined,
         "data": {
-          "componentName": undefined,
           "description": "log: log",
           "iconAlt": "pattern icon",
           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -10364,7 +10141,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             "name": "log",
           },
           "processorIconTooltip": "",
-          "processorName": "log",
           "schema": undefined,
           "secondaryNodeId": undefined,
           "tertiaryNodeId": undefined,
@@ -10429,7 +10205,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "otherwise",
               },
               "processorIconTooltip": "",
-              "processorName": "otherwise",
               "schema": undefined,
               "title": "otherwise",
             },
@@ -10504,7 +10279,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -10517,7 +10291,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -10603,7 +10376,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -10616,7 +10388,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -10643,7 +10414,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "when",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "when",
                     "schema": undefined,
                     "title": "when",
                   },
@@ -10668,7 +10438,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -10687,7 +10456,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -10700,7 +10468,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -10765,7 +10532,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": [],
                         "data": {
-                          "componentName": "timer",
                           "description": "timer: timer",
                           "iconAlt": "component icon",
                           "iconUrl": "/src/assets/components/timer.svg",
@@ -10778,7 +10544,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "from",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "from",
                           "schema": undefined,
                           "secondaryNodeId": {
                             "catalogKind": "component",
@@ -10904,7 +10669,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": [],
                       "data": {
-                        "componentName": "timer",
                         "description": "timer: timer",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/timer.svg",
@@ -10917,7 +10681,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "from",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "from",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -11074,7 +10837,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -11087,7 +10849,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -11115,7 +10876,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -11128,7 +10888,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -11217,7 +10976,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -11230,7 +10988,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -11341,7 +11098,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -11354,7 +11110,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -11392,7 +11147,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -11405,7 +11159,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -11494,7 +11247,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": "sql",
                           "description": "sql: sql",
                           "iconAlt": "component icon",
                           "iconUrl": "/src/assets/components/sql_db.png",
@@ -11507,7 +11259,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "to",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "to",
                           "schema": undefined,
                           "secondaryNodeId": {
                             "catalogKind": "component",
@@ -11671,7 +11422,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "otherwise",
             },
             "processorIconTooltip": "",
-            "processorName": "otherwise",
             "schema": undefined,
             "title": "otherwise",
           },
@@ -11746,7 +11496,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "setHeader: setHeader",
                       "iconAlt": "pattern icon",
                       "iconUrl": "/src/assets/eip/setheader.png",
@@ -11759,7 +11508,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "setHeader",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "setHeader",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -11845,7 +11593,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -11858,7 +11605,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -11885,7 +11631,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "when",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "when",
                   "schema": undefined,
                   "title": "when",
                 },
@@ -11910,7 +11655,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "choice",
               },
               "processorIconTooltip": "",
-              "processorName": "choice",
               "schema": undefined,
               "title": "choice",
             },
@@ -11929,7 +11673,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -11942,7 +11685,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -12007,7 +11749,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": [],
                       "data": {
-                        "componentName": "timer",
                         "description": "timer: timer",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/timer.svg",
@@ -12020,7 +11761,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "from",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "from",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -12146,7 +11886,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -12159,7 +11898,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -12316,7 +12054,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -12329,7 +12066,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -12357,7 +12093,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -12370,7 +12105,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -12459,7 +12193,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -12472,7 +12205,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -12583,7 +12315,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -12596,7 +12327,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -12634,7 +12364,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -12647,7 +12376,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -12736,7 +12464,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -12749,7 +12476,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -12920,7 +12646,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": undefined,
                 "description": "log: log",
                 "iconAlt": "pattern icon",
                 "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -12933,7 +12658,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "log",
                 },
                 "processorIconTooltip": "",
-                "processorName": "log",
                 "schema": undefined,
                 "secondaryNodeId": undefined,
                 "tertiaryNodeId": undefined,
@@ -12960,7 +12684,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "otherwise",
             },
             "processorIconTooltip": "",
-            "processorName": "otherwise",
             "schema": undefined,
             "title": "otherwise",
           },
@@ -13035,7 +12758,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "setHeader: setHeader",
                       "iconAlt": "pattern icon",
                       "iconUrl": "/src/assets/eip/setheader.png",
@@ -13048,7 +12770,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "setHeader",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "setHeader",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -13134,7 +12855,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -13147,7 +12867,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -13174,7 +12893,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "when",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "when",
                   "schema": undefined,
                   "title": "when",
                 },
@@ -13199,7 +12917,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "choice",
               },
               "processorIconTooltip": "",
-              "processorName": "choice",
               "schema": undefined,
               "title": "choice",
             },
@@ -13218,7 +12935,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -13231,7 +12947,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -13296,7 +13011,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": [],
                       "data": {
-                        "componentName": "timer",
                         "description": "timer: timer",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/timer.svg",
@@ -13309,7 +13023,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "from",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "from",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -13435,7 +13148,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -13448,7 +13160,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -13605,7 +13316,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -13618,7 +13328,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -13646,7 +13355,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -13659,7 +13367,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -13748,7 +13455,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -13761,7 +13467,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -13872,7 +13577,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -13885,7 +13589,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -13923,7 +13626,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -13936,7 +13638,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -14025,7 +13726,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -14038,7 +13738,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -14154,7 +13853,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
           },
           "children": undefined,
           "data": {
-            "componentName": undefined,
             "description": "log: log",
             "iconAlt": "pattern icon",
             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -14167,7 +13865,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "log",
             },
             "processorIconTooltip": "",
-            "processorName": "log",
             "schema": undefined,
             "secondaryNodeId": undefined,
             "tertiaryNodeId": undefined,
@@ -14204,7 +13901,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "otherwise",
               },
               "processorIconTooltip": "",
-              "processorName": "otherwise",
               "schema": undefined,
               "title": "otherwise",
             },
@@ -14279,7 +13975,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -14292,7 +13987,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -14378,7 +14072,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -14391,7 +14084,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -14418,7 +14110,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "when",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "when",
                     "schema": undefined,
                     "title": "when",
                   },
@@ -14443,7 +14134,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -14462,7 +14152,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -14475,7 +14164,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -14540,7 +14228,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": [],
                         "data": {
-                          "componentName": "timer",
                           "description": "timer: timer",
                           "iconAlt": "component icon",
                           "iconUrl": "/src/assets/components/timer.svg",
@@ -14553,7 +14240,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "from",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "from",
                           "schema": undefined,
                           "secondaryNodeId": {
                             "catalogKind": "component",
@@ -14679,7 +14365,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": [],
                       "data": {
-                        "componentName": "timer",
                         "description": "timer: timer",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/timer.svg",
@@ -14692,7 +14377,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "from",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "from",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -14849,7 +14533,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -14862,7 +14545,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -14890,7 +14572,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -14903,7 +14584,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -14992,7 +14672,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -15005,7 +14684,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -15116,7 +14794,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -15129,7 +14806,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -15167,7 +14843,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": "sql",
                         "description": "sql: sql",
                         "iconAlt": "component icon",
                         "iconUrl": "/src/assets/components/sql_db.png",
@@ -15180,7 +14855,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "to",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "to",
                         "schema": undefined,
                         "secondaryNodeId": {
                           "catalogKind": "component",
@@ -15269,7 +14943,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": "sql",
                           "description": "sql: sql",
                           "iconAlt": "component icon",
                           "iconUrl": "/src/assets/components/sql_db.png",
@@ -15282,7 +14955,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "to",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "to",
                           "schema": undefined,
                           "secondaryNodeId": {
                             "catalogKind": "component",
@@ -15428,7 +15100,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": undefined,
             "data": {
-              "componentName": undefined,
               "description": "log: log",
               "iconAlt": "pattern icon",
               "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -15441,7 +15112,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "log",
               },
               "processorIconTooltip": "",
-              "processorName": "log",
               "schema": undefined,
               "secondaryNodeId": undefined,
               "tertiaryNodeId": undefined,
@@ -15527,7 +15197,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": undefined,
                 "description": "log: log",
                 "iconAlt": "pattern icon",
                 "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -15540,7 +15209,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "log",
                 },
                 "processorIconTooltip": "",
-                "processorName": "log",
                 "schema": undefined,
                 "secondaryNodeId": undefined,
                 "tertiaryNodeId": undefined,
@@ -15567,7 +15235,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             "name": "otherwise",
           },
           "processorIconTooltip": "",
-          "processorName": "otherwise",
           "schema": undefined,
           "title": "otherwise",
         },
@@ -15642,7 +15309,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "setHeader: setHeader",
                     "iconAlt": "pattern icon",
                     "iconUrl": "/src/assets/eip/setheader.png",
@@ -15655,7 +15321,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "setHeader",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "setHeader",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -15741,7 +15406,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "setHeader: setHeader",
                       "iconAlt": "pattern icon",
                       "iconUrl": "/src/assets/eip/setheader.png",
@@ -15754,7 +15418,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "setHeader",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "setHeader",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -15781,7 +15444,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "when",
                 },
                 "processorIconTooltip": "",
-                "processorName": "when",
                 "schema": undefined,
                 "title": "when",
               },
@@ -15806,7 +15468,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "choice",
             },
             "processorIconTooltip": "",
-            "processorName": "choice",
             "schema": undefined,
             "title": "choice",
           },
@@ -15825,7 +15486,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": undefined,
             "data": {
-              "componentName": "sql",
               "description": "sql: sql",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/sql_db.png",
@@ -15838,7 +15498,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "to",
               },
               "processorIconTooltip": "",
-              "processorName": "to",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -15903,7 +15562,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": [],
                     "data": {
-                      "componentName": "timer",
                       "description": "timer: timer",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/timer.svg",
@@ -15916,7 +15574,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "from",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "from",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -16042,7 +15699,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -16055,7 +15711,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -16212,7 +15867,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -16225,7 +15879,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -16253,7 +15906,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -16266,7 +15918,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -16355,7 +16006,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -16368,7 +16018,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -16479,7 +16128,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": [],
             "data": {
-              "componentName": "timer",
               "description": "timer: timer",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/timer.svg",
@@ -16492,7 +16140,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "from",
               },
               "processorIconTooltip": "",
-              "processorName": "from",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -16530,7 +16177,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -16543,7 +16189,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -16632,7 +16277,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": "sql",
                       "description": "sql: sql",
                       "iconAlt": "component icon",
                       "iconUrl": "/src/assets/components/sql_db.png",
@@ -16645,7 +16289,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "to",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "to",
                       "schema": undefined,
                       "secondaryNodeId": {
                         "catalogKind": "component",
@@ -16833,7 +16476,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": undefined,
                   "description": "setHeader: setHeader",
                   "iconAlt": "pattern icon",
                   "iconUrl": "/src/assets/eip/setheader.png",
@@ -16846,7 +16488,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "setHeader",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "setHeader",
                   "schema": undefined,
                   "secondaryNodeId": undefined,
                   "tertiaryNodeId": undefined,
@@ -16932,7 +16573,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "setHeader: setHeader",
                     "iconAlt": "pattern icon",
                     "iconUrl": "/src/assets/eip/setheader.png",
@@ -16945,7 +16585,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "setHeader",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "setHeader",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -16972,7 +16611,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "when",
               },
               "processorIconTooltip": "",
-              "processorName": "when",
               "schema": undefined,
               "title": "when",
             },
@@ -17007,7 +16645,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": undefined,
                   "description": "log: log",
                   "iconAlt": "pattern icon",
                   "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -17020,7 +16657,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "log",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "log",
                   "schema": undefined,
                   "secondaryNodeId": undefined,
                   "tertiaryNodeId": undefined,
@@ -17106,7 +16742,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "log: log",
                     "iconAlt": "pattern icon",
                     "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -17119,7 +16754,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "log",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "log",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -17146,7 +16780,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "otherwise",
               },
               "processorIconTooltip": "",
-              "processorName": "otherwise",
               "schema": undefined,
               "title": "otherwise",
             },
@@ -17170,7 +16803,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             "name": "choice",
           },
           "processorIconTooltip": "",
-          "processorName": "choice",
           "schema": undefined,
           "title": "choice",
         },
@@ -17189,7 +16821,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
           },
           "children": undefined,
           "data": {
-            "componentName": "sql",
             "description": "sql: sql",
             "iconAlt": "component icon",
             "iconUrl": "/src/assets/components/sql_db.png",
@@ -17202,7 +16833,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "to",
             },
             "processorIconTooltip": "",
-            "processorName": "to",
             "schema": undefined,
             "secondaryNodeId": {
               "catalogKind": "component",
@@ -17267,7 +16897,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -17280,7 +16909,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -17406,7 +17034,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -17419,7 +17046,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -17576,7 +17202,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -17589,7 +17214,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -17617,7 +17241,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -17630,7 +17253,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -17719,7 +17341,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -17732,7 +17353,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -17843,7 +17463,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
           },
           "children": [],
           "data": {
-            "componentName": "timer",
             "description": "timer: timer",
             "iconAlt": "component icon",
             "iconUrl": "/src/assets/components/timer.svg",
@@ -17856,7 +17475,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "from",
             },
             "processorIconTooltip": "",
-            "processorName": "from",
             "schema": undefined,
             "secondaryNodeId": {
               "catalogKind": "component",
@@ -17894,7 +17512,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -17907,7 +17524,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -17996,7 +17612,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -18009,7 +17624,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -18136,7 +17750,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
         },
         "children": undefined,
         "data": {
-          "componentName": "sql",
           "description": "sql: sql",
           "iconAlt": "component icon",
           "iconUrl": "/src/assets/components/sql_db.png",
@@ -18149,7 +17762,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             "name": "to",
           },
           "processorIconTooltip": "",
-          "processorName": "to",
           "schema": undefined,
           "secondaryNodeId": {
             "catalogKind": "component",
@@ -18214,7 +17826,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -18227,7 +17838,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -18305,7 +17915,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -18318,7 +17927,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -18404,7 +18012,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             },
                             "children": undefined,
                             "data": {
-                              "componentName": undefined,
                               "description": "setHeader: setHeader",
                               "iconAlt": "pattern icon",
                               "iconUrl": "/src/assets/eip/setheader.png",
@@ -18417,7 +18024,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                                 "name": "setHeader",
                               },
                               "processorIconTooltip": "",
-                              "processorName": "setHeader",
                               "schema": undefined,
                               "secondaryNodeId": undefined,
                               "tertiaryNodeId": undefined,
@@ -18444,7 +18050,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "when",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "when",
                         "schema": undefined,
                         "title": "when",
                       },
@@ -18479,7 +18084,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -18492,7 +18096,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -18578,7 +18181,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             },
                             "children": undefined,
                             "data": {
-                              "componentName": undefined,
                               "description": "log: log",
                               "iconAlt": "pattern icon",
                               "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -18591,7 +18193,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                                 "name": "log",
                               },
                               "processorIconTooltip": "",
-                              "processorName": "log",
                               "schema": undefined,
                               "secondaryNodeId": undefined,
                               "tertiaryNodeId": undefined,
@@ -18618,7 +18219,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "otherwise",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "otherwise",
                         "schema": undefined,
                         "title": "otherwise",
                       },
@@ -18642,7 +18242,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "choice",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "choice",
                     "schema": undefined,
                     "title": "choice",
                   },
@@ -18723,7 +18322,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -18736,7 +18334,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -18822,7 +18419,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -18835,7 +18431,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -18862,7 +18457,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "when",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "when",
                       "schema": undefined,
                       "title": "when",
                     },
@@ -18897,7 +18491,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -18910,7 +18503,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -18996,7 +18588,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -19009,7 +18600,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -19036,7 +18626,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "otherwise",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "otherwise",
                       "schema": undefined,
                       "title": "otherwise",
                     },
@@ -19060,7 +18649,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "choice",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "choice",
                   "schema": undefined,
                   "title": "choice",
                 },
@@ -19081,7 +18669,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -19094,7 +18681,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -19220,7 +18806,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -19233,7 +18818,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -19311,7 +18895,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -19324,7 +18907,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -19410,7 +18992,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -19423,7 +19004,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -19450,7 +19030,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "when",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "when",
                       "schema": undefined,
                       "title": "when",
                     },
@@ -19485,7 +19064,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -19498,7 +19076,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -19584,7 +19161,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -19597,7 +19173,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -19624,7 +19199,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "otherwise",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "otherwise",
                       "schema": undefined,
                       "title": "otherwise",
                     },
@@ -19648,7 +19222,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "choice",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "choice",
                   "schema": undefined,
                   "title": "choice",
                 },
@@ -19729,7 +19302,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -19742,7 +19314,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -19828,7 +19399,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -19841,7 +19411,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -19868,7 +19437,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "when",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "when",
                     "schema": undefined,
                     "title": "when",
                   },
@@ -19903,7 +19471,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -19916,7 +19483,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -20002,7 +19568,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -20015,7 +19580,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -20042,7 +19606,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "otherwise",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "otherwise",
                     "schema": undefined,
                     "title": "otherwise",
                   },
@@ -20066,7 +19629,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -20087,7 +19649,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -20100,7 +19661,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -20298,7 +19858,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "setHeader: setHeader",
                     "iconAlt": "pattern icon",
                     "iconUrl": "/src/assets/eip/setheader.png",
@@ -20311,7 +19870,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "setHeader",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "setHeader",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -20397,7 +19955,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "setHeader: setHeader",
                       "iconAlt": "pattern icon",
                       "iconUrl": "/src/assets/eip/setheader.png",
@@ -20410,7 +19967,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "setHeader",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "setHeader",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -20437,7 +19993,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "when",
                 },
                 "processorIconTooltip": "",
-                "processorName": "when",
                 "schema": undefined,
                 "title": "when",
               },
@@ -20472,7 +20027,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": undefined,
                     "description": "log: log",
                     "iconAlt": "pattern icon",
                     "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -20485,7 +20039,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "log",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "log",
                     "schema": undefined,
                     "secondaryNodeId": undefined,
                     "tertiaryNodeId": undefined,
@@ -20571,7 +20124,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "log: log",
                       "iconAlt": "pattern icon",
                       "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -20584,7 +20136,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "log",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "log",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -20611,7 +20162,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "otherwise",
                 },
                 "processorIconTooltip": "",
-                "processorName": "otherwise",
                 "schema": undefined,
                 "title": "otherwise",
               },
@@ -20635,7 +20185,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "choice",
             },
             "processorIconTooltip": "",
-            "processorName": "choice",
             "schema": undefined,
             "title": "choice",
           },
@@ -20667,7 +20216,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -20680,7 +20228,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -20823,7 +20370,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": [],
             "data": {
-              "componentName": "timer",
               "description": "timer: timer",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/timer.svg",
@@ -20836,7 +20382,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "from",
               },
               "processorIconTooltip": "",
-              "processorName": "from",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -21046,7 +20591,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -21059,7 +20603,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -21137,7 +20680,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -21150,7 +20692,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -21236,7 +20777,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -21249,7 +20789,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -21276,7 +20815,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "when",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "when",
                       "schema": undefined,
                       "title": "when",
                     },
@@ -21311,7 +20849,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -21324,7 +20861,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -21410,7 +20946,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -21423,7 +20958,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -21450,7 +20984,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "otherwise",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "otherwise",
                       "schema": undefined,
                       "title": "otherwise",
                     },
@@ -21474,7 +21007,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "choice",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "choice",
                   "schema": undefined,
                   "title": "choice",
                 },
@@ -21493,7 +21025,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": undefined,
                   "data": {
-                    "componentName": "sql",
                     "description": "sql: sql",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/sql_db.png",
@@ -21506,7 +21037,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "to",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "to",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -21595,7 +21125,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -21608,7 +21137,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -21694,7 +21222,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -21707,7 +21234,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -21734,7 +21260,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "when",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "when",
                     "schema": undefined,
                     "title": "when",
                   },
@@ -21769,7 +21294,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -21782,7 +21306,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -21868,7 +21391,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -21881,7 +21403,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -21908,7 +21429,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "otherwise",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "otherwise",
                     "schema": undefined,
                     "title": "otherwise",
                   },
@@ -21932,7 +21452,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -21951,7 +21470,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -21964,7 +21482,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -21993,7 +21510,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -22006,7 +21522,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -22034,7 +21549,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -22047,7 +21561,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -22128,7 +21641,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -22141,7 +21653,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -22227,7 +21738,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -22240,7 +21750,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -22267,7 +21776,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "when",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "when",
                       "schema": undefined,
                       "title": "when",
                     },
@@ -22302,7 +21810,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -22315,7 +21822,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -22401,7 +21907,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -22414,7 +21919,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -22441,7 +21945,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "otherwise",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "otherwise",
                       "schema": undefined,
                       "title": "otherwise",
                     },
@@ -22465,7 +21968,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "choice",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "choice",
                   "schema": undefined,
                   "title": "choice",
                 },
@@ -22486,7 +21988,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -22499,7 +22000,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -22611,7 +22111,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
           },
           "children": undefined,
           "data": {
-            "componentName": "sql",
             "description": "sql: sql",
             "iconAlt": "component icon",
             "iconUrl": "/src/assets/components/sql_db.png",
@@ -22624,7 +22123,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               "name": "to",
             },
             "processorIconTooltip": "",
-            "processorName": "to",
             "schema": undefined,
             "secondaryNodeId": {
               "catalogKind": "component",
@@ -22661,7 +22159,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -22674,7 +22171,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -22752,7 +22248,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -22765,7 +22260,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -22851,7 +22345,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             },
                             "children": undefined,
                             "data": {
-                              "componentName": undefined,
                               "description": "setHeader: setHeader",
                               "iconAlt": "pattern icon",
                               "iconUrl": "/src/assets/eip/setheader.png",
@@ -22864,7 +22357,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                                 "name": "setHeader",
                               },
                               "processorIconTooltip": "",
-                              "processorName": "setHeader",
                               "schema": undefined,
                               "secondaryNodeId": undefined,
                               "tertiaryNodeId": undefined,
@@ -22891,7 +22383,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "when",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "when",
                         "schema": undefined,
                         "title": "when",
                       },
@@ -22926,7 +22417,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -22939,7 +22429,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -23025,7 +22514,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             },
                             "children": undefined,
                             "data": {
-                              "componentName": undefined,
                               "description": "log: log",
                               "iconAlt": "pattern icon",
                               "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -23038,7 +22526,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                                 "name": "log",
                               },
                               "processorIconTooltip": "",
-                              "processorName": "log",
                               "schema": undefined,
                               "secondaryNodeId": undefined,
                               "tertiaryNodeId": undefined,
@@ -23065,7 +22552,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "otherwise",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "otherwise",
                         "schema": undefined,
                         "title": "otherwise",
                       },
@@ -23089,7 +22575,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "choice",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "choice",
                     "schema": undefined,
                     "title": "choice",
                   },
@@ -23170,7 +22655,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -23183,7 +22667,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -23269,7 +22752,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -23282,7 +22764,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -23309,7 +22790,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "when",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "when",
                       "schema": undefined,
                       "title": "when",
                     },
@@ -23344,7 +22824,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -23357,7 +22836,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -23443,7 +22921,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -23456,7 +22933,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -23483,7 +22959,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "otherwise",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "otherwise",
                       "schema": undefined,
                       "title": "otherwise",
                     },
@@ -23507,7 +22982,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "choice",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "choice",
                   "schema": undefined,
                   "title": "choice",
                 },
@@ -23528,7 +23002,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -23541,7 +23014,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -23708,7 +23180,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "setHeader: setHeader",
                       "iconAlt": "pattern icon",
                       "iconUrl": "/src/assets/eip/setheader.png",
@@ -23721,7 +23192,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "setHeader",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "setHeader",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -23807,7 +23277,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -23820,7 +23289,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -23847,7 +23315,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "when",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "when",
                   "schema": undefined,
                   "title": "when",
                 },
@@ -23882,7 +23349,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "log: log",
                       "iconAlt": "pattern icon",
                       "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -23895,7 +23361,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "log",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "log",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -23981,7 +23446,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -23994,7 +23458,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -24021,7 +23484,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "otherwise",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "otherwise",
                   "schema": undefined,
                   "title": "otherwise",
                 },
@@ -24045,7 +23507,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "choice",
               },
               "processorIconTooltip": "",
-              "processorName": "choice",
               "schema": undefined,
               "title": "choice",
             },
@@ -24077,7 +23538,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -24090,7 +23550,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",
@@ -24202,7 +23661,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -24215,7 +23673,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -24371,7 +23828,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": [],
             "data": {
-              "componentName": "timer",
               "description": "timer: timer",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/timer.svg",
@@ -24384,7 +23840,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "from",
               },
               "processorIconTooltip": "",
-              "processorName": "from",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -24462,7 +23917,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -24475,7 +23929,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -24561,7 +24014,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -24574,7 +24026,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -24601,7 +24052,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "when",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "when",
                     "schema": undefined,
                     "title": "when",
                   },
@@ -24636,7 +24086,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -24649,7 +24098,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -24735,7 +24183,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -24748,7 +24195,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -24775,7 +24221,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "otherwise",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "otherwise",
                     "schema": undefined,
                     "title": "otherwise",
                   },
@@ -24799,7 +24244,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -24818,7 +24262,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": undefined,
                 "data": {
-                  "componentName": "sql",
                   "description": "sql: sql",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/sql_db.png",
@@ -24831,7 +24274,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "to",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "to",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -24951,7 +24393,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "setHeader: setHeader",
                       "iconAlt": "pattern icon",
                       "iconUrl": "/src/assets/eip/setheader.png",
@@ -24964,7 +24405,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "setHeader",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "setHeader",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -25050,7 +24490,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -25063,7 +24502,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -25090,7 +24528,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "when",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "when",
                   "schema": undefined,
                   "title": "when",
                 },
@@ -25125,7 +24562,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     },
                     "children": undefined,
                     "data": {
-                      "componentName": undefined,
                       "description": "log: log",
                       "iconAlt": "pattern icon",
                       "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -25138,7 +24574,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "log",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "log",
                       "schema": undefined,
                       "secondaryNodeId": undefined,
                       "tertiaryNodeId": undefined,
@@ -25224,7 +24659,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -25237,7 +24671,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -25264,7 +24697,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "otherwise",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "otherwise",
                   "schema": undefined,
                   "title": "otherwise",
                 },
@@ -25288,7 +24720,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "choice",
               },
               "processorIconTooltip": "",
-              "processorName": "choice",
               "schema": undefined,
               "title": "choice",
             },
@@ -25307,7 +24738,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -25320,7 +24750,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -25380,7 +24809,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": [],
               "data": {
-                "componentName": "timer",
                 "description": "timer: timer",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/timer.svg",
@@ -25393,7 +24821,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "from",
                 },
                 "processorIconTooltip": "",
-                "processorName": "from",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -25421,7 +24848,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
             },
             "children": undefined,
             "data": {
-              "componentName": "sql",
               "description": "sql: sql",
               "iconAlt": "component icon",
               "iconUrl": "/src/assets/components/sql_db.png",
@@ -25434,7 +24860,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 "name": "to",
               },
               "processorIconTooltip": "",
-              "processorName": "to",
               "schema": undefined,
               "secondaryNodeId": {
                 "catalogKind": "component",
@@ -25546,7 +24971,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "setHeader: setHeader",
                         "iconAlt": "pattern icon",
                         "iconUrl": "/src/assets/eip/setheader.png",
@@ -25559,7 +24983,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "setHeader",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "setHeader",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -25645,7 +25068,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -25658,7 +25080,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -25685,7 +25106,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "when",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "when",
                     "schema": undefined,
                     "title": "when",
                   },
@@ -25720,7 +25140,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       },
                       "children": undefined,
                       "data": {
-                        "componentName": undefined,
                         "description": "log: log",
                         "iconAlt": "pattern icon",
                         "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -25733,7 +25152,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           "name": "log",
                         },
                         "processorIconTooltip": "",
-                        "processorName": "log",
                         "schema": undefined,
                         "secondaryNodeId": undefined,
                         "tertiaryNodeId": undefined,
@@ -25819,7 +25237,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -25832,7 +25249,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -25859,7 +25275,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "otherwise",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "otherwise",
                     "schema": undefined,
                     "title": "otherwise",
                   },
@@ -25883,7 +25298,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "choice",
                 },
                 "processorIconTooltip": "",
-                "processorName": "choice",
                 "schema": undefined,
                 "title": "choice",
               },
@@ -25904,7 +25318,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                 },
                 "children": [],
                 "data": {
-                  "componentName": "timer",
                   "description": "timer: timer",
                   "iconAlt": "component icon",
                   "iconUrl": "/src/assets/components/timer.svg",
@@ -25917,7 +25330,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "from",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "from",
                   "schema": undefined,
                   "secondaryNodeId": {
                     "catalogKind": "component",
@@ -25976,7 +25388,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
               },
               "children": undefined,
               "data": {
-                "componentName": "sql",
                 "description": "sql: sql",
                 "iconAlt": "component icon",
                 "iconUrl": "/src/assets/components/sql_db.png",
@@ -25989,7 +25400,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   "name": "to",
                 },
                 "processorIconTooltip": "",
-                "processorName": "to",
                 "schema": undefined,
                 "secondaryNodeId": {
                   "catalogKind": "component",
@@ -26070,7 +25480,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "setHeader: setHeader",
                           "iconAlt": "pattern icon",
                           "iconUrl": "/src/assets/eip/setheader.png",
@@ -26083,7 +25492,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "setHeader",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "setHeader",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -26169,7 +25577,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "setHeader: setHeader",
                             "iconAlt": "pattern icon",
                             "iconUrl": "/src/assets/eip/setheader.png",
@@ -26182,7 +25589,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "setHeader",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "setHeader",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -26209,7 +25615,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "when",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "when",
                       "schema": undefined,
                       "title": "when",
                     },
@@ -26244,7 +25649,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         },
                         "children": undefined,
                         "data": {
-                          "componentName": undefined,
                           "description": "log: log",
                           "iconAlt": "pattern icon",
                           "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -26257,7 +25661,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                             "name": "log",
                           },
                           "processorIconTooltip": "",
-                          "processorName": "log",
                           "schema": undefined,
                           "secondaryNodeId": undefined,
                           "tertiaryNodeId": undefined,
@@ -26343,7 +25746,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                           },
                           "children": undefined,
                           "data": {
-                            "componentName": undefined,
                             "description": "log: log",
                             "iconAlt": "pattern icon",
                             "iconUrl": "data:image/svg+xml,%3c?xml%20version='1.0'%20encoding='utf-8'?%3e%3csvg%20fill='%233F4E67'%20version='1.1'%20id='Capa_1'%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20viewBox='0%200%20548.291%20548.291'%20xml:space='preserve'%20stroke='%233F4E67'%3e%3cg%20id='SVGRepo_bgCarrier'%20stroke-width='0'%3e%3c/g%3e%3cg%20id='SVGRepo_tracerCarrier'%20stroke-linecap='round'%20stroke-linejoin='round'%3e%3c/g%3e%3cg%20id='SVGRepo_iconCarrier'%3e%3cg%3e%3cpath%20d='M486.201,196.124h-13.166V132.59c0-0.396-0.062-0.795-0.115-1.196c-0.021-2.523-0.825-5-2.552-6.963L364.657,3.677%20c-0.033-0.031-0.064-0.042-0.085-0.073c-0.63-0.707-1.364-1.292-2.143-1.795c-0.229-0.157-0.461-0.286-0.702-0.421%20c-0.672-0.366-1.387-0.671-2.121-0.892c-0.2-0.055-0.379-0.136-0.577-0.188C358.23,0.118,357.401,0,356.562,0H96.757%20C84.894,0,75.256,9.651,75.256,21.502v174.613H62.092c-16.971,0-30.732,13.756-30.732,30.733v159.812%20c0,16.968,13.761,30.731,30.732,30.731h13.164V526.79c0,11.854,9.638,21.501,21.501,21.501h354.776%20c11.853,0,21.501-9.647,21.501-21.501V417.392h13.166c16.966,0,30.729-13.764,30.729-30.731V226.854%20C516.93,209.872,503.167,196.124,486.201,196.124z%20M96.757,21.502h249.054v110.009c0,5.939,4.817,10.75,10.751,10.75h94.972v53.861%20H96.757V21.502z%20M317.816,303.427c0,47.77-28.973,76.746-71.558,76.746c-43.234,0-68.531-32.641-68.531-74.152%20c0-43.679,27.887-76.319,70.906-76.319C293.389,229.702,317.816,263.213,317.816,303.427z%20M82.153,377.79V232.085h33.073v118.039%20h57.944v27.66H82.153V377.79z%20M451.534,520.962H96.757v-103.57h354.776V520.962z%20M461.176,371.092%20c-10.162,3.454-29.402,8.209-48.641,8.209c-26.589,0-45.833-6.698-59.24-19.664c-13.396-12.535-20.75-31.568-20.529-52.967%20c0.214-48.436,35.448-76.108,83.229-76.108c18.814,0,33.292,3.688,40.431,7.139l-6.92,26.37%20c-7.999-3.457-17.942-6.268-33.942-6.268c-27.449,0-48.209,15.567-48.209,47.134c0,30.049,18.807,47.771,45.831,47.771%20c7.564,0,13.623-0.852,16.21-2.152v-30.488h-22.478v-25.723h54.258V371.092L461.176,371.092z'%3e%3c/path%3e%3cpath%20d='M212.533,305.37c0,28.535,13.407,48.64,35.452,48.64c22.268,0,35.021-21.186,35.021-49.5%20c0-26.153-12.539-48.655-35.237-48.655C225.504,255.854,212.533,277.047,212.533,305.37z'%3e%3c/path%3e%3c/g%3e%3c/g%3e%3c/svg%3e",
@@ -26356,7 +25758,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                               "name": "log",
                             },
                             "processorIconTooltip": "",
-                            "processorName": "log",
                             "schema": undefined,
                             "secondaryNodeId": undefined,
                             "tertiaryNodeId": undefined,
@@ -26383,7 +25784,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                         "name": "otherwise",
                       },
                       "processorIconTooltip": "",
-                      "processorName": "otherwise",
                       "schema": undefined,
                       "title": "otherwise",
                     },
@@ -26407,7 +25807,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                     "name": "choice",
                   },
                   "processorIconTooltip": "",
-                  "processorName": "choice",
                   "schema": undefined,
                   "title": "choice",
                 },
@@ -26428,7 +25827,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                   },
                   "children": [],
                   "data": {
-                    "componentName": "timer",
                     "description": "timer: timer",
                     "iconAlt": "component icon",
                     "iconUrl": "/src/assets/components/timer.svg",
@@ -26441,7 +25839,6 @@ exports[`Nodes and Edges > should generate edges for steps with branches 1`] = `
                       "name": "from",
                     },
                     "processorIconTooltip": "",
-                    "processorName": "from",
                     "schema": undefined,
                     "secondaryNodeId": {
                       "catalogKind": "component",


### PR DESCRIPTION
#### Summary

This refactor replaces the `ICamelElementLookupResult` type (with its `processorName` / `componentName` bag of strings) as the public contract of the node-mapper pipeline with a typed `{ primaryNodeId: NodeIdentity; secondaryNodeId?: NodeIdentity }` shape. The change is purely structural — no new functionality is introduced.

#### Motivation

`ICamelElementLookupResult` was a loosely-typed bag that bundled processor lookup concerns with component resolution. `NodeIdentity` already carries both the `name` and `catalogKind`, making the intent explicit and removing the need for callers to smuggle component metadata through a separate, nullable `componentName` field.

#### Changes

**Node-mapper interfaces & service** ([`node-mapper.ts`](packages/ui/src/models/visualization/flows/nodes/node-mapper.ts), [`node-mapper.service.ts`](packages/ui/src/models/visualization/flows/nodes/node-mapper.service.ts), [`root-node-mapper.ts`](packages/ui/src/models/visualization/flows/nodes/root-node-mapper.ts))
- `INodeMapper.getVizNodeFromProcessor` and `NodeMapperService.getVizNode` now accept `{ primaryNodeId: NodeIdentity; secondaryNodeId?: NodeIdentity }` instead of `ICamelElementLookupResult`.
- `RootNodeMapper` resolves the concrete mapper using `primaryNodeId.name` rather than `processorName`.

**`BaseNodeMapper`** ([`base-node-mapper.ts`](packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts))
- Component / kamelet name resolution is extracted into a private `getComponentAndKameletNames()` helper that reads the URI from the entity definition for URI-bearing processors (`to`, `toD`, `poll`) — removing the need for callers to pre-compute `componentName`.
- Catalog-kind / node-id construction is extracted into `getCatalogAndNodeIds()`.
- Node data type narrowed from `CamelRouteVisualEntityData` → `IVisualizationNodeData`, removing the now-redundant `processorName` and `componentName` fields from node data payloads.
- Children are built with a plain `{ primaryNodeId: { name, catalogKind } }` literal rather than calling `CamelComponentSchemaService.getCamelComponentLookup`.

**Specialized node mappers** (choice, circuit-breaker, datamapper, from, on-fallback, otherwise, parallel-processor-base, route-configuration, step, when)
- All updated to the new signature; `CamelRouteVisualEntityData` replaced with `IVisualizationNodeData`; `processorName` field removed from constructed data objects.
- `RouteConfigurationNodeMapper` corrects the `primaryNodeId.catalogKind` to `CatalogKind.Entity` (was `CatalogKind.Processor`).

**Visual entities** (abstract-camel, route-configuration, intercept, intercept-from, intercept-send-to-endpoint, on-completion, on-exception)
- `toVizNode()` call-sites updated to pass an explicit `NodeIdentity` with the correct `catalogKind: CatalogKind.Entity` instead of a bare `{ processorName }` object.

**Tests & snapshots** — updated in lock-step with the production changes.

#### Impact

- No runtime behaviour change; the same visualization graph is produced.
- `ICamelElementLookupResult` is no longer imported in the node-mapper pipeline (usage confined to component-schema lookup, where it originated).
- `CamelRouteVisualEntityData` removed from node data construction; callers rely on the narrower `IVisualizationNodeData` interface.

fix: https://github.com/KaotoIO/kaoto/issues/3685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow visualization node identification across routes, processors, intercepts, conditions, and related entities.
  * Corrected component and Kamelet labeling, including support for bare Kamelet references.
  * Preserved placeholder nodes when optional clauses are missing.

* **Tests**
  * Expanded coverage for updated node identification and labeling.
  * Added validation for primary, secondary, and tertiary node relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->