### PR TITLE
refactor(DataMapper): give ExpansionPanel a real disclosure control

### DIFF
--- a/packages/ui/src/components/Document/BaseDocument.test.tsx
+++ b/packages/ui/src/components/Document/BaseDocument.test.tsx
@@ -1,4 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { ReactNode } from 'react';
+import type { Mock } from 'vitest';
 
 import {
   BODY_DOCUMENT_ID,
@@ -13,6 +15,8 @@ import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { TreeUIService } from '../../services/visualization/tree-ui.service';
 import { useDocumentTreeStore } from '../../store';
 import { TestUtil } from '../../stubs/datamapper/data-mapper';
+import { ExpansionContext } from '../ExpansionPanels/ExpansionContext';
+import { ExpansionPanel } from '../ExpansionPanels/ExpansionPanel';
 import { DocumentContent, DocumentHeader } from './BaseDocument';
 import { TargetDocumentNode } from './TargetDocumentNode';
 
@@ -104,6 +108,100 @@ describe('DocumentHeader', () => {
 
     const store = useDocumentTreeStore.getState();
     expect(store.selectedNodePath).toBeTruthy();
+  });
+
+  /**
+   * Characterization tests for a DocumentHeader rendered as an ExpansionPanel summary,
+   * which is how every source body, target body and parameter panel is composed.
+   *
+   * A header click currently performs two distinct actions at once: it selects the node
+   * for mapping AND toggles the panel. DocumentHeader deliberately does not stop
+   * propagation so that both happen. These tests pin that contract so any restructuring
+   * of the summary (see issue #3651) has to make the change deliberately.
+   */
+  describe('as an ExpansionPanel summary', () => {
+    const HEADER_TEST_ID = `document-doc-targetBody-${BODY_DOCUMENT_ID}`;
+
+    function renderInPanel(mockSetExpanded: Mock, additionalActions?: ReactNode[]) {
+      const document = new PrimitiveDocument(
+        new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
+      );
+
+      return render(
+        <DataMapperProvider>
+          <ExpansionContext.Provider
+            value={{
+              register: vi.fn(),
+              unregister: vi.fn(),
+              resize: vi.fn(),
+              setExpanded: mockSetExpanded,
+              queueLayoutChange: vi.fn(),
+              registerLayoutCallback: vi.fn(),
+              unregisterLayoutCallback: vi.fn(),
+            }}
+          >
+            <ExpansionPanel
+              id="target-body"
+              defaultExpanded
+              summary={
+                <DocumentHeader
+                  header={<div>Test Header</div>}
+                  document={document}
+                  documentType={DocumentType.TARGET_BODY}
+                  isReadOnly={false}
+                  additionalActions={additionalActions}
+                />
+              }
+            >
+              <div>Panel content</div>
+            </ExpansionPanel>
+          </ExpansionContext.Provider>
+        </DataMapperProvider>,
+      );
+    }
+
+    it('should both select the node and toggle the panel when the header is clicked', () => {
+      const mockSetExpanded = vi.fn();
+      renderInPanel(mockSetExpanded);
+
+      const headerContainer = screen.getByTestId(HEADER_TEST_ID);
+      const panel = headerContainer.closest('.expansion-panel');
+      expect(panel).toHaveAttribute('data-expanded', 'true');
+
+      fireEvent.click(headerContainer);
+
+      // Selection: handled by DocumentHeader itself.
+      expect(useDocumentTreeStore.getState().selectedNodePath).toBeTruthy();
+      // Expansion: the same click bubbles to the summary and toggles the panel.
+      expect(mockSetExpanded).toHaveBeenCalledWith('target-body', false);
+      expect(panel).toHaveAttribute('data-expanded', 'false');
+    });
+
+    it('should not toggle the panel when an action inside the header is clicked', () => {
+      const mockSetExpanded = vi.fn();
+      renderInPanel(mockSetExpanded, [
+        <button key="custom" type="button" data-testid="custom-action">
+          Custom
+        </button>,
+      ]);
+
+      fireEvent.click(screen.getByTestId('custom-action'));
+
+      // DocumentHeader stops propagation on its action list, so the panel is unaffected.
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+    });
+
+    it('should toggle the panel but not select the node when the summary is activated by keyboard', () => {
+      const mockSetExpanded = vi.fn();
+      renderInPanel(mockSetExpanded);
+
+      const summary = screen.getByTestId(HEADER_TEST_ID).closest('.expansion-panel__summary') as HTMLElement;
+      fireEvent.keyDown(summary, { key: 'Enter' });
+
+      expect(mockSetExpanded).toHaveBeenCalledWith('target-body', false);
+      // Keyboard activation targets the summary, so DocumentHeader never sees it.
+      expect(useDocumentTreeStore.getState().selectedNodePath).toBeFalsy();
+    });
   });
 });
 

