### PR TITLE
Fix typescript:S9020: Replace waitFor+getBy* with findBy* queries

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
@@ -269,7 +269,7 @@ describe('DataMapperLauncher', () => {
 
       render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
 
-      const span = await waitFor(() => screen.getByTestId('xslt-document-name'));
+      const span = await screen.findByTestId('xslt-document-name');
       expect(span).toHaveTextContent('my-transformation.xsl');
     });
 
@@ -313,7 +313,7 @@ describe('DataMapperLauncher', () => {
 
       render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
 
-      const helpButton = await waitFor(() => screen.getByRole('button', { name: 'More info' }));
+      const helpButton = await screen.findByRole('button', { name: 'More info' });
       expect(helpButton).toBeInTheDocument();
     });
 
@@ -403,7 +403,7 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: '' } });
 
         await waitFor(() => {
@@ -424,7 +424,7 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: 'invalid.txt' } });
 
         await waitFor(() => {
@@ -450,7 +450,7 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: 'existing.xsl' } });
 
         await waitFor(() => {
@@ -492,7 +492,7 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         expect(input).toBeInTheDocument();
         expect(input).toHaveValue('test-document.xsl');
       });
@@ -529,7 +529,7 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: 'changed.xsl' } });
 
         const cancelButton = screen.getByTestId('xslt-document-name--cancel');
@@ -553,7 +553,7 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: 'invalid' } });
 
         await waitFor(() => {
@@ -580,7 +580,7 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: 'valid-name.xsl' } });
 
         await waitFor(() => {
@@ -602,7 +602,7 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: '' } });
 
         await waitFor(() => {
@@ -654,10 +654,10 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: 'renamed.xsl' } });
 
-        const saveButton = await waitFor(() => screen.getByTestId('xslt-document-name--save'));
+        const saveButton = await screen.findByTestId('xslt-document-name--save');
         fireEvent.click(saveButton);
 
         await waitFor(() => {
@@ -719,10 +719,10 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: 'renamed.xsl' } });
 
-        const saveButton = await waitFor(() => screen.getByTestId('xslt-document-name--save'));
+        const saveButton = await screen.findByTestId('xslt-document-name--save');
         fireEvent.click(saveButton);
 
         // Should not proceed with rename operations when metadata is not found
@@ -771,10 +771,10 @@ describe('DataMapperLauncher', () => {
         const editButton = screen.getByTestId('xslt-document-name--edit');
         fireEvent.click(editButton);
 
-        const input = await waitFor(() => screen.getByTestId('xslt-document-name--text-input'));
+        const input = await screen.findByTestId('xslt-document-name--text-input');
         fireEvent.change(input, { target: { value: 'renamed.xsl' } });
 
-        const saveButton = await waitFor(() => screen.getByTestId('xslt-document-name--save'));
+        const saveButton = await screen.findByTestId('xslt-document-name--save');
         fireEvent.click(saveButton);
 
         await waitFor(() => {

--- a/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/ExportDocument/ExportDocument.test.tsx
@@ -1,6 +1,6 @@
 import { CamelYamlDsl } from '@kaoto/camel-catalog/types';
 import { VisualizationProvider } from '@patternfly/react-topology';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { parse } from 'yaml';
 
 import { CamelRouteResource } from '../../../../models/camel';
@@ -47,14 +47,10 @@ describe('FlowExportDocument.tsx', () => {
     const showAllBtn = wrapper.getByTestId('toggle-btn-all-show');
     fireEvent.click(showAllBtn);
 
-    await waitFor(async () => {
-      const header = await wrapper.findByTestId('documentationPreviewModal');
-      expect(header).toBeInTheDocument();
-    });
+    const header = await wrapper.findByTestId('documentationPreviewModal');
+    expect(header).toBeInTheDocument();
 
-    await waitFor(async () => {
-      const tables = await wrapper.findAllByTestId('export-document-preview-body');
-      expect(tables).toHaveLength(1);
-    });
+    const tables = await wrapper.findAllByTestId('export-document-preview-body');
+    expect(tables).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3691

## Summary

Replaces 18 `waitFor(() => screen.getByX(...))` patterns with the idiomatic `await screen.findByX(...)` in 2 test files.

Also removes the outer `waitFor` wrapper around `findBy*` calls in `ExportDocument.test.tsx` and drops the now-unused `waitFor` import.

### Prevention
`testing-library/prefer-find-by` (eslint-plugin-testing-library) is autofixable and would prevent regressions — not currently enabled in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous test handling for data mapping and document export workflows.
  * Preserved existing test behavior and assertions while simplifying verification of rendered elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->