### PR TITLE
Fix typescript:S2187: Move NOSONAR suppression to correct line in Form test files

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.000-050.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.000-050.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Component, range: { start: 0, end: 50 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.050-100.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.050-100.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Component, range: { start: 50, end: 100 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.100-150.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.100-150.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Component, range: { start: 100, end: 150 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.150-200.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.150-200.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Component, range: { start: 150, end: 200 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.200-250.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.200-250.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Component, range: { start: 200, end: 250 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.250-300.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.250-300.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Component, range: { start: 250, end: 300 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.300-end.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.components.300-end.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Component, range: { start: 300, end: undefined } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.eips.000-end.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.eips.000-end.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Pattern, range: { start: 0, end: undefined } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.000-050.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.000-050.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Kamelet, range: { start: 0, end: 50 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.050-100.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.050-100.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Kamelet, range: { start: 50, end: 100 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.100-150.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.100-150.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Kamelet, range: { start: 100, end: 150 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.150-200.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.150-200.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Kamelet, range: { start: 150, end: 200 } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});

--- a/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.200-end.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/Tests/Form.kamelets.200-end.test.tsx
@@ -4,5 +4,6 @@ import { FormTest } from './FormTest';
 const target = { kind: CatalogKind.Kamelet, range: { start: 200, end: undefined } } as const;
 
 describe(`Form: ${target.kind} - [${target.range.start} - ${target.range.end}]`, () => {
+  // NOSONAR typescript:S2187 - Tests are defined in FormTest function
   FormTest(target);
-}); // NOSONAR typescript:S2187 - Tests are defined in FormTest function
+});


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3689

## Summary

13 BLOCKER issues in `packages/ui/src/components/Visualization/Canvas/Form/Tests/` where test files had `// NOSONAR typescript:S2187` on the closing `});` line. Sonar didn't read it there.

Moved the comment inside the `describe` block — the Prettier-formatted position where Sonar evaluates it.

No logic change; all 13 files continue to run `FormTest(target)` which contains the real `it()` cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test annotations across form component coverage to improve consistency with static analysis tooling.
  - Preserved existing test behavior and coverage while standardizing annotation placement across visualization form scenarios.

- **Chores**
  - Refined test-file formatting and annotation structure without changing application functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->