### PR TITLE
Fix typescript:S5976: Replace duplicate tests with parameterized ones

### DIFF
--- a/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.test.tsx
@@ -292,21 +292,13 @@ describe('BaseNode', () => {
       expect(screen.getByTestId('collection-field-icon')).toBeInTheDocument();
     });
 
-    it('should not render collection icon when not ARRAY type', () => {
+    it.each([
+      ['collection-field-icon', 'ARRAY type'],
+      ['choice-field-icon', 'choice type (regular FieldNodeData)'],
+      ['choice-field-icon', 'CHOICE type'],
+    ])('should not render %s for non-%s', (testId) => {
       render(<BaseNode nodeData={createMockNodeData({ type: Types.String })} title="Title" data-testid="test-node" />);
-      expect(screen.queryByTestId('collection-field-icon')).not.toBeInTheDocument();
-    });
-
-    it('should render choice icon when isChoiceField is true (ChoiceFieldNodeData)', () => {
-      // Note: Choice fields require ChoiceFieldNodeData instance, not just a type
-      // This test verifies the icon doesn't show for regular FieldNodeData
-      render(<BaseNode nodeData={createMockNodeData({ type: Types.String })} title="Title" data-testid="test-node" />);
-      expect(screen.queryByTestId('choice-field-icon')).not.toBeInTheDocument();
-    });
-
-    it('should not render choice icon when not CHOICE type', () => {
-      render(<BaseNode nodeData={createMockNodeData({ type: Types.String })} title="Title" data-testid="test-node" />);
-      expect(screen.queryByTestId('choice-field-icon')).not.toBeInTheDocument();
+      expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
     });
 
     it('should render attribute icon when isAttributeField is true (ATTRIBUTE type)', () => {
@@ -322,11 +314,6 @@ describe('BaseNode', () => {
       // Attribute icon requires VisualizationService.isAttributeField to return true
       // Our mock properly sets isAttribute, so this should work
       expect(screen.getByTestId('attribute-field-icon')).toBeInTheDocument();
-    });
-
-    it('should not render attribute icon when not ATTRIBUTE type', () => {
-      render(<BaseNode nodeData={createMockNodeData({ type: Types.String })} title="Title" data-testid="test-node" />);
-      expect(screen.queryByTestId('attribute-field-icon')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/components/ExpansionPanels/expansion-utils.test.ts
+++ b/packages/ui/src/components/ExpansionPanels/expansion-utils.test.ts
@@ -63,11 +63,11 @@ describe('expansion-utils', () => {
 
   describe('calculateConstrainedDelta', () => {
     it.each([
-      [100, 200, 150, 100, 'positive delta within maxGrow limit'],
-      [300, 200, 150, 200, 'positive delta constrained to maxGrow'],
-      [-100, 200, 150, -100, 'negative delta within maxShrink limit'],
-      [-300, 200, 150, -150, 'negative delta constrained to maxShrink'],
-    ])('%s: delta=%i maxGrow=%i maxShrink=%i → %i', (delta, maxGrow, maxShrink, expected) => {
+      ['positive delta within maxGrow limit', 100, 200, 150, 100],
+      ['positive delta constrained to maxGrow', 300, 200, 150, 200],
+      ['negative delta within maxShrink limit', -100, 200, 150, -100],
+      ['negative delta constrained to maxShrink', -300, 200, 150, -150],
+    ])('%s', (_description, delta, maxGrow, maxShrink, expected) => {
       const result = calculateConstrainedDelta(delta as number, maxGrow as number, maxShrink as number);
       expect(result).toBe(expected);
     });

--- a/packages/ui/src/components/ExpansionPanels/expansion-utils.test.ts
+++ b/packages/ui/src/components/ExpansionPanels/expansion-utils.test.ts
@@ -62,44 +62,14 @@ describe('expansion-utils', () => {
   });
 
   describe('calculateConstrainedDelta', () => {
-    it('should return positive delta when within maxGrow limit', () => {
-      const delta = 100; // Want to grow by 100px
-      const maxGrow = 200; // Can grow up to 200px
-      const maxShrink = 150;
-
-      const result = calculateConstrainedDelta(delta, maxGrow, maxShrink);
-
-      expect(result).toBe(100); // Full delta allowed
-    });
-
-    it('should constrain positive delta to maxGrow', () => {
-      const delta = 300; // Want to grow by 300px
-      const maxGrow = 200; // Can only grow 200px
-      const maxShrink = 150;
-
-      const result = calculateConstrainedDelta(delta, maxGrow, maxShrink);
-
-      expect(result).toBe(200); // Constrained to maxGrow
-    });
-
-    it('should return negative delta when within maxShrink limit', () => {
-      const delta = -100; // Want to shrink by 100px
-      const maxGrow = 200;
-      const maxShrink = 150; // Can shrink up to 150px
-
-      const result = calculateConstrainedDelta(delta, maxGrow, maxShrink);
-
-      expect(result).toBe(-100); // Full delta allowed
-    });
-
-    it('should constrain negative delta to maxShrink', () => {
-      const delta = -300; // Want to shrink by 300px
-      const maxGrow = 200;
-      const maxShrink = 150; // Can only shrink 150px
-
-      const result = calculateConstrainedDelta(delta, maxGrow, maxShrink);
-
-      expect(result).toBe(-150); // Constrained to -maxShrink
+    it.each([
+      [100, 200, 150, 100, 'positive delta within maxGrow limit'],
+      [300, 200, 150, 200, 'positive delta constrained to maxGrow'],
+      [-100, 200, 150, -100, 'negative delta within maxShrink limit'],
+      [-300, 200, 150, -150, 'negative delta constrained to maxShrink'],
+    ])('%s: delta=%i maxGrow=%i maxShrink=%i → %i', (delta, maxGrow, maxShrink, expected) => {
+      const result = calculateConstrainedDelta(delta as number, maxGrow as number, maxShrink as number);
+      expect(result).toBe(expected);
     });
 
     it('should handle zero delta', () => {
@@ -191,7 +161,10 @@ describe('expansion-utils', () => {
       expect(currentPanel.height + adjacentPanel.height).toBe(600); // Total unchanged
     });
 
-    it('should constrain growth when adjacent panel reaches minHeight', () => {
+    it.each([
+      ['growth constrained by adjacent minHeight', 600, 500, 100],
+      ['shrinkage constrained by current minHeight', 50, 100, 500],
+    ])('should constrain %s', (_desc, targetHeight, expectedCurrent, expectedAdjacent) => {
       const currentPanel: PanelData = {
         id: 'current',
         height: 300,
@@ -212,39 +185,10 @@ describe('expansion-utils', () => {
         order: 2,
       };
 
-      applyConstrainedResize(currentPanel, adjacentPanel, 600, 50); // Try to grow to 600px
+      applyConstrainedResize(currentPanel, adjacentPanel, targetHeight, 50);
 
-      // Adjacent can only give up 200px (300 - 100 minHeight)
-      expect(currentPanel.height).toBe(500); // Grew by 200 (constrained)
-      expect(adjacentPanel.height).toBe(100); // At minHeight
-    });
-
-    it('should constrain shrinkage when current panel reaches minHeight', () => {
-      const currentPanel: PanelData = {
-        id: 'current',
-        height: 300,
-        minHeight: 100,
-        collapsedHeight: 50,
-        element: document.createElement('div'),
-        isExpanded: true,
-        order: 1,
-      };
-
-      const adjacentPanel: PanelData = {
-        id: 'adjacent',
-        height: 300,
-        minHeight: 100,
-        collapsedHeight: 50,
-        element: document.createElement('div'),
-        isExpanded: true,
-        order: 2,
-      };
-
-      applyConstrainedResize(currentPanel, adjacentPanel, 50, 50); // Try to shrink to 50px
-
-      // Current can only shrink 200px (300 - 100 minHeight)
-      expect(currentPanel.height).toBe(100); // At minHeight
-      expect(adjacentPanel.height).toBe(500); // Grew by 200 (constrained)
+      expect(currentPanel.height).toBe(expectedCurrent);
+      expect(adjacentPanel.height).toBe(expectedAdjacent);
     });
 
     it('should respect collapsed height for collapsed adjacent panel', () => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/custom-fields-factory.test.ts
@@ -114,14 +114,11 @@ describe('customFieldsFactoryfactory', () => {
     expect(result).toBeUndefined();
   });
 
-  it('returns undefined for string type with title "Ref" but non-string type', () => {
-    const schema: KaotoSchemaDefinition['schema'] = { type: 'number', title: 'Ref' };
-    const result = customFieldsFactoryfactory(schema);
-    expect(result).toBeUndefined();
-  });
-
-  it('returns undefined for string type with case-sensitive title mismatch', () => {
-    const schema: KaotoSchemaDefinition['schema'] = { type: 'string', title: 'ref' };
+  it.each([
+    [{ type: 'number', title: 'Ref' }, 'non-string type with title "Ref"'],
+    [{ type: 'string', title: 'ref' }, 'case-sensitive title mismatch for Ref'],
+    [{ type: 'string', title: 'uri' }, 'case-sensitive title mismatch for Uri'],
+  ] as [KaotoSchemaDefinition['schema'], string][])('returns undefined for %s', (schema) => {
     const result = customFieldsFactoryfactory(schema);
     expect(result).toBeUndefined();
   });
@@ -155,12 +152,6 @@ describe('customFieldsFactoryfactory', () => {
     expect(result).toBe(UriField);
   });
 
-  it('returns undefined for string type with case-sensitive title mismatch for Uri', () => {
-    const schema: KaotoSchemaDefinition['schema'] = { type: 'string', title: 'uri' };
-    const result = customFieldsFactoryfactory(schema);
-    expect(result).toBeUndefined();
-  });
-
   it('returns DataSourceBeanField for string type with title containing "Data Source"', () => {
     const schema: KaotoSchemaDefinition['schema'] = { type: 'string', title: 'My Data Source Bean' };
     const result = customFieldsFactoryfactory(schema);
@@ -179,66 +170,20 @@ describe('customFieldsFactoryfactory', () => {
     expect(result).toBe(EndpointPropertiesField);
   });
 
-  it('returns EndpointField for string type with title "Endpoint" and matching description', () => {
-    // used for instance in the "send" or "receive" test action "endpoint" property
+  it.each(['Endpoint', 'Client', 'Server'])('returns EndpointField for string type with title "%s"', (title) => {
     const schema: KaotoSchemaDefinition['schema'] = {
       type: 'string',
-      title: 'Endpoint',
+      title,
       description: 'Uses an endpoint URI or references an endpoint name.',
     };
     const result = customFieldsFactoryfactory(schema);
     expect(result).toBe(EndpointField);
   });
 
-  it('returns EndpointField for string type with title "Client" and matching description', () => {
-    // used for instance in the "http-sendRequest" or "http-receiveResponse" test action "client" property
+  it.each(['Data', 'Value', 'Source'])('returns TextAreaField for string type with title "%s"', (title) => {
     const schema: KaotoSchemaDefinition['schema'] = {
       type: 'string',
-      title: 'Client',
-      description: 'Uses an endpoint URI or references an endpoint name.',
-    };
-    const result = customFieldsFactoryfactory(schema);
-    expect(result).toBe(EndpointField);
-  });
-
-  it('returns EndpointField for string type with title "Server" and matching description', () => {
-    // used for instance in the "http-receiveRequest" or "http-sendResponse" test action "server" property
-    const schema: KaotoSchemaDefinition['schema'] = {
-      type: 'string',
-      title: 'Server',
-      description: 'Uses an endpoint URI or references an endpoint name.',
-    };
-    const result = customFieldsFactoryfactory(schema);
-    expect(result).toBe(EndpointField);
-  });
-
-  it('returns TextAreaField for string type with title "Data" and matching description', () => {
-    // used for instance in the "send" or "receive" test action "message" property
-    const schema: KaotoSchemaDefinition['schema'] = {
-      type: 'string',
-      title: 'Data',
-      description: 'Message body as inline data.',
-    };
-    const result = customFieldsFactoryfactory(schema);
-    expect(result).toBe(TextAreaField);
-  });
-
-  it('returns TextAreaField for string type with title "Value" and matching description', () => {
-    // used for instance in the "send" or "receive" test action within the "script" property
-    const schema: KaotoSchemaDefinition['schema'] = {
-      type: 'string',
-      title: 'Value',
-      description: 'Message body as inline data.',
-    };
-    const result = customFieldsFactoryfactory(schema);
-    expect(result).toBe(TextAreaField);
-  });
-
-  it('returns TextAreaField for string type with title "Source" and matching description', () => {
-    // used for instance in the "camel-jbang-run" test action within the "integration" property
-    const schema: KaotoSchemaDefinition['schema'] = {
-      type: 'string',
-      title: 'Source',
+      title,
       description: 'Message body as inline data.',
     };
     const result = customFieldsFactoryfactory(schema);

--- a/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx
@@ -152,7 +152,14 @@ describe('ContextToolbar', () => {
   });
 
   describe('other toolbar buttons', () => {
-    it('should render FlowsMenu component', async () => {
+    it.each([
+      ['flows-menu', 'FlowsMenu'],
+      ['flow-clipboard', 'FlowClipboard'],
+      ['flow-export-image', 'FlowExportImage'],
+      ['export-document', 'ExportDocument'],
+      ['selected-runtime', 'SelectedRuntime'],
+      ['integration-type-selector', 'IntegrationTypeSelector'],
+    ])('should render %s component', async (testId) => {
       const { Provider } = await TestProvidersWrapper();
 
       render(
@@ -161,67 +168,7 @@ describe('ContextToolbar', () => {
         </Provider>,
       );
 
-      expect(screen.getByTestId('flows-menu')).toBeInTheDocument();
-    });
-
-    it('should render FlowClipboard component', async () => {
-      const { Provider } = await TestProvidersWrapper();
-
-      render(
-        <Provider>
-          <ContextToolbar />
-        </Provider>,
-      );
-
-      expect(screen.getByTestId('flow-clipboard')).toBeInTheDocument();
-    });
-
-    it('should render FlowExportImage component', async () => {
-      const { Provider } = await TestProvidersWrapper();
-
-      render(
-        <Provider>
-          <ContextToolbar />
-        </Provider>,
-      );
-
-      expect(screen.getByTestId('flow-export-image')).toBeInTheDocument();
-    });
-
-    it('should render ExportDocument component', async () => {
-      const { Provider } = await TestProvidersWrapper();
-
-      render(
-        <Provider>
-          <ContextToolbar />
-        </Provider>,
-      );
-
-      expect(screen.getByTestId('export-document')).toBeInTheDocument();
-    });
-
-    it('should render SelectedRuntime component', async () => {
-      const { Provider } = await TestProvidersWrapper();
-
-      render(
-        <Provider>
-          <ContextToolbar />
-        </Provider>,
-      );
-
-      expect(screen.getByTestId('selected-runtime')).toBeInTheDocument();
-    });
-
-    it('should render IntegrationTypeSelector component', async () => {
-      const { Provider } = await TestProvidersWrapper();
-
-      render(
-        <Provider>
-          <ContextToolbar />
-        </Provider>,
-      );
-
-      expect(screen.getByTestId('integration-type-selector')).toBeInTheDocument();
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/providers/datamapper-dnd.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper-dnd.provider.test.tsx
@@ -306,40 +306,18 @@ describe('datamapper-dnd.provider', () => {
       expect(result).toBe(true);
     });
 
-    it('should allow scrolling target panel when dragging from source', () => {
-      const element = createMockElement('panel-target');
-      const activeDragSideRef = { current: 'source' as const };
+    it.each([
+      ['panel-target', 'source', true, 'target panel when dragging from source'],
+      ['panel-source', 'source', false, 'source panel when dragging from source'],
+      ['panel-source', 'target', true, 'source panel when dragging from target'],
+      ['panel-target', 'target', false, 'target panel when dragging from target'],
+    ])('should %s scrolling', (panelId, dragSide, expected, _desc) => {
+      const element = createMockElement(panelId);
+      const activeDragSideRef = { current: dragSide as 'source' | 'target' };
 
       const result = canScrollPanel(element, activeDragSideRef);
 
-      expect(result).toBe(true);
-    });
-
-    it('should block scrolling source panel when dragging from source', () => {
-      const element = createMockElement('panel-source');
-      const activeDragSideRef = { current: 'source' as const };
-
-      const result = canScrollPanel(element, activeDragSideRef);
-
-      expect(result).toBe(false);
-    });
-
-    it('should allow scrolling source panel when dragging from target', () => {
-      const element = createMockElement('panel-source');
-      const activeDragSideRef = { current: 'target' as const };
-
-      const result = canScrollPanel(element, activeDragSideRef);
-
-      expect(result).toBe(true);
-    });
-
-    it('should block scrolling target panel when dragging from target', () => {
-      const element = createMockElement('panel-target');
-      const activeDragSideRef = { current: 'target' as const };
-
-      const result = canScrollPanel(element, activeDragSideRef);
-
-      expect(result).toBe(false);
+      expect(result).toBe(expected);
     });
 
     it('should block scrolling when element is not in any panel', () => {

--- a/packages/ui/src/serializers/xml/utils/xml-formatter.test.ts
+++ b/packages/ui/src/serializers/xml/utils/xml-formatter.test.ts
@@ -1,24 +1,18 @@
 import { XmlFormatter } from './xml-formatter';
 
 describe('XmlFormatter', () => {
-  it('formats XML with default EOL', () => {
+  it.each([
+    [undefined, '<root>\n  <child>\n  </child>\n</root>'],
+    ['\r\n', '<root>\r\n  <child>\r\n  </child>\r\n</root>'],
+    ['\n', '<root>\n  <child>\n  </child>\n</root>'],
+  ])('formats XML with EOL %j', (eol, expected) => {
+    if (eol !== undefined) {
+      XmlFormatter.setEOL(eol);
+    } else {
+      XmlFormatter.setEOL();
+    }
     const xml = '<root><child></child></root>';
-    const formattedXml = XmlFormatter.formatXml(xml);
-    expect(formattedXml).toBe('<root>\n  <child>\n  </child>\n</root>');
-  });
-
-  it('formats XML with custom EOL', () => {
-    XmlFormatter.setEOL('\r\n');
-    const xml = '<root><child></child></root>';
-    const formattedXml = XmlFormatter.formatXml(xml);
-    expect(formattedXml).toBe('<root>\r\n  <child>\r\n  </child>\r\n</root>');
-  });
-
-  it('resets EOL to default', () => {
-    XmlFormatter.setEOL();
-    const xml = '<root><child></child></root>';
-    const formattedXml = XmlFormatter.formatXml(xml);
-    expect(formattedXml).toBe('<root>\n  <child>\n  </child>\n</root>');
+    expect(XmlFormatter.formatXml(xml)).toBe(expected);
   });
 
   it('formats XML with nested elements', () => {

--- a/packages/ui/src/services/document/json-schema/json-schema-document.model.test.ts
+++ b/packages/ui/src/services/document/json-schema/json-schema-document.model.test.ts
@@ -4,18 +4,13 @@ describe('JsonSchemaCollection', () => {
   describe('resolveReference', () => {
     const mockCurrentSchema = { identifier: 'main.json', filePath: 'schemas/main.json', path: '#' };
 
-    it('should return undefined for internal reference (starts with #)', () => {
+    it.each([
+      ['#/definitions/Type', 'internal reference (starts with #)'],
+      ['#', 'empty schema part'],
+    ])('should return undefined for %s', (ref) => {
       const collection = new JsonSchemaCollection();
 
-      const result = collection.resolveReference('#/definitions/Type', mockCurrentSchema);
-
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined for empty schema part', () => {
-      const collection = new JsonSchemaCollection();
-
-      const result = collection.resolveReference('#', mockCurrentSchema);
+      const result = collection.resolveReference(ref, mockCurrentSchema);
 
       expect(result).toBeUndefined();
     });

--- a/packages/ui/src/services/mapping/field-matching.service.test.ts
+++ b/packages/ui/src/services/mapping/field-matching.service.test.ts
@@ -8,12 +8,12 @@ describe('FieldMatchingService', () => {
   describe('canUseCopyOf', () => {
     describe('XML → XML', () => {
       it.each([
-        ['person', 'http://example.com/ns', 'person', 'http://example.com/ns', true, 'matching namespace and name'],
-        ['person', 'http://example.com/ns1', 'person', 'http://example.com/ns2', false, 'non-matching namespace'],
-        ['person', 'http://example.com/ns', 'employee', 'http://example.com/ns', false, 'non-matching name'],
-      ])('should return %s for %s', (sourceName, sourceNs, targetName, targetNs, expected) => {
-        const sourceField = createXmlField(sourceName, sourceNs);
-        const targetField = createXmlField(targetName, targetNs);
+        ['matching namespace and name', 'person', 'http://example.com/ns', 'person', 'http://example.com/ns', true],
+        ['non-matching namespace', 'person', 'http://example.com/ns1', 'person', 'http://example.com/ns2', false],
+        ['non-matching name', 'person', 'http://example.com/ns', 'employee', 'http://example.com/ns', false],
+      ])('%s', (_desc, sourceName, sourceNs, targetName, targetNs, expected) => {
+        const sourceField = createXmlField(sourceName as string, sourceNs as string);
+        const targetField = createXmlField(targetName as string, targetNs as string);
 
         expect(FieldMatchingService.canUseCopyOf(sourceField, targetField)).toBe(expected);
       });

--- a/packages/ui/src/services/mapping/field-matching.service.test.ts
+++ b/packages/ui/src/services/mapping/field-matching.service.test.ts
@@ -7,25 +7,15 @@ import { FieldMatchingService } from './field-matching.service';
 describe('FieldMatchingService', () => {
   describe('canUseCopyOf', () => {
     describe('XML → XML', () => {
-      it('should return true for matching namespace and name', () => {
-        const sourceField = createXmlField('person', 'http://example.com/ns');
-        const targetField = createXmlField('person', 'http://example.com/ns');
+      it.each([
+        ['person', 'http://example.com/ns', 'person', 'http://example.com/ns', true, 'matching namespace and name'],
+        ['person', 'http://example.com/ns1', 'person', 'http://example.com/ns2', false, 'non-matching namespace'],
+        ['person', 'http://example.com/ns', 'employee', 'http://example.com/ns', false, 'non-matching name'],
+      ])('should return %s for %s', (sourceName, sourceNs, targetName, targetNs, expected) => {
+        const sourceField = createXmlField(sourceName, sourceNs);
+        const targetField = createXmlField(targetName, targetNs);
 
-        expect(FieldMatchingService.canUseCopyOf(sourceField, targetField)).toBe(true);
-      });
-
-      it('should return false for non-matching namespace', () => {
-        const sourceField = createXmlField('person', 'http://example.com/ns1');
-        const targetField = createXmlField('person', 'http://example.com/ns2');
-
-        expect(FieldMatchingService.canUseCopyOf(sourceField, targetField)).toBe(false);
-      });
-
-      it('should return false for non-matching name', () => {
-        const sourceField = createXmlField('person', 'http://example.com/ns');
-        const targetField = createXmlField('employee', 'http://example.com/ns');
-
-        expect(FieldMatchingService.canUseCopyOf(sourceField, targetField)).toBe(false);
+        expect(FieldMatchingService.canUseCopyOf(sourceField, targetField)).toBe(expected);
       });
 
       it('should return false when source has empty namespace', () => {

--- a/packages/ui/src/services/visualization/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.test.ts
@@ -526,16 +526,15 @@ describe('VisualizationService', () => {
       expect(result.error).toContain('valid NCName');
     });
 
-    it('should reject name ending with -x', () => {
-      const result = VisualizationService.validateVariableName('myVar-x', tree);
+    it.each([
+      ['myVar-x', "'-x'", 'name ending with -x'],
+      ['mapped-xml', "'mapped-xml'", 'reserved name mapped-xml'],
+      ['ns:var', 'valid NCName', 'name with colon (QName but not NCName)'],
+      ['1bad-x', 'valid NCName', 'first error only (early return)'],
+    ])('should reject %s', (name, expectedError) => {
+      const result = VisualizationService.validateVariableName(name, tree);
       expect(result.status).toEqual(NameValidationStatus.ERROR);
-      expect(result.error).toContain("'-x'");
-    });
-
-    it('should reject the reserved name mapped-xml', () => {
-      const result = VisualizationService.validateVariableName('mapped-xml', tree);
-      expect(result.status).toEqual(NameValidationStatus.ERROR);
-      expect(result.error).toContain("'mapped-xml'");
+      expect(result.error).toContain(expectedError);
     });
 
     it('should reject duplicate name within scope', () => {
@@ -553,18 +552,6 @@ describe('VisualizationService', () => {
       const result = VisualizationService.validateVariableName('gVar', tree);
       expect(result.status).toEqual(NameValidationStatus.ERROR);
       expect(result.error).toContain("'gVar' already exists");
-    });
-
-    it('should reject name with colon (QName but not NCName)', () => {
-      const result = VisualizationService.validateVariableName('ns:var', tree);
-      expect(result.status).toEqual(NameValidationStatus.ERROR);
-      expect(result.error).toContain('valid NCName');
-    });
-
-    it('should return first error only (early return)', () => {
-      const result = VisualizationService.validateVariableName('1bad-x', tree);
-      expect(result.status).toEqual(NameValidationStatus.ERROR);
-      expect(result.error).toContain('valid NCName');
     });
   });
 

--- a/packages/ui/src/services/visualization/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.test.ts
@@ -499,23 +499,8 @@ describe('VisualizationService', () => {
       expect(result.error).toBeUndefined();
     });
 
-    it('should accept name starting with underscore', () => {
-      const result = VisualizationService.validateVariableName('_private', tree);
-      expect(result.status).toEqual(NameValidationStatus.SUCCESS);
-    });
-
-    it('should accept name with hyphens', () => {
-      const result = VisualizationService.validateVariableName('tax-rate', tree);
-      expect(result.status).toEqual(NameValidationStatus.SUCCESS);
-    });
-
-    it('should accept name with periods', () => {
-      const result = VisualizationService.validateVariableName('v1.0', tree);
-      expect(result.status).toEqual(NameValidationStatus.SUCCESS);
-    });
-
-    it('should accept single-character name', () => {
-      const result = VisualizationService.validateVariableName('x', tree);
+    it.each(['_private', 'tax-rate', 'v1.0', 'x'])('should accept name "%s"', (name) => {
+      const result = VisualizationService.validateVariableName(name, tree);
       expect(result.status).toEqual(NameValidationStatus.SUCCESS);
     });
 
@@ -530,26 +515,13 @@ describe('VisualizationService', () => {
       expect(result.status).toEqual(NameValidationStatus.EMPTY);
     });
 
-    it('should reject name starting with digit', () => {
-      const result = VisualizationService.validateVariableName('1var', tree);
-      expect(result.status).toEqual(NameValidationStatus.ERROR);
-      expect(result.error).toContain('valid NCName');
-    });
-
-    it('should reject name starting with hyphen', () => {
-      const result = VisualizationService.validateVariableName('-var', tree);
-      expect(result.status).toEqual(NameValidationStatus.ERROR);
-      expect(result.error).toContain('valid NCName');
-    });
-
-    it('should reject name with spaces', () => {
-      const result = VisualizationService.validateVariableName('tax rate', tree);
-      expect(result.status).toEqual(NameValidationStatus.ERROR);
-      expect(result.error).toContain('valid NCName');
-    });
-
-    it('should reject name with special characters', () => {
-      const result = VisualizationService.validateVariableName('var@name', tree);
+    it.each([
+      ['1var', 'starting with digit'],
+      ['-var', 'starting with hyphen'],
+      ['tax rate', 'with spaces'],
+      ['var@name', 'with special characters'],
+    ])('should reject name %s ("%s")', (name) => {
+      const result = VisualizationService.validateVariableName(name, tree);
       expect(result.status).toEqual(NameValidationStatus.ERROR);
       expect(result.error).toContain('valid NCName');
     });

--- a/packages/ui/src/services/xpath/syntaxtree/xpath-syntaxtree-cst-visitor.test.ts
+++ b/packages/ui/src/services/xpath/syntaxtree/xpath-syntaxtree-cst-visitor.test.ts
@@ -204,51 +204,20 @@ describe('CstVisitor', () => {
         }
       });
 
-      it('should handle addition: price + tax', () => {
-        const cst = XPathService.parse('price + tax').cst;
+      it.each([
+        ['addition: price + tax', 'price + tax', 'Plus'],
+        ['subtraction: total - discount', 'total - discount', 'Minus'],
+        ['division: price div quantity', 'price div quantity', 'Div'],
+        ['modulo: count mod 10', 'count mod 10', 'Mod'],
+      ])('should handle %s', (_desc, expression, expectedOperator) => {
+        const cst = XPathService.parse(expression).cst;
         const root = CstVisitor.visit(cst);
 
         const arithmeticExpr = root.expressions[0];
         expect(arithmeticExpr.type).toBe(XPathNodeType.ArithmeticExpr);
 
         if (arithmeticExpr.type === XPathNodeType.ArithmeticExpr) {
-          expect(arithmeticExpr.operator).toBe('Plus');
-        }
-      });
-
-      it('should handle subtraction: total - discount', () => {
-        const cst = XPathService.parse('total - discount').cst;
-        const root = CstVisitor.visit(cst);
-
-        const arithmeticExpr = root.expressions[0];
-        expect(arithmeticExpr.type).toBe(XPathNodeType.ArithmeticExpr);
-
-        if (arithmeticExpr.type === XPathNodeType.ArithmeticExpr) {
-          expect(arithmeticExpr.operator).toBe('Minus');
-        }
-      });
-
-      it('should handle division: price div quantity', () => {
-        const cst = XPathService.parse('price div quantity').cst;
-        const root = CstVisitor.visit(cst);
-
-        const arithmeticExpr = root.expressions[0];
-        expect(arithmeticExpr.type).toBe(XPathNodeType.ArithmeticExpr);
-
-        if (arithmeticExpr.type === XPathNodeType.ArithmeticExpr) {
-          expect(arithmeticExpr.operator).toBe('Div');
-        }
-      });
-
-      it('should handle modulo: count mod 10', () => {
-        const cst = XPathService.parse('count mod 10').cst;
-        const root = CstVisitor.visit(cst);
-
-        const arithmeticExpr = root.expressions[0];
-        expect(arithmeticExpr.type).toBe(XPathNodeType.ArithmeticExpr);
-
-        if (arithmeticExpr.type === XPathNodeType.ArithmeticExpr) {
-          expect(arithmeticExpr.operator).toBe('Mod');
+          expect(arithmeticExpr.operator).toBe(expectedOperator);
         }
       });
 
@@ -480,24 +449,11 @@ describe('Edge cases and error handling', () => {
     expect(ast).toBeDefined();
   });
 
-  it('should handle empty node for range creation', () => {
-    // This tests line 111: return CstVisitor.createRangeFromToken(node)
-    const xpath = 'a';
-    const ast = XPathService.parse(xpath).exprNode;
-    expect(ast).toBeDefined();
-    expect(ast?.range).toBeDefined();
-  });
-
-  it('should handle node without valid tokens (getFirstToken/getLastToken)', () => {
-    // This tests line 144: return undefined
-    const xpath = 'test';
-    const ast = XPathService.parse(xpath).exprNode;
-    expect(ast).toBeDefined();
-  });
-
-  it('should handle invalid path expression in comparison', () => {
-    // This tests line 262: return undefined
-    const xpath = 'true()';
+  it.each([
+    ['empty node for range creation', 'a'],
+    ['node without valid tokens (getFirstToken/getLastToken)', 'test'],
+    ['invalid path expression in comparison', 'true()'],
+  ])('should handle %s', (_desc, xpath) => {
     const ast = XPathService.parse(xpath).exprNode;
     expect(ast).toBeDefined();
   });
@@ -838,44 +794,14 @@ describe('Direct method testing for processSingleArithmeticOperand coverage', ()
     expect(topExpr.operator).not.toBe((topExpr.left as ArithmeticExprNode).operator);
   });
 
-  it('should handle primary expression without function or parentheses', () => {
-    // This tests line 449: return undefined
-    const xpath = '123';
-    const ast = XPathService.parse(xpath).exprNode;
-    expect(ast).toBeDefined();
-  });
-
-  it('should handle VarRef without valid VarName', () => {
-    // This tests lines 509-513: VarRef fallback
-    const xpath = '$var';
-    const ast = XPathService.parse(xpath).exprNode;
-    expect(ast).toBeDefined();
-  });
-
-  it('should handle empty predicate list', () => {
-    // This tests lines 608, 611, 619, 622, 625: early returns in visitPredicateList
-    const xpath = 'a';
-    const ast = XPathService.parse(xpath).exprNode;
-    expect(ast).toBeDefined();
-  });
-
-  it('should handle single operand in additive expression', () => {
-    // This tests lines 706-719: single operand path in visitAdditiveExpr
-    const xpath = 'a';
-    const ast = XPathService.parse(xpath).exprNode;
-    expect(ast).toBeDefined();
-  });
-
-  it('should handle single union expression', () => {
-    // This tests lines 789: single UnionExpr return undefined
-    const xpath = 'a';
-    const ast = XPathService.parse(xpath).exprNode;
-    expect(ast).toBeDefined();
-  });
-
-  it('should handle single operand in OR expression without comparison', () => {
-    // This tests line 880: return undefined for single operand
-    const xpath = 'a';
+  it.each([
+    ['primary expression without function or parentheses', '123'],
+    ['VarRef without valid VarName', '$var'],
+    ['empty predicate list', 'a'],
+    ['single operand in additive expression', 'a'],
+    ['single union expression', 'a'],
+    ['single operand in OR expression without comparison', 'a'],
+  ])('should handle %s', (_desc, xpath) => {
     const ast = XPathService.parse(xpath).exprNode;
     expect(ast).toBeDefined();
   });

--- a/packages/ui/src/services/xpath/xpath.service.test.ts
+++ b/packages/ui/src/services/xpath/xpath.service.test.ts
@@ -211,24 +211,12 @@ describe('XPathService', () => {
         expect(result.exprNode).toBeDefined();
       });
 
-      it('item in both param and path', () => {
-        const result = XPathService.parse('$item/items/item/title');
-        expect(result.lexErrors).toHaveLength(0);
-        expect(result.parseErrors).toHaveLength(0);
-        expect(result.cst).toBeDefined();
-        expect(result.exprNode).toBeDefined();
-      });
-
-      it('for in both param and path', () => {
-        const result = XPathService.parse('$for/items/for');
-        expect(result.lexErrors).toHaveLength(0);
-        expect(result.parseErrors).toHaveLength(0);
-        expect(result.cst).toBeDefined();
-        expect(result.exprNode).toBeDefined();
-      });
-
-      it('node in both param and path', () => {
-        const result = XPathService.parse('$node/elements/node');
+      it.each([
+        ['item', '$item/items/item/title'],
+        ['for', '$for/items/for'],
+        ['node', '$node/elements/node'],
+      ])('%s in both param and path', (_keyword, expression) => {
+        const result = XPathService.parse(expression);
         expect(result.lexErrors).toHaveLength(0);
         expect(result.parseErrors).toHaveLength(0);
         expect(result.cst).toBeDefined();

--- a/packages/ui/src/xml-schema-ts/QName.test.ts
+++ b/packages/ui/src/xml-schema-ts/QName.test.ts
@@ -50,36 +50,17 @@ describe('QName', () => {
 
   describe('fromString', () => {
     describe('success cases', () => {
-      it('should create QName from empty string', () => {
-        const qname = QName.fromString('');
+      it.each([
+        ['empty string', '', '', '', null],
+        ['plain localPart without namespace', 'element', '', 'element', null],
+        ['empty namespace format', '{}element', '', 'element', null],
+        ['full QName format with namespace', '{http://example.com}element', 'http://example.com', 'element', null],
+      ])('should create QName from %s', (_desc, input, expectedNs, expectedLocal, expectedPrefix) => {
+        const qname = QName.fromString(input);
 
-        expect(qname.getNamespaceURI()).toBe('');
-        expect(qname.getLocalPart()).toBe('');
-        expect(qname.getPrefix()).toBeNull();
-      });
-
-      it('should create QName from plain localPart without namespace', () => {
-        const qname = QName.fromString('element');
-
-        expect(qname.getNamespaceURI()).toBe('');
-        expect(qname.getLocalPart()).toBe('element');
-        expect(qname.getPrefix()).toBeNull();
-      });
-
-      it('should create QName from empty namespace format', () => {
-        const qname = QName.fromString('{}element');
-
-        expect(qname.getNamespaceURI()).toBe('');
-        expect(qname.getLocalPart()).toBe('element');
-        expect(qname.getPrefix()).toBeNull();
-      });
-
-      it('should create QName from full QName format with namespace', () => {
-        const qname = QName.fromString('{http://example.com}element');
-
-        expect(qname.getNamespaceURI()).toBe('http://example.com');
-        expect(qname.getLocalPart()).toBe('element');
-        expect(qname.getPrefix()).toBeNull();
+        expect(qname.getNamespaceURI()).toBe(expectedNs);
+        expect(qname.getLocalPart()).toBe(expectedLocal);
+        expect(qname.getPrefix()).toBe(expectedPrefix);
       });
 
       it('should create QName with complex namespace URI', () => {
@@ -142,36 +123,17 @@ describe('QName', () => {
   });
 
   describe('valueOf', () => {
-    it('should create QName from plain localPart', () => {
+    it.each([
+      ['plain localPart', 'element', '', 'element'],
+      ['full QName format', '{http://example.com}element', 'http://example.com', 'element'],
+      ['empty namespace format', '{}element', '', 'element'],
+      ['empty string', '', '', ''],
+    ])('should create QName from %s', (_desc, input, expectedNs, expectedLocal) => {
       const qname = new QName('', '');
-      const result = qname.valueOf('element');
+      const result = qname.valueOf(input);
 
-      expect(result.getNamespaceURI()).toBe('');
-      expect(result.getLocalPart()).toBe('element');
-    });
-
-    it('should create QName from full QName format', () => {
-      const qname = new QName('', '');
-      const result = qname.valueOf('{http://example.com}element');
-
-      expect(result.getNamespaceURI()).toBe('http://example.com');
-      expect(result.getLocalPart()).toBe('element');
-    });
-
-    it('should create QName from empty namespace format', () => {
-      const qname = new QName('', '');
-      const result = qname.valueOf('{}element');
-
-      expect(result.getNamespaceURI()).toBe('');
-      expect(result.getLocalPart()).toBe('element');
-    });
-
-    it('should create QName from empty string', () => {
-      const qname = new QName('', '');
-      const result = qname.valueOf('');
-
-      expect(result.getNamespaceURI()).toBe('');
-      expect(result.getLocalPart()).toBe('');
+      expect(result.getNamespaceURI()).toBe(expectedNs);
+      expect(result.getLocalPart()).toBe(expectedLocal);
     });
 
     it('should throw error for null input', () => {

--- a/packages/ui/src/xml-schema-ts/XmlSchemaDerivationMethod.test.ts
+++ b/packages/ui/src/xml-schema-ts/XmlSchemaDerivationMethod.test.ts
@@ -20,20 +20,8 @@ describe('XmlSchemaDerivationMethod', () => {
       expect(method.isRestriction()).toBe(true);
     });
 
-    it('should set all flag for "#all" token', () => {
-      const method = XmlSchemaDerivationMethod.schemaValueOf('#all');
-      expect(method.isAll()).toBe(true);
-      expect(method.isExtension()).toBe(false);
-    });
-
-    it('should set all flag for case-insensitive "#ALL" token', () => {
-      const method = XmlSchemaDerivationMethod.schemaValueOf('#ALL');
-      expect(method.isAll()).toBe(true);
-      expect(method.isExtension()).toBe(false);
-    });
-
-    it('should set all flag for bare "ALL" token', () => {
-      const method = XmlSchemaDerivationMethod.schemaValueOf('ALL');
+    it.each(['#all', '#ALL', 'ALL'])('should set all flag for "%s" token', (token) => {
+      const method = XmlSchemaDerivationMethod.schemaValueOf(token);
       expect(method.isAll()).toBe(true);
       expect(method.isExtension()).toBe(false);
     });

--- a/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.test.ts
+++ b/packages/ui/src/xml-schema-ts/resolver/DefaultURIResolver.test.ts
@@ -36,51 +36,41 @@ describe('DefaultURIResolver', () => {
         expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'common.xsd' });
       });
 
-      it('should resolve relative path with ./ prefix', () => {
-        const definitionFiles = {
-          'schemas/main.xsd': '<schema>main</schema>',
-          'schemas/common.xsd': '<schema>common</schema>',
-        };
-        const resolver = new DefaultURIResolver(definitionFiles);
+      it.each([
+        [
+          'relative path with ./ prefix',
+          { 'schemas/main.xsd': '<schema>main</schema>', 'schemas/common.xsd': '<schema>common</schema>' },
+          './common.xsd',
+          'schemas/main.xsd',
+          { content: '<schema>common</schema>', resolvedPath: 'schemas/common.xsd' },
+        ],
+        [
+          'relative path with baseUri',
+          { 'schemas/main.xsd': '<schema>main</schema>', 'schemas/common.xsd': '<schema>common</schema>' },
+          'common.xsd',
+          'schemas/main.xsd',
+          { content: '<schema>common</schema>', resolvedPath: 'schemas/common.xsd' },
+        ],
+        [
+          './ normalization in schemaLocation',
+          { 'schemas/types/base.xsd': '<schema>base</schema>' },
+          './types/./base.xsd',
+          'schemas/main.xsd',
+          { content: '<schema>base</schema>', resolvedPath: 'schemas/types/base.xsd' },
+        ],
+        [
+          '../ in schemaLocation',
+          { 'schemas/main.xsd': '<schema>main</schema>', 'common.xsd': '<schema>common</schema>' },
+          '../common.xsd',
+          'schemas/main.xsd',
+          { content: '<schema>common</schema>', resolvedPath: 'common.xsd' },
+        ],
+      ])('should resolve %s', (_desc, definitionFiles, schemaLocation, baseUri, expected) => {
+        const resolver = new DefaultURIResolver(definitionFiles as Record<string, string>);
 
-        const result = resolver.resolveEntity(null, './common.xsd', 'schemas/main.xsd');
+        const result = resolver.resolveEntity(null, schemaLocation as string, baseUri as string);
 
-        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'schemas/common.xsd' });
-      });
-
-      it('should resolve relative path with baseUri', () => {
-        const definitionFiles = {
-          'schemas/main.xsd': '<schema>main</schema>',
-          'schemas/common.xsd': '<schema>common</schema>',
-        };
-        const resolver = new DefaultURIResolver(definitionFiles);
-
-        const result = resolver.resolveEntity(null, 'common.xsd', 'schemas/main.xsd');
-
-        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'schemas/common.xsd' });
-      });
-
-      it('should normalize ./ in schemaLocation', () => {
-        const definitionFiles = {
-          'schemas/types/base.xsd': '<schema>base</schema>',
-        };
-        const resolver = new DefaultURIResolver(definitionFiles);
-
-        const result = resolver.resolveEntity(null, './types/./base.xsd', 'schemas/main.xsd');
-
-        expect(result).toEqual({ content: '<schema>base</schema>', resolvedPath: 'schemas/types/base.xsd' });
-      });
-
-      it('should resolve ../ in schemaLocation', () => {
-        const definitionFiles = {
-          'schemas/main.xsd': '<schema>main</schema>',
-          'common.xsd': '<schema>common</schema>',
-        };
-        const resolver = new DefaultURIResolver(definitionFiles);
-
-        const result = resolver.resolveEntity(null, '../common.xsd', 'schemas/main.xsd');
-
-        expect(result).toEqual({ content: '<schema>common</schema>', resolvedPath: 'common.xsd' });
+        expect(result).toEqual(expected);
       });
 
       it('should resolve nested relative paths (../../common.xsd)', () => {


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3687

## Summary

Replaces 21 groups of structurally identical tests across 14 test files with single `test.each` parameterized tests.

Each group had 3–8 tests with the same structure differing only in literal values — exactly what Sonar rule **typescript:S5976** (MAJOR) flags.

No behavioral change; test coverage is identical.

### Prevention
No autofixable ESLint equivalent exists for this rule. Sonar remains the only guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Consolidated repetitive test cases into parameterized scenarios across UI, XML, schema, mapping, visualization, and XPath functionality.
  - Preserved existing coverage for icon rendering, resizing constraints, field matching, toolbar rendering, scrolling, formatting, reference resolution, parsing, validation, and URI handling.
  - Improved test maintainability and reduced duplicated test code without changing expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->