### PR TITLE
Clean resolveCatalogLookup

### DIFF
--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -309,7 +309,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
       `${this.getRootPath()}.from`,
       {
         primaryNodeId: {
-          name: 'from' as keyof ProcessorDefinition,
+          name: 'from',
           catalogKind: CatalogKind.Entity,
         } satisfies NodeIdentity,
       },

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -1,12 +1,9 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
-import { DynamicCatalog } from '../../../../dynamic-catalog/dynamic-catalog';
-import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { DATAMAPPER_ID_PREFIX, XSLT_COMPONENT_NAME } from '../../../../utils';
 import { ICamelComponentDefinition } from '../../../camel/camel-components-catalog';
-import { IKameletDefinition } from '../../../camel/kamelets-catalog';
 import { CatalogKind } from '../../../catalog-kind';
 import { IClipboardContent } from '../../clipboard';
 import { CamelCatalogService } from '../camel-catalog.service';
@@ -506,89 +503,6 @@ describe('CamelComponentSchemaService', () => {
       const result = CamelComponentSchemaService.canBeDisabled('from' as keyof ProcessorDefinition);
 
       expect(result).toBe(false);
-    });
-  });
-
-  describe('resolveCatalogLookup', () => {
-    const timerComponent = {
-      component: { name: 'timer', syntax: 'timer:name' },
-      properties: {},
-      propertiesSchema: {},
-    } as ICamelComponentDefinition;
-
-    const kameletComponent = {
-      component: { name: 'kamelet' },
-      properties: {},
-      propertiesSchema: {},
-    } as ICamelComponentDefinition;
-
-    const chuckNorrisKamelet = {
-      kind: 'Kamelet',
-      metadata: { name: 'chuck-norris-source' },
-      spec: { definition: {} },
-    } as IKameletDefinition;
-
-    beforeEach(() => {
-      const componentCatalog = new DynamicCatalog<ICamelComponentDefinition>({
-        id: 'component-provider',
-        fetch: (key) =>
-          Promise.resolve(
-            ({ timer: timerComponent, kamelet: kameletComponent } as Record<string, ICamelComponentDefinition>)[key],
-          ),
-        fetchAll: () => Promise.resolve({ timer: timerComponent, kamelet: kameletComponent }),
-      });
-
-      const kameletCatalog = new DynamicCatalog<IKameletDefinition>({
-        id: 'kamelet-provider',
-        fetch: (key) =>
-          Promise.resolve(({ 'chuck-norris-source': chuckNorrisKamelet } as Record<string, IKameletDefinition>)[key]),
-        fetchAll: () => Promise.resolve({ 'chuck-norris-source': chuckNorrisKamelet }),
-      });
-
-      DynamicCatalogRegistry.get().setCatalog(CatalogKind.Component, componentCatalog);
-      DynamicCatalogRegistry.get().setCatalog(CatalogKind.Kamelet, kameletCatalog);
-    });
-
-    it('should return undefined for an empty component name', async () => {
-      const lookup = await CamelComponentSchemaService.resolveCatalogLookup('');
-
-      expect(lookup).toBeUndefined();
-    });
-
-    it('should return a component from the catalog lookup', async () => {
-      const lookup = await CamelComponentSchemaService.resolveCatalogLookup('timer');
-
-      expect(lookup).toEqual({
-        catalogKind: CatalogKind.Component,
-        definition: timerComponent,
-      });
-    });
-
-    it('should return a kamelet from the catalog lookup', async () => {
-      const lookup = await CamelComponentSchemaService.resolveCatalogLookup('kamelet:chuck-norris-source');
-
-      expect(lookup).toEqual({
-        catalogKind: CatalogKind.Kamelet,
-        definition: chuckNorrisKamelet,
-      });
-    });
-
-    it('should return the kamelet component for unknown kamelets', async () => {
-      const lookup = await CamelComponentSchemaService.resolveCatalogLookup('kamelet:non-existing-kamelet');
-
-      expect(lookup).toEqual({
-        catalogKind: CatalogKind.Component,
-        definition: kameletComponent,
-      });
-    });
-
-    it('should pass forceFresh to underlying catalog lookups', async () => {
-      const componentCatalog = DynamicCatalogRegistry.get().getCatalog(CatalogKind.Component)!;
-      const getSpy = vi.spyOn(componentCatalog, 'get');
-
-      await CamelComponentSchemaService.resolveCatalogLookup('timer', { forceFresh: true });
-
-      expect(getSpy).toHaveBeenCalledWith('timer', { forceFresh: true });
     });
   });
 });

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -2,10 +2,7 @@ import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 import { cloneDeep } from 'lodash';
 
-import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CamelUriHelper, DATAMAPPER_ID_PREFIX, isDataMapperNode, ParsedParameters } from '../../../../utils';
-import { ICamelComponentDefinition } from '../../../camel/camel-components-catalog';
-import { IKameletDefinition } from '../../../camel/kamelets-catalog';
 import { CatalogKind } from '../../../catalog-kind';
 import { KaotoSchemaDefinition } from '../../../kaoto-schema';
 import { REST_DSL_VERBS } from '../../../special-processors.constants';
@@ -40,15 +37,6 @@ const CAMEL_REST_DSL_STEP_PROPERTIES: CamelProcessorStepsProperties[] = REST_DSL
 }));
 const CAMEL_REST_VERB_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [{ name: 'to', type: 'single-clause' }];
 
-type CatalogLookupResult =
-  | {
-      catalogKind: CatalogKind.Component;
-      definition?: ICamelComponentDefinition;
-    }
-  | {
-      catalogKind: CatalogKind.Kamelet;
-      definition?: IKameletDefinition;
-    };
 export class CamelComponentSchemaService {
   static readonly DISABLED_SIBLING_STEPS = [
     'route',
@@ -310,37 +298,6 @@ export class CamelComponentSchemaService {
 
     const queryParams = CamelUriHelper.getParametersFromQueryString(query);
     return { uri: componentName, parameters: { ...pathParams, ...queryParams } };
-  }
-
-  static async resolveCatalogLookup(
-    componentName: string,
-    options: { forceFresh?: boolean } = {},
-  ): Promise<CatalogLookupResult | undefined> {
-    if (!componentName) {
-      return undefined;
-    }
-
-    if (componentName.startsWith('kamelet:')) {
-      const kameletName = componentName.replace('kamelet:', '');
-      const definition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Kamelet, kameletName, options);
-
-      if (definition) {
-        return {
-          catalogKind: CatalogKind.Kamelet,
-          definition,
-        };
-      }
-
-      return {
-        catalogKind: CatalogKind.Component,
-        definition: await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, 'kamelet', options),
-      };
-    }
-
-    return {
-      catalogKind: CatalogKind.Component,
-      definition: await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, componentName, options),
-    };
   }
 
   /**


### PR DESCRIPTION
Refactor duplicated node mappers to use a common branch-node-mapper.

This PR has been created over [PR](https://github.com/KaotoIO/kaoto/pull/3667)

closes: https://github.com/KaotoIO/kaoto/issues/3229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow visualization so nodes consistently display the correct entity, pattern, component, and Kamelet identities.
  * Added better handling for bare Kamelet URIs and processor definitions.
  * Improved visualization of conditional branches, including `when`, `otherwise`, and fallback paths.

* **Refactor**
  * Consolidated branch visualization behavior for more consistent node rendering across supported flow patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->