### PR TITLE
chore(dynamic_catalog): clean-up getNodeDefinition()

### DIFF
--- a/packages/ui/src/components/GroupAutoStartupSwitch/GroupAutoStartupSwitch.test.tsx
+++ b/packages/ui/src/components/GroupAutoStartupSwitch/GroupAutoStartupSwitch.test.tsx
@@ -16,26 +16,6 @@ describe('GroupAutoStartupSwitch', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('should return null when entity is undefined', async () => {
-    const vizNode = createVisualizationNode('test-node', {
-      name: 'route',
-      path: 'route',
-      isPlaceholder: false,
-      isGroup: false,
-      iconUrl: '',
-      title: '',
-      description: '',
-    });
-
-    const { Provider } = await TestProvidersWrapper();
-    const { container } = render(
-      <Provider>
-        <GroupAutoStartupSwitch vizNode={vizNode} />
-      </Provider>,
-    );
-    expect(container.firstChild).toBeNull();
-  });
-
   it('should render switch as checked when autoStartup is enabled (undefined)', async () => {
     const entity = new CamelRouteVisualEntity({
       route: { from: { uri: 'direct:test', steps: [] } },

--- a/packages/ui/src/components/GroupAutoStartupSwitch/GroupAutoStartupSwitch.tsx
+++ b/packages/ui/src/components/GroupAutoStartupSwitch/GroupAutoStartupSwitch.tsx
@@ -3,7 +3,7 @@ import { Switch } from '@patternfly/react-core';
 import { FunctionComponent } from 'react';
 
 import { useEntityContext } from '../../hooks/useEntityContext/useEntityContext';
-import { CamelRouteVisualEntity, IVisualizationNode } from '../../models';
+import { IVisualizationNode } from '../../models';
 
 interface IGroupAutoStartupSwitchProps {
   vizNode?: IVisualizationNode;
@@ -22,13 +22,8 @@ export const GroupAutoStartupSwitch: FunctionComponent<IGroupAutoStartupSwitchPr
     return null;
   }
 
-  const entity = vizNode.data.entity;
-  if (!entity) {
-    return null;
-  }
-
   // Get the current autoStartup value from the route definition
-  const routeDefinition: RouteDefinition = entity.getNodeDefinition(CamelRouteVisualEntity.ROOT_PATH);
+  const routeDefinition: RouteDefinition = vizNode.getNodeDefinition();
   const autoStartupValue = routeDefinition?.autoStartup;
 
   // Only treat actual boolean false as disabled; strings (including "false" or placeholders like "{{...}}")

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -35,7 +35,7 @@ export interface BaseVisualEntity extends BaseEntity {
 
   /** Given a path, returns the node's underlying definition in JSON format */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getNodeDefinition(path?: string): any;
+  getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): any;
 
   /** Return fields that should be omitted when configuring this entity */
   getOmitFormFields: () => string[];
@@ -77,7 +77,11 @@ export interface BaseVisualEntity extends BaseEntity {
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction;
 
   /** Given a path, retrieve the Node validation status */
-  getNodeValidationText(path?: string, schema?: KaotoSchemaDefinition['schema']): string | undefined;
+  getNodeValidationText(
+    path?: string,
+    schema?: KaotoSchemaDefinition['schema'],
+    ids?: IVisualizationNodeIds,
+  ): string | undefined;
 
   /** Generates a IVisualizationNode from the underlying Camel entity */
   toVizNode: () => Promise<IVisualizationNode>;

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -13,6 +13,7 @@ import { NodeLabelType } from '../../settings';
 import { AddStepMode, IVisualizationNodeData } from '../base-visual-entity';
 import { CamelCatalogService } from './camel-catalog.service';
 import { CamelRouteVisualEntity } from './camel-route-visual-entity';
+import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
 describe('AbstractCamelVisualEntity', () => {
   let abstractVisualEntity: CamelRouteVisualEntity;
@@ -36,6 +37,16 @@ describe('AbstractCamelVisualEntity', () => {
   beforeEach(() => {
     abstractVisualEntity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson));
   });
+
+  const toStepIds = {
+    primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+    secondaryNodeId: { name: 'direct', catalogKind: CatalogKind.Component },
+  };
+
+  const fromStepIds = {
+    primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
+    secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
+  };
 
   // Test helper to create mock node data with consistent defaults
   const createMockNodeData = (overrides: Partial<IVisualizationNodeData> = {}): IVisualizationNodeData => ({
@@ -157,7 +168,7 @@ describe('AbstractCamelVisualEntity', () => {
         primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
         secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
       });
-      const result = abstractVisualEntity.getNodeValidationText('route.from', schema);
+      const result = abstractVisualEntity.getNodeValidationText('route.from', schema, fromStepIds);
 
       expect(result).toBe('2 required parameters are not yet configured: [ uri,timerName ]');
     });
@@ -176,7 +187,7 @@ describe('AbstractCamelVisualEntity', () => {
         parameters: { name: 'my-route', bridgeErrorHandler: true },
       };
 
-      const result = abstractVisualEntity.getNodeDefinition(path);
+      const result = abstractVisualEntity.getNodeDefinition(path, toStepIds);
       expect(result).toEqual(definition);
     });
 
@@ -188,7 +199,7 @@ describe('AbstractCamelVisualEntity', () => {
         (abstractVisualEntity.entityDef.route.from.steps[2].to as NonStringEIP<To>).parameters =
           parameters as unknown as Record<string, unknown>;
 
-        const definition = abstractVisualEntity.getNodeDefinition(path);
+        const definition = abstractVisualEntity.getNodeDefinition(path, toStepIds);
         expect((definition as NonStringEIP<To>).parameters).toEqual({});
       },
     );
@@ -198,12 +209,26 @@ describe('AbstractCamelVisualEntity', () => {
       (abstractVisualEntity.entityDef.route.from.steps[2].to as NonStringEIP<To>).uri = 'direct';
       (abstractVisualEntity.entityDef.route.from.steps[2].to as NonStringEIP<To>).parameters = { prop: true };
 
-      const definition = abstractVisualEntity.getNodeDefinition(path);
+      const definition = abstractVisualEntity.getNodeDefinition(path, toStepIds);
 
       expect(definition).toEqual({
         uri: 'direct',
         parameters: { prop: true },
       });
+    });
+
+    it('should pass the kamelet component name to getUpdatedDefinition', () => {
+      const entity = new CamelRouteVisualEntity(cloneDeep(camelRouteWithKameletJson));
+      const getUpdatedDefinitionSpy = vi.spyOn(CamelComponentSchemaService, 'getUpdatedDefinition');
+      const kameletFromIds = {
+        primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
+        secondaryNodeId: { name: 'kamelet', catalogKind: CatalogKind.Component },
+        tertiaryNodeId: { name: 'avro-deserialize-action', catalogKind: CatalogKind.Kamelet },
+      };
+
+      entity.getNodeDefinition('route.from', kameletFromIds);
+
+      expect(getUpdatedDefinitionSpy).toHaveBeenCalledWith(kameletFromIds, camelRouteWithKameletJson.route.from);
     });
   });
 
@@ -228,7 +253,7 @@ describe('AbstractCamelVisualEntity', () => {
 
       abstractVisualEntity.updateModel('route.from.steps.2.to.parameters', parameters);
 
-      expect(abstractVisualEntity.getNodeDefinition('route.from.steps.2.to')).toEqual({
+      expect(abstractVisualEntity.getNodeDefinition('route.from.steps.2.to', toStepIds)).toEqual({
         uri: 'direct',
         parameters: {
           name: 'my-route',

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -130,12 +130,11 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     return schema;
   }
 
-  getNodeDefinition(path?: string): unknown {
+  getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): unknown {
     if (!path) return undefined;
 
     const definition = getValue(this.entityDef, path);
-    const camelElementLookup = CamelComponentSchemaService.getCamelComponentLookup(path, definition);
-    const updatedDefinition = CamelComponentSchemaService.getUpdatedDefinition(camelElementLookup, definition);
+    const updatedDefinition = CamelComponentSchemaService.getUpdatedDefinition(ids, definition);
 
     /** Overriding parameters with an empty object When the parameters property is mistakenly set to null */
     if (updatedDefinition?.parameters === null) {
@@ -282,8 +281,12 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     };
   }
 
-  getNodeValidationText(path?: string | undefined, schema?: KaotoSchemaDefinition['schema']): string | undefined {
-    const definition = this.getNodeDefinition(path);
+  getNodeValidationText(
+    path?: string | undefined,
+    schema?: KaotoSchemaDefinition['schema'],
+    ids?: IVisualizationNodeIds,
+  ): string | undefined {
+    const definition = this.getNodeDefinition(path, ids);
     if (!schema || !definition) return undefined;
 
     return ModelValidationService.validateNodeStatus(schema, definition);

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
@@ -137,7 +137,7 @@ describe('CamelRestVisualEntity', () => {
       // Use a path where method is NOT in REST_DSL_METHODS
       entity.getNodeDefinition('rest.unknown.0');
 
-      expect(superGetNodeDefinitionSpy).toHaveBeenCalledWith('rest.unknown.0');
+      expect(superGetNodeDefinitionSpy).toHaveBeenCalledWith('rest.unknown.0', undefined);
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.ts
@@ -88,7 +88,7 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
     return definition?.propertiesSchema;
   }
 
-  getNodeDefinition(path?: string): unknown {
+  getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): unknown {
     if (path === CamelRestVisualEntity.ROOT_PATH) {
       return { ...this.restDef.rest };
     }
@@ -100,7 +100,7 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
       return { ...getValue(this.restDef, path) };
     }
 
-    return super.getNodeDefinition(path);
+    return super.getNodeDefinition(path, ids);
   }
 
   updateModel(path: string | undefined, value: unknown): void {

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.ts
@@ -115,12 +115,12 @@ export class CamelRouteConfigurationVisualEntity
     return await super.fetchNodeSchema(ids);
   }
 
-  getNodeDefinition(path?: string): unknown {
+  getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): unknown {
     if (path === this.getRootPath()) {
       return { ...this.routeConfigurationDef.routeConfiguration };
     }
 
-    return super.getNodeDefinition(path);
+    return super.getNodeDefinition(path, ids);
   }
 
   getOmitFormFields(): string[] {

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -6,6 +6,7 @@ import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog
 import { mockRandomValues } from '../../../stubs';
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
+import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { NodeLabelType } from '../../settings/settings.model';
 import { IVisualizationNode } from '../base-visual-entity';
@@ -83,6 +84,20 @@ describe('Camel Route', () => {
   });
 
   describe('getNodeDefinition', () => {
+    const toStepIds = {
+      primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+      secondaryNodeId: { name: 'direct', catalogKind: CatalogKind.Component },
+    };
+
+    const fromStepIds = {
+      primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
+      secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
+    };
+
+    const logStepIds = {
+      primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
+    };
+
     it('should return undefined if no path is provided', () => {
       expect(camelEntity.getNodeDefinition()).toBeUndefined();
     });
@@ -96,12 +111,9 @@ describe('Camel Route', () => {
     it('should return the updated definition for a valid path', () => {
       const getUpdatedDefinitionSpy = vi.spyOn(CamelComponentSchemaService, 'getUpdatedDefinition');
 
-      const result = camelEntity.getNodeDefinition('route.from.steps.2.to');
+      const result = camelEntity.getNodeDefinition('route.from.steps.2.to', toStepIds);
 
-      expect(getUpdatedDefinitionSpy).toHaveBeenCalledWith(
-        { processorName: 'to', componentName: 'direct' },
-        camelRouteJson.route.from.steps[2].to,
-      );
+      expect(getUpdatedDefinitionSpy).toHaveBeenCalledWith(toStepIds, camelRouteJson.route.from.steps[2].to);
       expect(result).toEqual({
         uri: 'direct',
         parameters: {
@@ -115,7 +127,7 @@ describe('Camel Route', () => {
       const mockDefinition = { uri: 'timer', parameters: null };
       getUpdatedDefinitionSpy.mockReturnValueOnce(mockDefinition);
 
-      const result = camelEntity.getNodeDefinition('route.from');
+      const result = camelEntity.getNodeDefinition('route.from', fromStepIds);
 
       expect(result).toEqual({ uri: 'timer', parameters: {} });
     });
@@ -125,12 +137,9 @@ describe('Camel Route', () => {
       const mockDefinition = { message: 'We got a one.', id: 'log-1' };
       getUpdatedDefinitionSpy.mockReturnValueOnce(mockDefinition);
 
-      camelEntity.getNodeDefinition('route.from.steps.1.choice.when.0.steps.0.log');
+      camelEntity.getNodeDefinition('route.from.steps.1.choice.when.0.steps.0.log', logStepIds);
 
-      expect(getUpdatedDefinitionSpy).toHaveBeenCalledWith(
-        { processorName: 'log' },
-        { message: 'We got a one.', id: 'log-1' },
-      );
+      expect(getUpdatedDefinitionSpy).toHaveBeenCalledWith(logStepIds, { message: 'We got a one.', id: 'log-1' });
     });
 
     it('should preserve original definition when parameters is undefined', () => {
@@ -138,7 +147,7 @@ describe('Camel Route', () => {
       const mockDefinition = { uri: 'direct' };
       spy.mockReturnValueOnce(mockDefinition);
 
-      const result = camelEntity.getNodeDefinition('route.from.steps.2.to');
+      const result = camelEntity.getNodeDefinition('route.from.steps.2.to', toStepIds);
 
       expect(result).toEqual({ uri: 'direct' });
     });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -21,6 +21,14 @@ import { CitrusTestSchemaService } from './support/citrus-test-schema.service';
 describe('CitrusTestVisualEntity', () => {
   let citrusTestEntity: CitrusTestVisualEntity;
 
+  const printActionIds = {
+    primaryNodeId: { name: 'print', catalogKind: CatalogKind.TestAction },
+  };
+
+  const rootTestIds = {
+    primaryNodeId: { name: CITRUS_TEST_ROOT_ENTITY_NAME, catalogKind: CatalogKind.Entity },
+  };
+
   beforeAll(async () => {
     const catalogsMap = await getFirstCitrusCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.TestAction, catalogsMap.actionsCatalogMap);
@@ -216,19 +224,19 @@ describe('CitrusTestVisualEntity', () => {
     });
 
     it('should return the test object for root path', () => {
-      const result = citrusTestEntity.getNodeDefinition('test');
+      const result = citrusTestEntity.getNodeDefinition('test', rootTestIds);
 
       expect(result).toEqual(citrusTestEntity.test);
     });
 
     it('should return an empty object if path does not exist in the entity', () => {
-      const result = citrusTestEntity.getNodeDefinition('invalid.path');
+      const result = citrusTestEntity.getNodeDefinition('invalid.path', printActionIds);
 
       expect(result).toEqual({});
     });
 
     it('should return action definition for a valid path', () => {
-      const result = citrusTestEntity.getNodeDefinition('actions.0.print');
+      const result = citrusTestEntity.getNodeDefinition('actions.0.print', printActionIds);
 
       expect(result).toEqual({
         message: 'Hello from Citrus!',
@@ -243,7 +251,7 @@ describe('CitrusTestVisualEntity', () => {
         },
       });
 
-      const result = citrusTestEntity.getNodeDefinition('actions.1.iterate.actions.0.print');
+      const result = citrusTestEntity.getNodeDefinition('actions.1.iterate.actions.0.print', printActionIds);
 
       expect(result).toEqual({
         message: '${i}: Hello World!',
@@ -262,7 +270,9 @@ describe('CitrusTestVisualEntity', () => {
         },
       });
 
-      const result = citrusTestEntity.getNodeDefinition('actions.1.http-sendRequest');
+      const result = citrusTestEntity.getNodeDefinition('actions.1.http-sendRequest', {
+        primaryNodeId: { name: 'http-sendRequest', catalogKind: CatalogKind.TestAction },
+      });
 
       expect(result).toEqual({
         client: 'fooClient',
@@ -909,7 +919,7 @@ describe('CitrusTestVisualEntity', () => {
       const entity = new CitrusTestVisualEntity(invalidModel);
       const schema = CitrusTestSchemaService.getNodeSchema('print');
 
-      const result = entity.getNodeValidationText('actions.0.print', schema);
+      const result = entity.getNodeValidationText('actions.0.print', schema, printActionIds);
 
       expect(result).toBe('1 required parameter is not yet configured: [ message ]');
     });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -185,13 +185,13 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     return CitrusTestSchemaService.getNodeSchema(ids.primaryNodeId.name);
   }
 
-  getNodeDefinition(path?: string): unknown {
-    if (!path) return undefined;
+  getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): unknown {
+    if (!path || !ids?.primaryNodeId?.name) return undefined;
     if (path === this.getRootPath()) {
       return this.test;
     }
 
-    const actionName = CitrusTestSchemaService.extractTestActionName(path);
+    const actionName = ids.primaryNodeId.name;
     const actionModel: TestAction = getValue(this.test, this.toModelPath(path));
 
     if (actionModel) {
@@ -346,8 +346,12 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(path?: string, schema?: KaotoSchemaDefinition['schema']): string | undefined {
-    const definition = this.getNodeDefinition(path);
+  getNodeValidationText(
+    path?: string,
+    schema?: KaotoSchemaDefinition['schema'],
+    ids?: IVisualizationNodeIds,
+  ): string | undefined {
+    const definition = this.getNodeDefinition(path, ids);
     if (!schema || !definition) return undefined;
 
     return ModelValidationService.validateNodeStatus(schema, definition);

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -87,12 +87,12 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
     return await super.fetchNodeSchema(ids);
   }
 
-  getNodeDefinition(path?: string): unknown {
+  getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): unknown {
     if (path === this.getRootPath()) {
       return getCustomSchemaFromKamelet(this.kamelet);
     }
 
-    return super.getNodeDefinition(path);
+    return super.getNodeDefinition(path, ids);
   }
 
   getCopiedContent(path?: string, ids?: IVisualizationNodeIds): IClipboardContent | undefined {

--- a/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
@@ -56,6 +56,10 @@ describe('NodeEnrichmentService', () => {
     return vizNode;
   };
 
+  const enrichNode = async (vizNode: IVisualizationNode): Promise<void> => {
+    await NodeEnrichmentService.enrichVisualizationTree(vizNode);
+  };
+
   it('should enrich node with all catalog data on success', async () => {
     const mockSchema: KaotoSchemaDefinition['schema'] = {
       type: 'object' as const,
@@ -70,7 +74,8 @@ describe('NodeEnrichmentService', () => {
     mockGetTitleRequest.mockResolvedValue('Log EIP');
 
     const vizNode = createMockVizNode(async () => mockSchema);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Component);
+    vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'log' };
+    await enrichNode(vizNode);
 
     expect(vizNode.data.iconUrl).toBe('log-icon.svg');
     expect(vizNode.data.iconAlt).toBe('Log icon');
@@ -89,7 +94,8 @@ describe('NodeEnrichmentService', () => {
     const vizNode = createMockVizNode(async () => {
       throw new Error('Schema service down');
     });
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Component);
+    vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'log' };
+    await enrichNode(vizNode);
 
     expect(vizNode.data.iconUrl).toBe('');
     expect(vizNode.data.iconAlt).toBeUndefined();
@@ -114,7 +120,8 @@ describe('NodeEnrichmentService', () => {
     mockGetTitleRequest.mockResolvedValue('Log EIP');
 
     const vizNode = createMockVizNode(async () => mockSchema);
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Component);
+    vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'log' };
+    await enrichNode(vizNode);
 
     expect(vizNode.data.iconUrl).toBe('');
     expect(vizNode.data.iconAlt).toBeUndefined();
@@ -136,10 +143,10 @@ describe('NodeEnrichmentService', () => {
     vizNode.data.name = "${header.foo} == 'bar'";
     vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Pattern, name: 'when' };
 
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Processor);
+    await enrichNode(vizNode);
 
     // Verify getTitleRequest was called with primaryNodeId.name, not name
-    expect(mockGetTitleRequest).toHaveBeenCalledWith(CatalogKind.Processor, 'when', undefined);
+    expect(mockGetTitleRequest).toHaveBeenCalledWith(CatalogKind.Pattern, 'when', undefined);
     expect(vizNode.data.title).toBe('When EIP');
   });
 
@@ -154,7 +161,7 @@ describe('NodeEnrichmentService', () => {
     vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Pattern, name: 'from' };
     vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'timer' };
 
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Component);
+    await enrichNode(vizNode);
 
     // Verify getTitleRequest was called with name (not primaryNodeId.name) for Component kind
     expect(mockGetTitleRequest).toHaveBeenCalledWith(CatalogKind.Component, 'timer', 'timer');
@@ -169,17 +176,17 @@ describe('NodeEnrichmentService', () => {
       mockGetTitleRequest.mockResolvedValue('Beer Source');
 
       const vizNode = createMockVizNode();
-      vizNode.data.name = 'kamelet';
+      vizNode.data.name = 'beer-source';
       vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Entity, name: 'from' };
       vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'kamelet' };
       vizNode.data.tertiaryNodeId = { catalogKind: CatalogKind.Kamelet, name: 'beer-source' };
 
-      await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Entity);
+      await enrichNode(vizNode);
 
-      // Should resolve using tertiaryNodeId (Kamelet) rather than the node name
+      // deriveCatalogKind selects Kamelet; enrichment uses the kamelet name from node data
       expect(mockGetIconRequest).toHaveBeenCalledWith(CatalogKind.Kamelet, 'beer-source');
       expect(mockGetTooltipRequest).toHaveBeenCalledWith(CatalogKind.Kamelet, 'beer-source', expect.any(String));
-      expect(mockGetTitleRequest).toHaveBeenCalledWith(CatalogKind.Kamelet, 'beer-source', undefined);
+      expect(mockGetTitleRequest).toHaveBeenCalledWith(CatalogKind.Kamelet, 'beer-source', 'kamelet');
       expect(vizNode.data.title).toBe('Beer Source');
     });
 
@@ -195,7 +202,7 @@ describe('NodeEnrichmentService', () => {
       vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'timer' };
       vizNode.data.tertiaryNodeId = undefined;
 
-      await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Entity);
+      await enrichNode(vizNode);
 
       // Should resolve using secondaryNodeId (Component)
       expect(mockGetIconRequest).toHaveBeenCalledWith(CatalogKind.Component, 'timer');
@@ -216,7 +223,7 @@ describe('NodeEnrichmentService', () => {
       vizNode.data.secondaryNodeId = undefined;
       vizNode.data.tertiaryNodeId = undefined;
 
-      await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Entity);
+      await enrichNode(vizNode);
 
       // Should keep Entity kind with original name
       expect(mockGetIconRequest).toHaveBeenCalledWith(CatalogKind.Entity, 'from');
@@ -236,7 +243,7 @@ describe('NodeEnrichmentService', () => {
       vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Entity, name: 'route' };
       vizNode.data.secondaryNodeId = { catalogKind: CatalogKind.Component, name: 'timer' };
 
-      await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Entity);
+      await enrichNode(vizNode);
 
       // Should NOT redirect to the secondaryNodeId — stays with Entity kind and original name
       expect(mockGetIconRequest).toHaveBeenCalledWith(CatalogKind.Entity, 'my-route');
@@ -253,7 +260,7 @@ describe('NodeEnrichmentService', () => {
     vizNode.data.name = 'split-expression';
     vizNode.data.primaryNodeId = { catalogKind: CatalogKind.Pattern, name: 'split' };
 
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Pattern);
+    await enrichNode(vizNode);
 
     // Pattern kind → titleIdentifier must be processorName, not the node name
     expect(mockGetTitleRequest).toHaveBeenCalledWith(CatalogKind.Pattern, 'split', undefined);
@@ -284,11 +291,12 @@ describe('NodeEnrichmentService', () => {
       iconUrl: '',
       title: '',
       description: '',
+      primaryNodeId: { catalogKind: CatalogKind.Entity, name: 'route' },
     } as unknown as CamelRouteVisualEntityData);
 
     vizNode.fetchSchema = vi.fn(async () => rootSchema);
 
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Entity);
+    await enrichNode(vizNode);
 
     expect(vizNode.fetchSchema).toHaveBeenCalled();
     expect(vizNode.data.schema).toBe(rootSchema);
@@ -317,11 +325,12 @@ describe('NodeEnrichmentService', () => {
       iconUrl: '',
       title: '',
       description: '',
+      primaryNodeId: { catalogKind: CatalogKind.Pattern, name: 'log' },
     } as unknown as CamelRouteVisualEntityData);
 
     vizNode.fetchSchema = vi.fn(async () => standardSchema);
 
-    await NodeEnrichmentService.enrichNodeFromCatalog(vizNode, CatalogKind.Processor);
+    await enrichNode(vizNode);
 
     expect(vizNode.fetchSchema).toHaveBeenCalled();
     expect(vizNode.data.schema).toBe(standardSchema);

--- a/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.ts
@@ -79,12 +79,7 @@ export class NodeEnrichmentService {
     await visit(root);
   }
 
-  /**
-   * Enriches a visualization node with catalog properties (icon, title, description).
-   * @param vizNode - The visualization node to enrich
-   * @param catalogKind - The catalog kind (Component or Processor)
-   */
-  static async enrichNodeFromCatalog(vizNode: IVisualizationNode, catalogKind: CatalogKind): Promise<void> {
+  private static async enrichNodeFromCatalog(vizNode: IVisualizationNode, catalogKind: CatalogKind): Promise<void> {
     // Special handling for From nodes with Entity catalog kind
     // Use the component or kamelet for enrichment instead of the processor
     let effectiveCatalogKind = catalogKind;

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -5,10 +5,11 @@ import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { DATAMAPPER_ID_PREFIX, XSLT_COMPONENT_NAME } from '../../../../utils';
 import { ICamelComponentDefinition } from '../../../camel/camel-components-catalog';
 import { CatalogKind } from '../../../catalog-kind';
+import { IVisualizationNodeIds } from '../../base-visual-entity';
 import { IClipboardContent } from '../../clipboard';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { CamelComponentSchemaService } from './camel-component-schema.service';
-import { CamelProcessorStepsProperties, ICamelElementLookupResult } from './camel-component-types';
+import { CamelProcessorStepsProperties } from './camel-component-types';
 
 describe('CamelComponentSchemaService', () => {
   beforeAll(async () => {
@@ -138,11 +139,11 @@ describe('CamelComponentSchemaService', () => {
   });
 
   describe('getUpdatedDefinition', () => {
-    const textBasedProcessors: [ICamelElementLookupResult, string, object][] = [
+    const textBasedProcessors: [IVisualizationNodeIds, string, object][] = [
       [
         {
-          processorName: 'to',
-          componentName: 'bean',
+          primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+          secondaryNodeId: { name: 'bean', catalogKind: CatalogKind.Component },
         },
         'bean:myBean?method=hello',
         {
@@ -155,8 +156,8 @@ describe('CamelComponentSchemaService', () => {
       ],
       [
         {
-          processorName: 'toD',
-          componentName: 'bean',
+          primaryNodeId: { name: 'toD', catalogKind: CatalogKind.Pattern },
+          secondaryNodeId: { name: 'bean', catalogKind: CatalogKind.Component },
         },
         'bean:myBean?method=hello',
         {
@@ -169,7 +170,7 @@ describe('CamelComponentSchemaService', () => {
       ],
       [
         {
-          processorName: 'log',
+          primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
         },
         '${body}',
         {
@@ -178,14 +179,11 @@ describe('CamelComponentSchemaService', () => {
       ],
     ];
 
-    it.each(textBasedProcessors)(
-      'should transform string-based processors',
-      (componentLookup, definition, expectedResult) => {
-        const result = CamelComponentSchemaService.getUpdatedDefinition(componentLookup, definition);
+    it.each(textBasedProcessors)('should transform string-based processors', (ids, definition, expectedResult) => {
+      const result = CamelComponentSchemaService.getUpdatedDefinition(ids, definition);
 
-        expect(result).toMatchObject(expectedResult);
-      },
-    );
+      expect(result).toMatchObject(expectedResult);
+    });
 
     it(`should clone the component's definition`, () => {
       const toLogDefinition = {
@@ -199,7 +197,10 @@ describe('CamelComponentSchemaService', () => {
       };
 
       const result = CamelComponentSchemaService.getUpdatedDefinition(
-        { processorName: 'to', componentName: 'log' },
+        {
+          primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+          secondaryNodeId: { name: 'log', catalogKind: CatalogKind.Component },
+        },
         toLogDefinition,
       );
 
@@ -213,7 +214,10 @@ describe('CamelComponentSchemaService', () => {
       };
 
       const result = CamelComponentSchemaService.getUpdatedDefinition(
-        { processorName: 'from' as keyof ProcessorDefinition, componentName: 'timer' },
+        {
+          primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
+          secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
+        },
         toLogDefinition,
       );
 
@@ -232,7 +236,10 @@ describe('CamelComponentSchemaService', () => {
       };
 
       const result = CamelComponentSchemaService.getUpdatedDefinition(
-        { processorName: 'to', componentName: 'non-existing-component' },
+        {
+          primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+          secondaryNodeId: { name: 'non-existing-component', catalogKind: CatalogKind.Component },
+        },
         toNonExistingDefinition,
       );
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -6,6 +6,7 @@ import { CamelUriHelper, DATAMAPPER_ID_PREFIX, isDataMapperNode, ParsedParameter
 import { CatalogKind } from '../../../catalog-kind';
 import { KaotoSchemaDefinition } from '../../../kaoto-schema';
 import { REST_DSL_VERBS } from '../../../special-processors.constants';
+import { IVisualizationNodeIds } from '../../base-visual-entity';
 import { IClipboardContent } from '../../clipboard';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { CamelProcessorStepsProperties, ICamelElementLookupResult } from './camel-component-types';
@@ -255,18 +256,29 @@ export class CamelComponentSchemaService {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static getUpdatedDefinition(camelElementLookup: ICamelElementLookupResult, definition: any) {
+  static getUpdatedDefinition(ids: IVisualizationNodeIds | undefined, definition: any) {
     /** Clone the original definition since we want to preserve the original one, until the form is changed */
     let updatedDefinition = cloneDeep(definition);
 
-    const prop = this.PROCESSOR_STRING_DEFINITIONS[camelElementLookup.processorName];
-    if (prop && typeof definition === 'string') {
-      updatedDefinition = { [prop]: definition };
+    const processorName = ids?.primaryNodeId?.name;
+    const componentName =
+      ids?.secondaryNodeId?.name === 'kamelet' && ids?.tertiaryNodeId?.name !== undefined
+        ? `kamelet:${ids.tertiaryNodeId.name}`
+        : ids?.secondaryNodeId?.name;
+
+    if (processorName !== undefined) {
+      const prop = this.PROCESSOR_STRING_DEFINITIONS[processorName];
+      if (prop && typeof definition === 'string') {
+        updatedDefinition = { [prop]: definition };
+      }
     }
 
-    if (camelElementLookup.componentName !== undefined) {
+    if (componentName !== undefined) {
+      if (updatedDefinition == null) {
+        return updatedDefinition;
+      }
       updatedDefinition.parameters = updatedDefinition.parameters ?? {};
-      this.applyParametersFromSyntax(camelElementLookup.componentName, updatedDefinition);
+      this.applyParametersFromSyntax(componentName, updatedDefinition);
     }
 
     return updatedDefinition;

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 
 import { camelRouteJson } from '../../stubs/camel-route';
+import { CatalogKind } from '../catalog-kind';
 import { NodeLabelType } from '../settings';
 import { IClipboardContent } from '../visualization/clipboard';
 import {
@@ -24,6 +25,9 @@ describe('VisualizationNode', () => {
       title: '',
       description: '',
       iconUrl: '',
+      primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
+      secondaryNodeId: undefined,
+      tertiaryNodeId: undefined,
     });
   });
 
@@ -95,10 +99,13 @@ describe('VisualizationNode', () => {
       title: '',
       description: '',
       iconUrl: '',
+      primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
     });
     node.getNodeDefinition();
 
-    expect(getNodeDefinitionSpy).toHaveBeenCalledWith(node.data.path);
+    expect(getNodeDefinitionSpy).toHaveBeenCalledWith(node.data.path, {
+      primaryNodeId: node.data.primaryNodeId,
+    });
   });
 
   it('should delegate getOmitFormFields() to the underlying BaseVisualCamelEntity', () => {
@@ -172,7 +179,7 @@ describe('VisualizationNode', () => {
     } as unknown as BaseVisualEntity;
 
     const rootNode = createVisualizationNode('test', {
-      name: 'log',
+      name: 'root',
       path: 'test-path',
       entity: visualEntity,
       isPlaceholder: false,
@@ -180,6 +187,7 @@ describe('VisualizationNode', () => {
       title: '',
       description: '',
       iconUrl: '',
+      primaryNodeId: { name: 'route', catalogKind: CatalogKind.Entity },
     });
     node.setParentNode(rootNode);
 
@@ -187,7 +195,9 @@ describe('VisualizationNode', () => {
     node.getNodeDefinition();
 
     /** Assert */
-    expect(getNodeDefinitionSpy).toHaveBeenCalledWith(node.data.path);
+    expect(getNodeDefinitionSpy).toHaveBeenCalledWith(node.data.path, {
+      primaryNodeId: node.data.primaryNodeId,
+    });
   });
 
   describe('updateModel', () => {
@@ -433,10 +443,13 @@ describe('VisualizationNode', () => {
         description: '',
         iconUrl: '',
         schema: { type: 'object' },
+        primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
       });
       const validationText = node.getNodeValidationText();
 
-      expect(getNodeValidationTextSpy).toHaveBeenCalledWith(node.data.path, node.data.schema);
+      expect(getNodeValidationTextSpy).toHaveBeenCalledWith(node.data.path, node.data.schema, {
+        primaryNodeId: node.data.primaryNodeId,
+      });
       expect(validationText).toBe('test-validation-text');
     });
   });
@@ -471,8 +484,8 @@ describe('VisualizationNode', () => {
         title: '',
         description: '',
         iconUrl: '',
-        primaryNodeId: { name: 'to', catalogKind: 'processor' as never },
-        secondaryNodeId: { name: 'log', catalogKind: 'component' as never },
+        primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+        secondaryNodeId: { name: 'log', catalogKind: CatalogKind.Component },
         tertiaryNodeId: undefined,
       });
       const copiedContent = node.getCopiedContent();
@@ -480,7 +493,6 @@ describe('VisualizationNode', () => {
       expect(getCopiedContentSpy).toHaveBeenCalledWith(node.data.path, {
         primaryNodeId: node.data.primaryNodeId,
         secondaryNodeId: node.data.secondaryNodeId,
-        tertiaryNodeId: node.data.tertiaryNodeId,
       });
       expect(copiedContent).toBe('test-copied-content');
     });
@@ -592,17 +604,13 @@ describe('VisualizationNode', () => {
         iconUrl: '',
         title: '',
         description: '',
-        primaryNodeId: { name: 'log', catalogKind: 'processor' as never },
-        secondaryNodeId: undefined,
-        tertiaryNodeId: undefined,
+        primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
       });
 
       const result = await node.fetchSchema();
 
       expect(fetchNodeSchemaSpy).toHaveBeenCalledWith({
         primaryNodeId: node.data.primaryNodeId,
-        secondaryNodeId: undefined,
-        tertiaryNodeId: undefined,
       });
       expect(result).toBe(mockSchema);
     });
@@ -651,8 +659,8 @@ describe('VisualizationNode', () => {
       const fetchNodeSchemaSpy = vi.fn().mockResolvedValue(undefined);
       const visualEntity = { fetchNodeSchema: fetchNodeSchemaSpy } as unknown as BaseVisualEntity;
 
-      const primaryNodeId = { name: 'to', catalogKind: 'processor' as never };
-      const secondaryNodeId = { name: 'timer', catalogKind: 'component' as never };
+      const primaryNodeId = { name: 'to', catalogKind: CatalogKind.Pattern };
+      const secondaryNodeId = { name: 'timer', catalogKind: CatalogKind.Component };
 
       node = createVisualizationNode('test', {
         name: 'timer',
@@ -672,7 +680,6 @@ describe('VisualizationNode', () => {
       expect(fetchNodeSchemaSpy).toHaveBeenCalledWith({
         primaryNodeId,
         secondaryNodeId,
-        tertiaryNodeId: undefined,
       });
     });
   });

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -120,7 +120,12 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
   }
 
   getNodeDefinition(): unknown {
-    return this.getBaseEntity()?.getNodeDefinition(this.data.path);
+    const { primaryNodeId, secondaryNodeId, tertiaryNodeId } = this.data;
+    return this.getBaseEntity()?.getNodeDefinition(this.data.path, {
+      primaryNodeId,
+      secondaryNodeId,
+      tertiaryNodeId,
+    });
   }
 
   getOmitFormFields(): string[] {
@@ -179,7 +184,12 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
   }
 
   getNodeValidationText(): string | undefined {
-    return this.getBaseEntity()?.getNodeValidationText(this.data.path, this.data.schema);
+    const ids: IVisualizationNodeIds = {
+      primaryNodeId: this.data.primaryNodeId,
+      secondaryNodeId: this.data.secondaryNodeId,
+      tertiaryNodeId: this.data.tertiaryNodeId,
+    };
+    return this.getBaseEntity()?.getNodeValidationText(this.data.path, this.data.schema, ids);
   }
 
   /**

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
@@ -65,7 +65,7 @@ export const RestDslEditorPage: FunctionComponent = () => {
     selectedElement?.ids?.primaryNodeId?.name,
   ]);
 
-  const model = selectedEntity?.getNodeDefinition(selectedElement?.modelPath);
+  const model = selectedEntity?.getNodeDefinition(selectedElement?.modelPath, selectedElement?.ids);
 
   const [treeVersion, setTreeVersion] = useState(0);
 

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
@@ -119,7 +119,9 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
               >
                 {node.children?.map((child) => {
                   const currentEntity = entities.find((entity) => entity.id === node.entityId);
-                  const pathLabel = currentEntity?.getNodeDefinition(child?.modelPath).path;
+                  const pathLabel = currentEntity?.getNodeDefinition(child?.modelPath, {
+                    primaryNodeId: child.primaryNodeId,
+                  }).path;
                   const label = pathLabel?.trim() ? (
                     pathLabel
                   ) : (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved visualization node definitions and validation messages using node identity information for more accurate results across nested, grouped, REST, Camel, and Citrus nodes.
  - REST editor selections and tree labels now resolve more consistently, including component- and catalog-based nodes.
  - Group auto-startup controls now render correctly for supported visualization nodes.
  - Improved synchronization of nested and grouped Citrus actions.

- **Tests**
  - Expanded coverage for nested nodes, catalog types, component names, validation scenarios, and grouped actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->