### PR TITLE
Fix typescript:S2699: Tests should include assertions

### DIFF
--- a/packages/ui/src/providers/datamapper.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper.provider.test.tsx
@@ -31,7 +31,7 @@ describe('DataMapperProvider', () => {
         <div data-testid="testdiv" />
       </DataMapperProvider>,
     );
-    await screen.findByTestId('testdiv');
+    expect(await screen.findByTestId('testdiv')).toBeInTheDocument();
   });
 
   it('refreshMappingTree should re-create the MappingTree instance', async () => {


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3679

## Summary

One test case in `datamapper.provider.test.tsx` (line 28) awaited `screen.findByTestId` without making any assertion on the result, leaving the test as a silent no-op that always passes.

**Change:** wrapped the await in `expect(...).toBeInTheDocument()`.

No test logic changed — the element lookup already threw on absence; this makes the assertion explicit.

### Prevention

`vitest/valid-expect` (ESLint) — not currently enabled — would catch both S2699 and S2970 class bugs at lint time.