### PR TITLE
Fix typescript:S2970: Assertions should be complete

### DIFF
--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -13,6 +13,8 @@ export default [
     rules: {
       'vitest/prefer-to-have-length': 'error',
       'vitest/prefer-to-be': 'error',
+      // Prevent incomplete assertions (SonarQube typescript:S2970, S2699).
+      'vitest/valid-expect': 'error',
     },
   },
   {

--- a/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
@@ -46,7 +46,7 @@ describe('DetachSchemaButton', () => {
     fireEvent.click(confirmBtn);
     await screen.findByTestId('detachtest');
     expect(sourceDoc!.fields).toHaveLength(0);
-    expect(sourceDoc! instanceof PrimitiveDocument).toBe(true);
+    expect(sourceDoc!).toBeInstanceOf(PrimitiveDocument);
   });
 
   it('should open and close modal', async () => {

--- a/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
+++ b/packages/ui/src/components/Document/actions/DetachSchemaButton.test.tsx
@@ -46,7 +46,7 @@ describe('DetachSchemaButton', () => {
     fireEvent.click(confirmBtn);
     await screen.findByTestId('detachtest');
     expect(sourceDoc!.fields).toHaveLength(0);
-    expect(sourceDoc! instanceof PrimitiveDocument);
+    expect(sourceDoc! instanceof PrimitiveDocument).toBe(true);
   });
 
   it('should open and close modal', async () => {

--- a/packages/ui/src/components/Document/actions/DocumentActions.test.tsx
+++ b/packages/ui/src/components/Document/actions/DocumentActions.test.tsx
@@ -16,7 +16,7 @@ describe('DocumentActions', () => {
         </MappingLinksProvider>
       </DataMapperProvider>,
     );
-    expect(await screen.findByTestId('attach-schema-sourceBody-Body-button'));
+    expect(await screen.findByTestId('attach-schema-sourceBody-Body-button')).toBeInTheDocument();
   });
 
   it('should render for Parameters', async () => {
@@ -28,9 +28,9 @@ describe('DocumentActions', () => {
         </MappingLinksProvider>
       </DataMapperProvider>,
     );
-    expect(await screen.findByTestId('attach-schema-param-testparam1-button'));
-    expect(await screen.findByTestId('detach-schema-param-testparam1-button'));
-    expect(await screen.findByTestId('rename-parameter-testparam1-button'));
-    expect(await screen.findByTestId('delete-parameter-testparam1-button'));
+    expect(await screen.findByTestId('attach-schema-param-testparam1-button')).toBeInTheDocument();
+    expect(await screen.findByTestId('detach-schema-param-testparam1-button')).toBeInTheDocument();
+    expect(await screen.findByTestId('rename-parameter-testparam1-button')).toBeInTheDocument();
+    expect(await screen.findByTestId('delete-parameter-testparam1-button')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/providers/action-confirmaton-modal.provider.test.tsx
+++ b/packages/ui/src/providers/action-confirmaton-modal.provider.test.tsx
@@ -68,8 +68,8 @@ describe('ActionConfirmationModalProvider', () => {
     const modalDialog = wrapper.getByRole('dialog');
     expect(modalDialog).toMatchSnapshot();
 
-    expect(wrapper.queryByText('Custom title')).toBeInTheDocument;
-    expect(wrapper.queryByText('Custom text')).toBeInTheDocument;
+    expect(wrapper.queryByText('Custom title')).toBeInTheDocument();
+    expect(wrapper.queryByText('Custom text')).toBeInTheDocument();
   });
 
   it('should show 3 options to choose', async () => {

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -783,7 +783,7 @@ describe('MappingService', () => {
       const orderIdFieldItem = tree.children[0].children[0];
       orderIdFieldItem.children = [];
       MappingService.mapToField(sourceDoc.fields[0].fields[0], orderIdFieldItem);
-      expect(orderIdFieldItem.children[0] instanceof ValueSelector).toBe(true);
+      expect(orderIdFieldItem.children[0]).toBeInstanceOf(ValueSelector);
       const orderIdValueSelector = orderIdFieldItem.children[0] as ValueSelector;
       expect(orderIdValueSelector.expression).toBe('/ns0:ShipOrder/@OrderId');
     });
@@ -793,7 +793,7 @@ describe('MappingService', () => {
       const orderIdFieldItem = tree.children[0].children[0];
       orderIdFieldItem.children = [];
       MappingService.mapToField(sourceDoc.fields[0].fields[0], orderIdFieldItem);
-      expect(orderIdFieldItem.children[0] instanceof ValueSelector).toBe(true);
+      expect(orderIdFieldItem.children[0]).toBeInstanceOf(ValueSelector);
       const orderIdValueSelector = orderIdFieldItem.children[0] as ValueSelector;
       expect(orderIdValueSelector.expression).toBe('/ns0:ShipOrder/@OrderId');
     });

--- a/packages/ui/src/services/mapping/mapping.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping.service.test.ts
@@ -783,7 +783,7 @@ describe('MappingService', () => {
       const orderIdFieldItem = tree.children[0].children[0];
       orderIdFieldItem.children = [];
       MappingService.mapToField(sourceDoc.fields[0].fields[0], orderIdFieldItem);
-      expect(orderIdFieldItem.children[0] instanceof ValueSelector);
+      expect(orderIdFieldItem.children[0] instanceof ValueSelector).toBe(true);
       const orderIdValueSelector = orderIdFieldItem.children[0] as ValueSelector;
       expect(orderIdValueSelector.expression).toBe('/ns0:ShipOrder/@OrderId');
     });
@@ -793,7 +793,7 @@ describe('MappingService', () => {
       const orderIdFieldItem = tree.children[0].children[0];
       orderIdFieldItem.children = [];
       MappingService.mapToField(sourceDoc.fields[0].fields[0], orderIdFieldItem);
-      expect(orderIdFieldItem.children[0] instanceof ValueSelector);
+      expect(orderIdFieldItem.children[0] instanceof ValueSelector).toBe(true);
       const orderIdValueSelector = orderIdFieldItem.children[0] as ValueSelector;
       expect(orderIdValueSelector.expression).toBe('/ns0:ShipOrder/@OrderId');
     });


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3677

## Summary

10 incomplete assertions across 4 test files were silently passing as no-ops:

- `expect(x instanceof Y)` → `expect(x instanceof Y).toBe(true)`
- `expect(await screen.findByTestId(...))` → `.toBeInTheDocument()`
- `.toBeInTheDocument` (uncalled) → `.toBeInTheDocument()`

No test logic changed — these assertions were previously not asserting anything.

### Prevention

`vitest/valid-expect` (ESLint) catches this class of bug and is not currently enabled. Adding it to the ESLint config would prevent regressions without waiting for a Sonar scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for document detachment and action controls.
  * Corrected assertions for confirmation modal text and titles.
  * Strengthened validation of mapped field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->