### PR TITLE
Fix typescript:S6647: Remove useless constructors and add ESLint guard

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,6 +48,7 @@ export default [
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-confusing-void-expression': 'error',
+      '@typescript-eslint/no-useless-constructor': 'error',
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
     },

--- a/packages/ui/src/utils/event-notifier.ts
+++ b/packages/ui/src/utils/event-notifier.ts
@@ -6,10 +6,6 @@ interface Events {
 export class EventNotifier extends EventTarget {
   private static instance: EventNotifier | undefined;
 
-  constructor() {
-    super();
-  }
-
   static getInstance(): EventNotifier {
     if (!this.instance) {
       this.instance = new EventNotifier();

--- a/packages/ui/src/xml-schema-ts/complex/XmlSchemaComplexType.ts
+++ b/packages/ui/src/xml-schema-ts/complex/XmlSchemaComplexType.ts
@@ -21,13 +21,6 @@ export class XmlSchemaComplexType extends XmlSchemaType {
   private particle: XmlSchemaParticle | null = null;
   private _isAbstract: boolean = false;
 
-  /**
-   * Creates new XmlSchemaComplexType
-   */
-  constructor(schema: XmlSchema, topLevel: boolean) {
-    super(schema, topLevel);
-  }
-
   getAnyAttribute() {
     return this.anyAttribute;
   }

--- a/packages/ui/src/xml-schema-ts/complex/XmlSchemaComplexType.ts
+++ b/packages/ui/src/xml-schema-ts/complex/XmlSchemaComplexType.ts
@@ -1,6 +1,5 @@
 import type { XmlSchemaAttributeOrGroupRef } from '../attribute/XmlSchemaAttributeOrGroupRef';
 import type { XmlSchemaParticle } from '../particle/XmlSchemaParticle';
-import type { XmlSchema } from '../XmlSchema';
 import type { XmlSchemaAnyAttribute } from '../XmlSchemaAnyAttribute';
 import type { XmlSchemaContentModel } from '../XmlSchemaContentModel';
 import type { XmlSchemaContentType } from '../XmlSchemaContentType';

--- a/packages/ui/src/xml-schema-ts/external/XmlSchemaImport.ts
+++ b/packages/ui/src/xml-schema-ts/external/XmlSchemaImport.ts
@@ -4,6 +4,11 @@ import { XmlSchemaExternal } from './XmlSchemaExternal';
 export class XmlSchemaImport extends XmlSchemaExternal {
   namespace: string | null = null;
 
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(parent: XmlSchema) {
+    super(parent);
+  }
+
   getNamespace(): string | null {
     return this.namespace;
   }

--- a/packages/ui/src/xml-schema-ts/external/XmlSchemaImport.ts
+++ b/packages/ui/src/xml-schema-ts/external/XmlSchemaImport.ts
@@ -4,13 +4,6 @@ import { XmlSchemaExternal } from './XmlSchemaExternal';
 export class XmlSchemaImport extends XmlSchemaExternal {
   namespace: string | null = null;
 
-  /**
-   * Creates new XmlSchemaImport
-   */
-  constructor(parent: XmlSchema) {
-    super(parent);
-  }
-
   getNamespace(): string | null {
     return this.namespace;
   }

--- a/packages/ui/src/xml-schema-ts/external/XmlSchemaInclude.ts
+++ b/packages/ui/src/xml-schema-ts/external/XmlSchemaInclude.ts
@@ -1,11 +1,4 @@
 import type { XmlSchema } from '../XmlSchema';
 import { XmlSchemaExternal } from './XmlSchemaExternal';
 
-export class XmlSchemaInclude extends XmlSchemaExternal {
-  /**
-   * Creates new XmlSchemaInclude
-   */
-  constructor(parent: XmlSchema) {
-    super(parent);
-  }
-}
+export class XmlSchemaInclude extends XmlSchemaExternal {}

--- a/packages/ui/src/xml-schema-ts/external/XmlSchemaInclude.ts
+++ b/packages/ui/src/xml-schema-ts/external/XmlSchemaInclude.ts
@@ -1,4 +1,9 @@
 import type { XmlSchema } from '../XmlSchema';
 import { XmlSchemaExternal } from './XmlSchemaExternal';
 
-export class XmlSchemaInclude extends XmlSchemaExternal {}
+export class XmlSchemaInclude extends XmlSchemaExternal {
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(parent: XmlSchema) {
+    super(parent);
+  }
+}

--- a/packages/ui/src/xml-schema-ts/external/XmlSchemaRedefine.ts
+++ b/packages/ui/src/xml-schema-ts/external/XmlSchemaRedefine.ts
@@ -18,6 +18,11 @@ export class XmlSchemaRedefine extends XmlSchemaExternal {
 
   private readonly items: XmlSchemaObject[] = [];
 
+  // eslint-disable-next-line @typescript-eslint/no-useless-constructor
+  constructor(parent: XmlSchema) {
+    super(parent);
+  }
+
   getAttributeGroups() {
     return this.attributeGroups;
   }

--- a/packages/ui/src/xml-schema-ts/external/XmlSchemaRedefine.ts
+++ b/packages/ui/src/xml-schema-ts/external/XmlSchemaRedefine.ts
@@ -18,13 +18,6 @@ export class XmlSchemaRedefine extends XmlSchemaExternal {
 
   private readonly items: XmlSchemaObject[] = [];
 
-  /**
-   * Creates new XmlSchemaRedefine
-   */
-  constructor(parent: XmlSchema) {
-    super(parent);
-  }
-
   getAttributeGroups() {
     return this.attributeGroups;
   }


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3694

Removes useless constructors flagged by `typescript:S6647` and adds the `@typescript-eslint/no-useless-constructor` ESLint rule to prevent future occurrences.

## Changes

### Constructors removed
- `packages/ui/src/utils/event-notifier.ts` — constructor only called `super()` with no parameters or body
- `packages/ui/src/xml-schema-ts/complex/XmlSchemaComplexType.ts` — constructor only delegated to `super(schema, topLevel)`; parent constructor is public

### Constructors retained (with ESLint suppression)
`XmlSchemaExternal` has a `protected` constructor. The three subclasses below extend it and their constructors serve as the **public entry point** used by `SchemaBuilder.ts`. Removing them caused `TS2674: Constructor of class 'XmlSchemaExternal' is protected and only accessible within the class declaration`. They are retained with an inline `// eslint-disable-next-line` comment explaining why:

- `packages/ui/src/xml-schema-ts/external/XmlSchemaImport.ts`
- `packages/ui/src/xml-schema-ts/external/XmlSchemaInclude.ts`
- `packages/ui/src/xml-schema-ts/external/XmlSchemaRedefine.ts`

### ESLint rule added
`'@typescript-eslint/no-useless-constructor': 'error'` added to `eslint.config.mjs` — future occurrences will be caught at lint time before reaching Sonar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal object initialization by removing redundant constructors.
  * Preserved existing behavior for XML schema imports, includes, and redefinitions.

* **Chores**
  * Added a linting rule to flag unnecessary constructors.
  * Updated code comments to align with linting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->