### PR TITLE
Fix typescript:S2187: Test files should contain at least one test case

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.000-050.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.000-050.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Component, range: { start: 0, end: 50 } } as 
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.050-100.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.050-100.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Component, range: { start: 50, end: 100 } } a
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.100-150.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.100-150.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Component, range: { start: 100, end: 150 } } 
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.150-200.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.150-200.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Component, range: { start: 150, end: 200 } } 
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.200-250.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.200-250.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Component, range: { start: 200, end: 250 } } 
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.250-300.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.250-300.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Component, range: { start: 250, end: 300 } } 
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.300-end.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.300-end.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Component, range: { start: 300, end: undefine
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.eips.000-end.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.eips.000-end.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Pattern, range: { start: 0, end: undefined } 
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.000-050.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.000-050.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Kamelet, range: { start: 0, end: 50 } } as co
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.050-100.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.050-100.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Kamelet, range: { start: 50, end: 100 } } as 
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.100-150.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.100-150.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Kamelet, range: { start: 100, end: 150 } } as
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.150-200.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.150-200.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Kamelet, range: { start: 150, end: 200 } } as
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.200-end.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.200-end.test.tsx
@@ -1,4 +1,3 @@
-// NOSONAR typescript:S2187 - Tests are defined in FormTest function
 import { CatalogKind } from '../../../../../models';
 import { FormTest } from './FormTest';
 
@@ -6,4 +5,4 @@ const target = { kind: CatalogKind.Kamelet, range: { start: 200, end: undefined 
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
   FormTest(target);
-});
+}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3675

## Summary

13 test files in `packages/ui/src/components/Visualization/Canvas/Form/Tests/` were flagged by SonarCloud with rule `typescript:S2187` (BLOCKER) because they contain no direct `it`/`test` calls — they delegate to a shared `FormTest` helper inside a `describe` block.

The existing `// NOSONAR` suppression was placed on a standalone comment line (line 1), which SonarCloud does not honor for file-level issues. The suppression must appear on the last executable line.

## Change

Moved `// NOSONAR typescript:S2187` from the standalone comment at the top of each file to the closing `});` line, so SonarCloud's inline suppression is applied correctly.

No logic, behavior, or test output is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static-analysis suppression comments across form test suites for clearer, more targeted placement.
  * Added explanatory context where applicable.

* **Tests**
  * Test setup and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->