### PR TITLE
fix(DataMapper): Fixed the out of sync connection lines with variables on scroll

### DIFF
--- a/packages/ui/src/components/Document/Variables/VariablesSection.tsx
+++ b/packages/ui/src/components/Document/Variables/VariablesSection.tsx
@@ -115,6 +115,7 @@ export const VariablesSection: FunctionComponent<VariablesSectionProps> = ({
       defaultExpanded={hasContent}
       defaultHeight={hasContent ? variableListHeight : PANEL_COLLAPSED_HEIGHT}
       minHeight={PANEL_MIN_HEIGHT}
+      onScroll={syncConnectionPorts}
       onLayoutChange={() => {
         syncConnectionPorts();
         onLayoutChange?.();


### PR DESCRIPTION
Resolves: [#3672](https://github.com/KaotoIO/kaoto/issues/3672)


https://github.com/user-attachments/assets/b924adc9-5b63-4171-b84e-97c53afe610f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Connection ports now stay synchronized when scrolling through the Variables section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->