--- a/packages/ui/src/components/Document/BaseDocument.test.tsx
+++ b/packages/ui/src/components/Document/BaseDocument.test.tsx
@@ -114,10 +114,12 @@ describe('DocumentHeader', () => {
    * Characterization tests for a DocumentHeader rendered as an ExpansionPanel summary,
    * which is how every source body, target body and parameter panel is composed.
    *
-   * A header click currently performs two distinct actions at once: it selects the node
-   * for mapping AND toggles the panel. DocumentHeader deliberately does not stop
-   * propagation so that both happen. These tests pin that contract so any restructuring
-   * of the summary (see issue #3651) has to make the change deliberately.
+   * A header click selects the node for mapping and nothing else; expansion belongs to
+   * the panel's disclosure button. These tests pin that split so any further
+   * restructuring of the summary (see issue #3651) has to change it deliberately.
+   *
+   * Before the disclosure refactor a single header click did both at once, because
+   * DocumentHeader deliberately does not stop propagation.
    */
   describe('as an ExpansionPanel summary', () => {
     const HEADER_TEST_ID = `document-doc-targetBody-${BODY_DOCUMENT_ID}`;

--- a/packages/ui/src/components/Document/BaseDocument.test.tsx
+++ b/packages/ui/src/components/Document/BaseDocument.test.tsx
@@ -160,7 +160,7 @@ describe('DocumentHeader', () => {
       );
     }
 
-    it('should both select the node and toggle the panel when the header is clicked', () => {
+    it('should select the node without toggling the panel when the header is clicked', () => {
       const mockSetExpanded = vi.fn();
       renderInPanel(mockSetExpanded);
 
@@ -172,9 +172,19 @@ describe('DocumentHeader', () => {
 
       // Selection: handled by DocumentHeader itself.
       expect(useDocumentTreeStore.getState().selectedNodePath).toBeTruthy();
-      // Expansion: the same click bubbles to the summary and toggles the panel.
+      // Expansion is now owned solely by the disclosure button, so the panel is untouched.
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+      expect(panel).toHaveAttribute('data-expanded', 'true');
+    });
+
+    it('should toggle the panel without selecting the node when the disclosure button is clicked', () => {
+      const mockSetExpanded = vi.fn();
+      renderInPanel(mockSetExpanded);
+
+      fireEvent.click(screen.getByTestId('target-body-disclosure'));
+
       expect(mockSetExpanded).toHaveBeenCalledWith('target-body', false);
-      expect(panel).toHaveAttribute('data-expanded', 'false');
+      expect(useDocumentTreeStore.getState().selectedNodePath).toBeFalsy();
     });
 
     it('should not toggle the panel when an action inside the header is clicked', () => {
@@ -191,16 +201,18 @@ describe('DocumentHeader', () => {
       expect(mockSetExpanded).not.toHaveBeenCalled();
     });
 
-    it('should toggle the panel but not select the node when the summary is activated by keyboard', () => {
+    it('should not treat the summary itself as a control', () => {
       const mockSetExpanded = vi.fn();
       renderInPanel(mockSetExpanded);
 
       const summary = screen.getByTestId(HEADER_TEST_ID).closest('.expansion-panel__summary') as HTMLElement;
+
+      // The summary is a plain container; DocumentHeader is no longer nested inside a
+      // second role="button", which is what made Enter/Space ambiguous.
+      expect(summary).not.toHaveAttribute('role', 'button');
       fireEvent.keyDown(summary, { key: 'Enter' });
 
-      expect(mockSetExpanded).toHaveBeenCalledWith('target-body', false);
-      // Keyboard activation targets the summary, so DocumentHeader never sees it.
-      expect(useDocumentTreeStore.getState().selectedNodePath).toBeFalsy();
+      expect(mockSetExpanded).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -134,7 +134,6 @@ const ParameterPanel: FunctionComponent<ParameterPanelProps> = ({
   }, [flattenedNodes.length, syncConnectionPorts]);
 
   const hasSchema = !parameterNodeData.isPrimitive;
-  const [isExpanded, setIsExpanded] = useState(hasSchema);
 
   const renderParameterItem = useCallback(
     (index: number) => {
@@ -202,11 +201,6 @@ const ParameterPanel: FunctionComponent<ParameterPanelProps> = ({
           <ParameterInputPlaceholder parameter={parameterName} onComplete={onStopRename} />
         ) : (
           <div className="parameter-panel__summary">
-            {hasSchema && (
-              <Icon isInline className="parameter-panel__chevron">
-                {isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}
-              </Icon>
-            )}
             <DocumentHeader
               header={<span className="panel-header-text panel-header-text--parameter">{parameterName}</span>}
               document={document}
@@ -219,7 +213,6 @@ const ParameterPanel: FunctionComponent<ParameterPanelProps> = ({
         )
       }
       onLayoutChange={syncConnectionPorts}
-      onExpandedChange={setIsExpanded}
     >
       {/* Only render children if parameter has schema */}
       {hasSchema && parameterTree && (

--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -2,7 +2,7 @@ import './BaseDocument.scss';
 import './Parameters.scss';
 
 import { ActionList, ActionListItem, Button, Icon, Label } from '@patternfly/react-core';
-import { AngleDownIcon, AngleRightIcon, EyeIcon, EyeSlashIcon, PlusIcon } from '@patternfly/react-icons';
+import { EyeIcon, EyeSlashIcon, PlusIcon } from '@patternfly/react-icons';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.scss
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.scss
@@ -22,7 +22,8 @@
   }
 
   &__summary {
-    cursor: pointer;
+    display: flex;
+    align-items: center;
     font-size: var(--datamapper-panel-header-font-size, var(--pf-t--global--font--size--heading--h5));
     font-weight: var(
       --pf-t--global--font--weight--200
@@ -36,6 +37,23 @@
     box-shadow: var(--pf-t--global--box-shadow--sm--bottom);
     user-select: none;
     flex-shrink: 0;
+  }
+
+  &__summary-content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__disclosure {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    padding: 0;
+    margin-right: var(--pf-t--global--spacer--sm);
+    border: none;
+    background: none;
+    color: inherit;
+    cursor: pointer;
   }
 
   &__content {

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -174,9 +174,25 @@ describe('ExpansionPanel', () => {
 
       const region = document.getElementById('test-panel-content');
       expect(region).toHaveAttribute('role', 'region');
+      expect(region).toHaveAttribute('aria-labelledby', 'test-panel-summary');
+      expect(document.getElementById('test-panel-summary')).toBeInTheDocument();
 
       fireEvent.click(disclosure);
       expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should keep collapsed content out of the tab order and the accessibility tree', () => {
+      renderPanel({ defaultExpanded: true });
+
+      const region = document.getElementById('test-panel-content') as HTMLElement;
+      // Expanded: content is reachable.
+      expect(region).not.toHaveAttribute('inert');
+
+      fireEvent.click(screen.getByTestId('test-panel-disclosure'));
+
+      // Collapsed: CSS only clips the row, so `inert` is what actually removes the
+      // content's controls from keyboard navigation and assistive technology.
+      expect(region).toHaveAttribute('inert');
     });
 
     it('should allow resize even when collapsible is false', () => {

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.test.tsx
@@ -125,45 +125,58 @@ describe('ExpansionPanel', () => {
       expect(panel).toHaveAttribute('data-expanded', 'false');
     });
 
-    it('should toggle expansion when summary is clicked', () => {
+    it('should toggle expansion when the disclosure button is clicked', () => {
       renderPanel({ defaultExpanded: true });
 
-      const summary = screen.getByText('Test Summary');
-
-      fireEvent.click(summary);
+      fireEvent.click(screen.getByTestId('test-panel-disclosure'));
 
       expect(mockSetExpanded).toHaveBeenCalledWith('test-panel', false);
 
-      const panel = summary.closest('.expansion-panel');
+      const panel = screen.getByText('Test Summary').closest('.expansion-panel');
       expect(panel).toHaveAttribute('data-expanded', 'false');
     });
 
-    it('should NOT allow expansion when there are no children', () => {
-      renderPanel({ children: null });
+    it('should NOT toggle expansion when the summary itself is clicked', () => {
+      renderPanel({ defaultExpanded: true });
 
       const summary = screen.getByText('Test Summary');
-
       fireEvent.click(summary);
 
-      // Should not call setExpanded
+      // The summary is not a control; only the disclosure button toggles.
+      expect(mockSetExpanded).not.toHaveBeenCalled();
+      expect(summary.closest('.expansion-panel')).toHaveAttribute('data-expanded', 'true');
+    });
+
+    it('should NOT render a disclosure button when there are no children', () => {
+      renderPanel({ children: null });
+
+      // Nothing to disclose, so no control is advertised.
+      expect(screen.queryByTestId('test-panel-disclosure')).not.toBeInTheDocument();
       expect(mockSetExpanded).not.toHaveBeenCalled();
     });
 
-    it('should NOT allow collapse when collapsible is false', () => {
+    it('should NOT render a disclosure button when collapsible is false', () => {
       renderPanel({ defaultExpanded: true, collapsible: false });
 
-      const summary = screen.getByText('Test Summary');
-      const panel = summary.closest('.expansion-panel');
+      const panel = screen.getByText('Test Summary').closest('.expansion-panel');
 
-      // Should start expanded
-      expect(panel).toHaveAttribute('data-expanded', 'true');
-
-      fireEvent.click(summary);
-
-      // Should not call setExpanded - panel cannot be collapsed
+      expect(screen.queryByTestId('test-panel-disclosure')).not.toBeInTheDocument();
       expect(mockSetExpanded).not.toHaveBeenCalled();
-      // Should still be expanded
       expect(panel).toHaveAttribute('data-expanded', 'true');
+    });
+
+    it('should expose disclosure state and the content it controls to assistive tech', () => {
+      renderPanel({ defaultExpanded: true });
+
+      const disclosure = screen.getByTestId('test-panel-disclosure');
+      expect(disclosure).toHaveAttribute('aria-expanded', 'true');
+      expect(disclosure).toHaveAttribute('aria-controls', 'test-panel-content');
+
+      const region = document.getElementById('test-panel-content');
+      expect(region).toHaveAttribute('role', 'region');
+
+      fireEvent.click(disclosure);
+      expect(disclosure).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('should allow resize even when collapsible is false', () => {
@@ -401,33 +414,28 @@ describe('ExpansionPanel', () => {
   });
 
   describe('Keyboard Behavior', () => {
-    it('should toggle expansion on Enter key', () => {
+    it.each(['{Enter}', ' '])(
+      'should toggle expansion when the disclosure button is activated with "%s"',
+      async (key) => {
+        const user = userEvent.setup();
+        renderPanel({ defaultExpanded: true });
+
+        screen.getByTestId('test-panel-disclosure').focus();
+        await user.keyboard(key);
+
+        expect(mockSetExpanded).toHaveBeenCalledWith('test-panel', false);
+      },
+    );
+
+    it('should not make the summary itself a keyboard target', () => {
       renderPanel({ defaultExpanded: true });
 
       const summary = screen.getByText('Test Summary').closest('.expansion-panel__summary') as HTMLElement;
+
+      expect(summary).not.toHaveAttribute('role', 'button');
+      expect(summary).not.toHaveAttribute('tabindex');
 
       fireEvent.keyDown(summary, { key: 'Enter' });
-
-      expect(mockSetExpanded).toHaveBeenCalledWith('test-panel', false);
-    });
-
-    it('should toggle expansion on Space key', () => {
-      renderPanel({ defaultExpanded: true });
-
-      const summary = screen.getByText('Test Summary').closest('.expansion-panel__summary') as HTMLElement;
-
-      fireEvent.keyDown(summary, { key: ' ' });
-
-      expect(mockSetExpanded).toHaveBeenCalledWith('test-panel', false);
-    });
-
-    it('should NOT toggle when a modifier key is held', () => {
-      renderPanel({ defaultExpanded: true });
-
-      const summary = screen.getByText('Test Summary').closest('.expansion-panel__summary') as HTMLElement;
-
-      fireEvent.keyDown(summary, { key: 'Enter', ctrlKey: true });
-
       expect(mockSetExpanded).not.toHaveBeenCalled();
     });
 
@@ -437,15 +445,8 @@ describe('ExpansionPanel', () => {
       renderPanel({
         defaultExpanded: true,
         summary: (
-          // Summary buttons stop click propagation so activating them does not toggle the panel.
-          <button
-            type="button"
-            data-testid="summary-button"
-            onClick={(event) => {
-              event.stopPropagation();
-              onButtonClick();
-            }}
-          >
+          // No stopPropagation: a control in the summary needs no special handling.
+          <button type="button" data-testid="summary-button" onClick={onButtonClick}>
             Confirm
           </button>
         ),

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
@@ -116,6 +116,7 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
   // disclose anything must not advertise one to assistive technology.
   const isDisclosable = Boolean(children) && collapsible;
   const contentId = `${id}-content`;
+  const summaryId = `${id}-summary`;
 
   // Use refs for stable event handlers that don't change during resize
   const mouseMoveHandlerRef = useRef<(e: MouseEvent) => void>(() => {});
@@ -245,10 +246,23 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
             <Icon isInline>{isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}</Icon>
           </button>
         )}
-        <div className="expansion-panel__summary-content">{summary}</div>
+        <div className="expansion-panel__summary-content" id={summaryId}>
+          {summary}
+        </div>
       </div>
 
-      <div className="expansion-panel__content" id={contentId} role="region" onScroll={onScroll}>
+      {/*
+        Collapsed content is only clipped by CSS, so without `inert` its controls stay
+        in the tab order and the accessibility tree while invisible.
+      */}
+      <div
+        className="expansion-panel__content"
+        id={contentId}
+        role="region"
+        aria-labelledby={summaryId}
+        inert={!isExpanded}
+        onScroll={onScroll}
+      >
         {children}
       </div>
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanel.tsx
@@ -1,5 +1,7 @@
 import './ExpansionPanel.scss';
 
+import { Icon } from '@patternfly/react-core';
+import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 import {
   FunctionComponent,
   PropsWithChildren,
@@ -110,19 +112,10 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
     }
   };
 
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (event.target !== event.currentTarget) return;
-      if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        event.stopPropagation();
-        toggleExpanded();
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isExpanded, children, collapsible],
-  );
+  // The disclosure button is the only expand/collapse control. Panels that cannot
+  // disclose anything must not advertise one to assistive technology.
+  const isDisclosable = Boolean(children) && collapsible;
+  const contentId = `${id}-content`;
 
   // Use refs for stable event handlers that don't change during resize
   const mouseMoveHandlerRef = useRef<(e: MouseEvent) => void>(() => {});
@@ -238,17 +231,24 @@ export const ExpansionPanel: FunctionComponent<PropsWithChildren<ExpansionPanelP
 
   return (
     <div className="expansion-panel" data-expanded={isExpanded} data-resizing={isResizing} ref={panelRef}>
-      <div
-        className="pf-v6-u-box-shadow-sm expansion-panel__summary"
-        role="button"
-        tabIndex={0}
-        onClick={toggleExpanded}
-        onKeyDown={handleKeyDown}
-      >
-        {summary}
+      <div className="pf-v6-u-box-shadow-sm expansion-panel__summary">
+        {isDisclosable && (
+          <button
+            type="button"
+            className="expansion-panel__disclosure"
+            data-testid={`${id}-disclosure`}
+            aria-expanded={isExpanded}
+            aria-controls={contentId}
+            aria-label={isExpanded ? 'Collapse panel' : 'Expand panel'}
+            onClick={toggleExpanded}
+          >
+            <Icon isInline>{isExpanded ? <AngleDownIcon /> : <AngleRightIcon />}</Icon>
+          </button>
+        )}
+        <div className="expansion-panel__summary-content">{summary}</div>
       </div>
 
-      <div className="expansion-panel__content" onScroll={onScroll}>
+      <div className="expansion-panel__content" id={contentId} role="region" onScroll={onScroll}>
         {children}
       </div>
 

--- a/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
+++ b/packages/ui/src/components/ExpansionPanels/ExpansionPanels.test.tsx
@@ -82,10 +82,13 @@ const clickElement = async (element: HTMLElement) => {
   });
 };
 
-const clickElements = async (labels: string[]) => {
+// Expansion is driven by the panel's disclosure button, not by the summary itself.
+const getDisclosure = (panelId: string) => screen.getByTestId(`${panelId}-disclosure`);
+
+const clickDisclosures = async (panelIds: string[]) => {
   await act(() => {
-    labels.forEach((label) => {
-      screen.getByText(label).click();
+    panelIds.forEach((panelId) => {
+      getDisclosure(panelId).click();
     });
     return delay(10);
   });
@@ -320,8 +323,7 @@ describe('ExpansionPanels', () => {
       let gridTemplate = getGridTemplate(container);
       expect(gridTemplate).toContain('300px 300px');
 
-      const panel1Summary = screen.getByText('Panel 1');
-      await clickElement(panel1Summary);
+      await clickElement(getDisclosure('panel-1'));
 
       gridTemplate = getGridTemplate(container);
       const heights = parseHeights(gridTemplate);
@@ -446,8 +448,7 @@ describe('ExpansionPanels', () => {
       const { container, rerender } = renderPanels([{ id: 'panel-1', summary: 'Panel 1', minHeight: 100 }]);
       await setupBasicPanels(container);
 
-      const panel1Summary = screen.getByText('Panel 1');
-      await clickElement(panel1Summary);
+      await clickElement(getDisclosure('panel-1'));
 
       rerender(
         <ExpansionPanels>{createPanelElement({ id: 'panel-1', summary: 'Panel 1', minHeight: 150 })}</ExpansionPanels>,
@@ -552,7 +553,7 @@ describe('ExpansionPanels', () => {
       mockContainerHeight(container, 200);
       await waitForUpdate();
 
-      await clickElements(['Panel 1', 'Panel 2', 'Panel 3']);
+      await clickDisclosures(['panel-1', 'panel-2', 'panel-3']);
 
       const gridTemplate = getGridTemplate(container);
       expect(gridTemplate).toBeTruthy();
@@ -804,8 +805,7 @@ describe('ExpansionPanels', () => {
       await setupPanelMocks(container);
 
       // Collapse a panel to trigger grid template change
-      const panel1Summary = screen.getByText('Panel 1');
-      await clickElement(panel1Summary);
+      await clickElement(getDisclosure('panel-1'));
 
       // Grid template should be updated
       const gridTemplate = getGridTemplate(container);


### PR DESCRIPTION
Phase 1 of #3651. **This does not close the issue** — see Scope below.

## Problem

The panel summary was a `div role="button"` wrapping whatever a consumer passed as `summary`, including inputs, action menus, and `DocumentHeader`'s own `role="button"`. Interactive descendants inside `role="button"` are invalid ARIA, and it forced every nested control to defend itself: keydown needed a `target !== currentTarget` guard, clicks needed `stopPropagation` wrappers, and screen readers announced the whole summary as one button.

## Change

The WAI-ARIA disclosure pattern. The summary becomes a plain container; expansion moves to a real `<button>` with `aria-expanded` and `aria-controls`.

- Disclosure button rendered **only** when the panel has children and is collapsible, so panels that cannot disclose anything (`target-body` is `collapsible={false}`, `parameters-header` has no children) advertise no control rather than lying to assistive tech.
- Content region gets an `id` and `role="region"` for `aria-controls` to point at.
- `role="button"`, `tabIndex` and the keydown handler are gone from the summary, which removes the `target !== currentTarget` guard entirely.
- `Parameters` rendered its own chevron purely to mirror panel state; that moves into the panel, and the `isExpanded` state plus `onExpandedChange` wiring that existed only to feed it go with it.

## Behaviour change, deliberate

**Clicking the summary no longer toggles the panel.** Expansion is the disclosure button's job.

This is the decision the issue implies but doesn't state. On a document header, one click previously did two unrelated things at once — selected the node for mapping *and* toggled the panel — because `DocumentHeader` deliberately does not stop propagation. Only one of those could survive being made accessible. **Node selection is preserved untouched**; expansion is what moved.

If you would rather keep click-anywhere-to-expand, say so and I will restore the summary's `onClick`. It costs the click half of the issue: nested controls would still bubble into a toggle and would still need `stopPropagation`.

## Scope

Phase 1 only. `DocumentHeader` still renders its own `role="button"` around real action buttons (`BaseDocument.tsx:117`, `:151`), so the no-interactive-descendants violation and its local `stopPropagation` remain one level down for source body, target body and parameter summaries. #3651 should stay open until that lands.

## Verification

First commit is characterization tests, added before any production change, pinning the current contract so this refactor had to change expectations visibly rather than silently. Each was verified to pin exactly one behaviour: removing the summary's `onClick`, `DocumentHeader`'s action-list `stopPropagation`, or the summary's `onKeyDown` fails one test and only that one.

Reverting just the production changes and keeping the tests fails 15 tests. Among them, `should let a focused button inside the summary be activated` now fails on the old code **because this PR deletes the `stopPropagation` its fixture previously needed** — the most direct evidence that "new interactive elements in summary work out of the box" is actually delivered.

Full suite: 7037 passed, 1 failed. The failure is `test-load-catalog.test.ts > should load Camel catalog`, a 10s timeout that reproduces identically on unmodified `main` on this machine and is unrelated to this change. `lint` and `lint:style` are clean.

## One thing worth flagging

`SourcePanel.test.tsx:35` ("should trigger handleLayoutChange when panel is toggled") is vacuous. It renders without a schema, so the panel has no children and `toggleExpanded` already early-returned before this PR; it clicks the summary and asserts `data-expanded="false"` on a panel that started collapsed. It passes whether or not anything toggles. I left it alone since fixing it is unrelated to this change, but it is not testing what its name claims.

## Known limitation

The disclosure button's accessible name is a generic "Expand panel"/"Collapse panel". The summary is an opaque `ReactNode`, so there is no reliable title to label it with. Phase 2 can improve this once `DocumentHeader` is restructured and the title is addressable.

---

🤖 Authored with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved expansion panels with dedicated disclosure buttons, accessible labels, and expanded-state indicators.
  * Added keyboard support for expanding and collapsing panels with Enter and Space.
  * Prevented header and action interactions from unintentionally toggling panels.
  * Improved collapsed-content accessibility by hiding it from interaction until expanded.

* **UI Improvements**
  * Refined panel layout and disclosure controls for clearer, more consistent presentation.
  * Removed the unnecessary expansion indicator from parameter summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->