### PR TITLE
feat(datamapper): S4 — DataMapper validation step management service

### DIFF
--- a/packages/ui/src/services/datamapper-validation-step.service.test.ts
+++ b/packages/ui/src/services/datamapper-validation-step.service.test.ts
@@ -1,0 +1,277 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+
+import { createVisualizationNode, IVisualizationNode } from '../models';
+import { DocumentDefinitionType } from '../models/datamapper/document';
+import { IDocumentMetadata } from '../models/datamapper/metadata';
+import { EntitiesContextResult } from '../providers';
+import { DataMapperValidationStepService } from './datamapper-validation-step.service';
+
+describe('DataMapperValidationStepService', () => {
+  let vizNode: IVisualizationNode;
+  let mockEntitiesContext: Mocked<EntitiesContextResult>;
+
+  const xmlMetadata = { type: DocumentDefinitionType.XML_SCHEMA, filePath: ['ShipOrder.xsd'] } as IDocumentMetadata;
+  const jsonMetadata = { type: DocumentDefinitionType.JSON_SCHEMA, filePath: ['schema.json'] } as IDocumentMetadata;
+  const primitiveMetadata = { type: DocumentDefinitionType.Primitive, filePath: [] } as IDocumentMetadata;
+  const emptyFilePathMetadata = { type: DocumentDefinitionType.XML_SCHEMA, filePath: [] } as IDocumentMetadata;
+
+  const createModel = (...stepUris: string[]) => ({
+    id: 'step-id',
+    steps: stepUris.map((uri) => ({ to: { uri } }) as ProcessorDefinition),
+  });
+
+  beforeEach(() => {
+    vizNode = createVisualizationNode('test', {
+      name: 'step',
+      isPlaceholder: false,
+      isGroup: false,
+      title: '',
+      description: '',
+      iconUrl: '',
+    });
+    mockEntitiesContext = {
+      updateSourceCodeFromEntities: vi.fn(),
+    } as unknown as Mocked<EntitiesContextResult>;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getValidationStep', () => {
+    it('should return undefined when only XSLT step is present', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      expect(DataMapperValidationStepService.getValidationStep(vizNode)).toBeUndefined();
+    });
+
+    it('should return the validator step when present', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'validator:ShipOrder.xsd');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      const result = DataMapperValidationStepService.getValidationStep(vizNode);
+      expect(result).toBeDefined();
+      expect(result!.to.uri).toBe('validator:ShipOrder.xsd');
+    });
+
+    it('should return the json-validator step when present', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'json-validator:schema.json');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      const result = DataMapperValidationStepService.getValidationStep(vizNode);
+      expect(result).toBeDefined();
+      expect(result!.to.uri).toBe('json-validator:schema.json');
+    });
+  });
+
+  describe('isValidationEnabled', () => {
+    it('should return false when no validator step is present', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      expect(DataMapperValidationStepService.isValidationEnabled(vizNode)).toBe(false);
+    });
+
+    it('should return true when validator step is present', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'validator:ShipOrder.xsd');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      expect(DataMapperValidationStepService.isValidationEnabled(vizNode)).toBe(true);
+    });
+
+    it('should return true when json-validator step is present', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'json-validator:schema.json');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      expect(DataMapperValidationStepService.isValidationEnabled(vizNode)).toBe(true);
+    });
+  });
+
+  describe('addValidationStep', () => {
+    it('should add validator step for XML_SCHEMA target', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+
+      DataMapperValidationStepService.addValidationStep(vizNode, xmlMetadata, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(2);
+      expect((model.steps[1] as ProcessorDefinition).to).toMatchObject({ uri: 'validator:ShipOrder.xsd' });
+      expect((model.steps[0] as ProcessorDefinition).to).toMatchObject({ uri: 'xslt-saxon:transform.xsl' });
+      expect(updateModelSpy).toHaveBeenCalledWith(model);
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalled();
+    });
+
+    it('should add json-validator step for JSON_SCHEMA target', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+
+      DataMapperValidationStepService.addValidationStep(vizNode, jsonMetadata, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(2);
+      expect((model.steps[1] as ProcessorDefinition).to).toMatchObject({ uri: 'json-validator:schema.json' });
+      expect(updateModelSpy).toHaveBeenCalledWith(model);
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalled();
+    });
+
+    it('should generate step ID starting with kaoto-datamapper-validator- for XML target', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      DataMapperValidationStepService.addValidationStep(vizNode, xmlMetadata, mockEntitiesContext);
+
+      const addedStep = model.steps[1] as { to: { id: string; uri: string } };
+      expect(addedStep.to.id).toMatch(/^kaoto-datamapper-validator-/);
+    });
+
+    it('should generate step ID starting with kaoto-datamapper-json-validator- for JSON target', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      DataMapperValidationStepService.addValidationStep(vizNode, jsonMetadata, mockEntitiesContext);
+
+      const addedStep = model.steps[1] as { to: { id: string; uri: string } };
+      expect(addedStep.to.id).toMatch(/^kaoto-datamapper-json-validator-/);
+    });
+
+    it('should do nothing for Primitive target', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+
+      DataMapperValidationStepService.addValidationStep(vizNode, primitiveMetadata, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(1);
+      expect(updateModelSpy).not.toHaveBeenCalled();
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when filePath is empty', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+
+      DataMapperValidationStepService.addValidationStep(vizNode, emptyFilePathMetadata, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(1);
+      expect(updateModelSpy).not.toHaveBeenCalled();
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeValidationStep', () => {
+    it('should remove validator step and preserve XSLT step', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'validator:ShipOrder.xsd');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+
+      DataMapperValidationStepService.removeValidationStep(vizNode, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(1);
+      expect((model.steps[0] as ProcessorDefinition).to).toMatchObject({ uri: 'xslt-saxon:transform.xsl' });
+      expect(updateModelSpy).toHaveBeenCalledWith(model);
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalled();
+    });
+
+    it('should remove json-validator step and preserve XSLT step', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'json-validator:schema.json');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+
+      DataMapperValidationStepService.removeValidationStep(vizNode, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(1);
+      expect((model.steps[0] as ProcessorDefinition).to).toMatchObject({ uri: 'xslt-saxon:transform.xsl' });
+      expect(updateModelSpy).toHaveBeenCalledWith(model);
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalled();
+    });
+
+    it('should do nothing when no validator step is present', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+
+      DataMapperValidationStepService.removeValidationStep(vizNode, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(1);
+      expect(updateModelSpy).not.toHaveBeenCalled();
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateValidationStep', () => {
+    it('should update URI when file changes for same type (XML)', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'validator:Old.xsd');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+      const newMetadata = { type: DocumentDefinitionType.XML_SCHEMA, filePath: ['New.xsd'] } as IDocumentMetadata;
+
+      DataMapperValidationStepService.updateValidationStep(vizNode, newMetadata, mockEntitiesContext);
+
+      expect((model.steps[1] as ProcessorDefinition).to).toMatchObject({ uri: 'validator:New.xsd' });
+      expect(updateModelSpy).toHaveBeenCalledWith(model);
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update URI when file changes for same type (JSON)', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'json-validator:old-schema.json');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+      const newMetadata = {
+        type: DocumentDefinitionType.JSON_SCHEMA,
+        filePath: ['new-schema.json'],
+      } as IDocumentMetadata;
+
+      DataMapperValidationStepService.updateValidationStep(vizNode, newMetadata, mockEntitiesContext);
+
+      expect((model.steps[1] as ProcessorDefinition).to).toMatchObject({ uri: 'json-validator:new-schema.json' });
+      expect(updateModelSpy).toHaveBeenCalledWith(model);
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalledTimes(1);
+    });
+
+    it('should replace step in place when type changes from XML to JSON', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'validator:ShipOrder.xsd');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      DataMapperValidationStepService.updateValidationStep(vizNode, jsonMetadata, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(2);
+      expect((model.steps[1] as ProcessorDefinition).to).toMatchObject({ uri: 'json-validator:schema.json' });
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalledTimes(1);
+    });
+
+    it('should replace step in place when type changes from JSON to XML', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'json-validator:schema.json');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      DataMapperValidationStepService.updateValidationStep(vizNode, xmlMetadata, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(2);
+      expect((model.steps[1] as ProcessorDefinition).to).toMatchObject({ uri: 'validator:ShipOrder.xsd' });
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove step when target becomes Primitive', () => {
+      const model = createModel('xslt-saxon:transform.xsl', 'validator:ShipOrder.xsd');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+
+      DataMapperValidationStepService.updateValidationStep(vizNode, primitiveMetadata, mockEntitiesContext);
+
+      expect(model.steps).toHaveLength(1);
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).toHaveBeenCalledTimes(1);
+    });
+
+    it('should do nothing when no existing validator step', () => {
+      const model = createModel('xslt-saxon:transform.xsl');
+      vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(model);
+      const updateModelSpy = vi.spyOn(vizNode, 'updateModel');
+
+      DataMapperValidationStepService.updateValidationStep(vizNode, xmlMetadata, mockEntitiesContext);
+
+      expect(updateModelSpy).not.toHaveBeenCalled();
+      expect(mockEntitiesContext.updateSourceCodeFromEntities).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ui/src/services/datamapper-validation-step.service.ts
+++ b/packages/ui/src/services/datamapper-validation-step.service.ts
@@ -1,0 +1,181 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+
+import { getCamelRandomId } from '../camel-utils/camel-random-id';
+import { IVisualizationNode } from '../models';
+import { DocumentDefinitionType } from '../models/datamapper/document';
+import { IDocumentMetadata } from '../models/datamapper/metadata';
+import { EntitiesContextResult } from '../providers';
+import {
+  isJsonValidatorComponent,
+  isValidatorComponent,
+  isXSLTComponent,
+  JSON_VALIDATOR_COMPONENT_NAME,
+  VALIDATOR_COMPONENT_NAME,
+} from '../utils';
+import type { ValidatorComponentDef } from '../utils/is-validator-component';
+
+/**
+ * Service for managing the validation step within a DataMapper step group.
+ *
+ * When output validation is enabled, a validator step is added after the XSLT step:
+ * ```yaml
+ * - step:
+ *     id: kaoto-datamapper-xxxxxxxx
+ *     steps:
+ *       - to:
+ *           uri: xslt-saxon:kaoto-datamapper-xxxxxxxx.xsl
+ *       - to:
+ *           uri: validator:ShipOrder.xsd
+ * ```
+ *
+ * This service handles:
+ * - Adding/removing the validation step (validator or json-validator)
+ * - Updating the validation resource URI when the target schema changes
+ * - Detecting whether validation is currently enabled
+ */
+export class DataMapperValidationStepService {
+  /**
+   * Gets the validation step from the DataMapper step group, if present.
+   * @param vizNode The visualization node representing the DataMapper step
+   * @returns The validator step definition, or `undefined` if none exists
+   */
+  static getValidationStep(vizNode: IVisualizationNode): ValidatorComponentDef | undefined {
+    const model = vizNode.getNodeDefinition();
+    return (model.steps as ProcessorDefinition[])?.find(
+      (s): s is ValidatorComponentDef => isValidatorComponent(s) || isJsonValidatorComponent(s),
+    );
+  }
+
+  /**
+   * Checks whether a validation step is currently present in the DataMapper step group.
+   * @param vizNode The visualization node representing the DataMapper step
+   * @returns `true` if a validator or json-validator step is present, `false` otherwise
+   */
+  static isValidationEnabled(vizNode: IVisualizationNode): boolean {
+    return DataMapperValidationStepService.getValidationStep(vizNode) !== undefined;
+  }
+
+  /**
+   * Adds a validation step after the XSLT step in the DataMapper step group.
+   * Uses `validator` for XML_SCHEMA targets and `json-validator` for JSON_SCHEMA targets.
+   * Does nothing for Primitive targets or when `filePath` is empty.
+   * @param vizNode The visualization node representing the DataMapper step
+   * @param targetMetadata The metadata for the target document schema
+   * @param entitiesContext The entities context for updating source code
+   */
+  static addValidationStep(
+    vizNode: IVisualizationNode,
+    targetMetadata: IDocumentMetadata,
+    entitiesContext: EntitiesContextResult,
+  ): void {
+    let componentName: string;
+    let idPrefix: string;
+
+    switch (targetMetadata.type) {
+      case DocumentDefinitionType.XML_SCHEMA:
+        componentName = VALIDATOR_COMPONENT_NAME;
+        idPrefix = 'kaoto-datamapper-validator';
+        break;
+      case DocumentDefinitionType.JSON_SCHEMA:
+        componentName = JSON_VALIDATOR_COMPONENT_NAME;
+        idPrefix = 'kaoto-datamapper-json-validator';
+        break;
+      default:
+        return;
+    }
+
+    const resourceUri = targetMetadata.filePath?.[0];
+    if (!resourceUri) {
+      return;
+    }
+
+    if (DataMapperValidationStepService.getValidationStep(vizNode)) {
+      return;
+    }
+
+    const model = vizNode.getNodeDefinition();
+    const steps = model.steps as ProcessorDefinition[] | undefined;
+    const xsltIndex = steps?.findIndex((s) => isXSLTComponent(s)) ?? -1;
+    if (!steps || xsltIndex < 0) {
+      return;
+    }
+
+    const newStep = { to: { id: getCamelRandomId(idPrefix), uri: `${componentName}:${resourceUri}` } };
+    steps.splice(xsltIndex + 1, 0, newStep);
+    vizNode.updateModel(model);
+    entitiesContext.updateSourceCodeFromEntities();
+  }
+
+  /**
+   * Removes the validation step from the DataMapper step group, if present.
+   * Does nothing if no validator step exists.
+   * @param vizNode The visualization node representing the DataMapper step
+   * @param entitiesContext The entities context for updating source code
+   */
+  static removeValidationStep(vizNode: IVisualizationNode, entitiesContext: EntitiesContextResult): void {
+    const model = vizNode.getNodeDefinition();
+    const steps = model.steps as ProcessorDefinition[];
+    const index = steps?.findIndex((s) => isValidatorComponent(s) || isJsonValidatorComponent(s));
+    if (index === undefined || index < 0) {
+      return;
+    }
+    steps.splice(index, 1);
+    vizNode.updateModel(model);
+    entitiesContext.updateSourceCodeFromEntities();
+  }
+
+  /**
+   * Updates the validation step when the target schema changes.
+   * Handles both URI updates (same component type) and component swaps (XML↔JSON).
+   * Removes the validation step if the target becomes Primitive.
+   * Does nothing if no validation step exists.
+   * @param vizNode The visualization node representing the DataMapper step
+   * @param targetMetadata The metadata for the updated target document schema
+   * @param entitiesContext The entities context for updating source code
+   */
+  static updateValidationStep(
+    vizNode: IVisualizationNode,
+    targetMetadata: IDocumentMetadata,
+    entitiesContext: EntitiesContextResult,
+  ): void {
+    const existingStep = DataMapperValidationStepService.getValidationStep(vizNode);
+    if (!existingStep) {
+      return;
+    }
+
+    if (targetMetadata.type === DocumentDefinitionType.Primitive) {
+      DataMapperValidationStepService.removeValidationStep(vizNode, entitiesContext);
+      return;
+    }
+
+    const resourceUri = targetMetadata.filePath?.[0];
+    if (!resourceUri) {
+      return;
+    }
+
+    let componentName: string;
+    switch (targetMetadata.type) {
+      case DocumentDefinitionType.XML_SCHEMA:
+        componentName = VALIDATOR_COMPONENT_NAME;
+        break;
+      case DocumentDefinitionType.JSON_SCHEMA:
+        componentName = JSON_VALIDATOR_COMPONENT_NAME;
+        break;
+      default:
+        return;
+    }
+
+    const model = vizNode.getNodeDefinition();
+    const currentComponent = existingStep.to.uri.split(':')[0];
+    if (currentComponent !== componentName) {
+      existingStep.to.id = getCamelRandomId(
+        componentName === JSON_VALIDATOR_COMPONENT_NAME
+          ? 'kaoto-datamapper-json-validator'
+          : 'kaoto-datamapper-validator',
+      );
+    }
+    existingStep.to.uri = `${componentName}:${resourceUri}`;
+    vizNode.updateModel(model);
+    entitiesContext.updateSourceCodeFromEntities();
+  }
+}

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -14,6 +14,7 @@ export * from './is-enum-type';
 export * from './is-raw-string';
 export * from './is-same-array';
 export * from './is-to-processor';
+export * from './is-validator-component';
 export * from './is-xslt-component';
 export * from './pipe-custom-schema';
 export * from './process-tree-node';

--- a/packages/ui/src/utils/is-datamapper.ts
+++ b/packages/ui/src/utils/is-datamapper.ts
@@ -2,6 +2,8 @@ import { ProcessorDefinition, Step } from '@kaoto/camel-catalog/types';
 
 export const DATAMAPPER_ID_PREFIX = 'kaoto-datamapper' as keyof ProcessorDefinition;
 export const XSLT_COMPONENT_NAME = 'xslt-saxon';
+export const VALIDATOR_COMPONENT_NAME = 'validator';
+export const JSON_VALIDATOR_COMPONENT_NAME = 'json-validator';
 
 export const isDataMapperNode = (stepDefinition: Step): stepDefinition is Step => {
   const isDatamapperId = stepDefinition.id?.startsWith(DATAMAPPER_ID_PREFIX) ?? false;

--- a/packages/ui/src/utils/is-validator-component.test.ts
+++ b/packages/ui/src/utils/is-validator-component.test.ts
@@ -1,0 +1,32 @@
+import { JSON_VALIDATOR_COMPONENT_NAME, VALIDATOR_COMPONENT_NAME } from './is-datamapper';
+import { isJsonValidatorComponent, isValidatorComponent } from './is-validator-component';
+
+describe('isValidatorComponent', () => {
+  it.each([
+    [false, { to: 'mock' }],
+    [false, { toD: 'mock' }],
+    [false, {}],
+    [false, { to: { uri: undefined } }],
+    [false, { to: { uri: 'json-validator:schema.json' } }],
+    [false, { to: { uri: 'xslt-saxon:doc.xsl' } }],
+    [true, { to: { uri: `${VALIDATOR_COMPONENT_NAME}` } }],
+    [true, { to: { uri: `${VALIDATOR_COMPONENT_NAME}:ShipOrder.xsd` } }],
+  ] as const)('should return %s when toDefinition is %s', (result, toDefinition) => {
+    expect(isValidatorComponent(toDefinition)).toBe(result);
+  });
+});
+
+describe('isJsonValidatorComponent', () => {
+  it.each([
+    [false, { to: 'mock' }],
+    [false, { toD: 'mock' }],
+    [false, {}],
+    [false, { to: { uri: undefined } }],
+    [false, { to: { uri: 'validator:ShipOrder.xsd' } }],
+    [false, { to: { uri: 'xslt-saxon:doc.xsl' } }],
+    [true, { to: { uri: `${JSON_VALIDATOR_COMPONENT_NAME}` } }],
+    [true, { to: { uri: `${JSON_VALIDATOR_COMPONENT_NAME}:schema.json` } }],
+  ] as const)('should return %s when toDefinition is %s', (result, toDefinition) => {
+    expect(isJsonValidatorComponent(toDefinition)).toBe(result);
+  });
+});

--- a/packages/ui/src/utils/is-validator-component.ts
+++ b/packages/ui/src/utils/is-validator-component.ts
@@ -1,0 +1,23 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+
+import { JSON_VALIDATOR_COMPONENT_NAME, VALIDATOR_COMPONENT_NAME } from './is-datamapper';
+import type { ToObjectDef } from './is-to-processor';
+import { isToProcessor } from './is-to-processor';
+
+export type ValidatorComponentDef = ToObjectDef & { to: { uri: string } };
+
+export const isValidatorComponent = (toDefinition: ProcessorDefinition): toDefinition is ValidatorComponentDef => {
+  if (!isToProcessor(toDefinition)) {
+    return false;
+  }
+
+  return toDefinition.to.uri?.startsWith(VALIDATOR_COMPONENT_NAME) ?? false;
+};
+
+export const isJsonValidatorComponent = (toDefinition: ProcessorDefinition): toDefinition is ValidatorComponentDef => {
+  if (!isToProcessor(toDefinition)) {
+    return false;
+  }
+
+  return toDefinition.to.uri?.startsWith(JSON_VALIDATOR_COMPONENT_NAME) ?? false;
+};


### PR DESCRIPTION
### Description

Implements the validation step management service for the DataMapper output validation feature. 

The DataMapper step group currently contains only the XSLT step. This PR adds the service layer that manages a second `to:` step — the validator — placed immediately after the XSLT step in the same step group.

**Before:**
```yaml
step:
  id: kaoto-datamapper-xxxxxxxx
  steps:
    - to:
        id: kaoto-datamapper-xslt-nnnn
        uri: xslt-saxon:kaoto-datamapper-xxxxxxxx.xsl
        parameters:
          failOnNullBody: false
```

**After (with validation enabled):**
```yaml
step:
  id: kaoto-datamapper-xxxxxxxx
  steps:
    - to:
        id: kaoto-datamapper-xslt-nnnn
        uri: xslt-saxon:kaoto-datamapper-xxxxxxxx.xsl
        parameters:
          failOnNullBody: false
    - to:
        id: kaoto-datamapper-validator-nnnn
        uri: validator:ShipOrder.xsd   # or json-validator:schema.json for JSON targets
```

#### Changes

**New constants** in `is-datamapper.ts`:
- `VALIDATOR_COMPONENT_NAME = 'validator'`
- `JSON_VALIDATOR_COMPONENT_NAME = 'json-validator'`

**New type guards** in `is-validator-component.ts` (mirrors `is-xslt-component.ts` pattern):
- `isValidatorComponent()` — narrows `ProcessorDefinition` to a `validator:` step
- `isJsonValidatorComponent()` — narrows to a `json-validator:` step

**New service** `DataMapperValidationStepService` (static class, same pattern as `DataMapperStepService`):
- `getValidationStep(vizNode)` — returns the validator step or `undefined`
- `isValidationEnabled(vizNode)` — boolean presence check
- `addValidationStep(vizNode, targetMetadata, entitiesContext)` — appends `validator:` or `json-validator:` step; no-ops for Primitive or empty `filePath`
- `removeValidationStep(vizNode, entitiesContext)` — splices the validator step out
- `updateValidationStep(vizNode, targetMetadata, entitiesContext)` — updates URI in-place (same type), swaps component for XML↔JSON changes, removes for Primitive


Closes #3606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation management for DataMapper flows, including XML and JSON schema validators.
  * Validators can be added, removed, updated, or switched when target schemas change.
  * Validation status can be detected for supported DataMapper targets.
  * Added support for recognizing standard and JSON validation components.

* **Tests**
  * Added comprehensive coverage for validator detection, lifecycle operations, schema updates, and unsupported targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->