### PR TITLE
Fix typescript:S6353: Use concise regex character class syntax in xpath-2.0-parser

### DIFF
--- a/packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts
+++ b/packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts
@@ -12,9 +12,9 @@ fragments['NameChar'] = new RegExp(
 );
 fragments['Name'] = new RegExp(`(${f.NameStartChar.source})(${f.NameChar.source})*`);
 fragments['StringLiteral'] = /("(""|[^"])*")|('(''|[^'])*')/;
-fragments['Digits'] = /[0-9]+/;
-fragments['DecimalLiteral'] = /(\.[0-9]+)|([0-9]+\.[0-9]*)/;
-fragments['DoubleLiteral'] = /((\.[0-9]+)|([0-9]+(\.[0-9]*)?))[eE][+-]?[0-9]+/;
+fragments['Digits'] = /\d+/;
+fragments['DecimalLiteral'] = /(\.\d+)|(\d+\.\d*)/;
+fragments['DoubleLiteral'] = /((\.\d+)|(\d+(\.\d*)?))[eE][+-]?\d+/;
 
 const allTokens: TokenType[] = [];
 


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3696

Replaces verbose `[0-9]` character classes with the `\d` shorthand in three regex literals in `xpath-2.0-parser.ts`. The patterns are semantically identical — `\d` is shorter and more readable.

**Affected file:** `packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts` (8 occurrences across `Digits`, `DecimalLiteral`, `DoubleLiteral`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted numeric literal parsing patterns without changing how integer, decimal, or double values are recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->