### PR TITLE
Fix typescript:S8784: Move assertions out of describe() body into beforeAll() hooks

### DIFF
--- a/packages/ui/src/services/mapping/mapping-serializer.service.json.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.json.test.ts
@@ -19,16 +19,16 @@ import {
   getShipOrderJsonSchema,
   getShipOrderJsonXslt,
 } from '../../stubs/datamapper/data-mapper';
-import { JsonSchemaField } from '../document/json-schema/json-schema-document.model';
+import { JsonSchemaDocument, JsonSchemaField } from '../document/json-schema/json-schema-document.model';
 import { JsonSchemaDocumentService } from '../document/json-schema/json-schema-document.service';
 import { MappingSerializerService } from './mapping-serializer.service';
 import { TO_JSON_TARGET_VARIABLE } from './mapping-serializer-json-addon';
 
 describe('MappingSerializerService / JSON', () => {
-  let accountParamDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
-  let cartParamDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+  let accountParamDoc: JsonSchemaDocument;
+  let cartParamDoc: JsonSchemaDocument;
   let sourceParameterMap: Map<string, IDocument>;
-  let targetDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+  let targetDoc: JsonSchemaDocument;
 
   beforeAll(() => {
     const accountDefinition = new DocumentDefinition(

--- a/packages/ui/src/services/mapping/mapping-serializer.service.json.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.json.test.ts
@@ -25,35 +25,47 @@ import { MappingSerializerService } from './mapping-serializer.service';
 import { TO_JSON_TARGET_VARIABLE } from './mapping-serializer-json-addon';
 
 describe('MappingSerializerService / JSON', () => {
-  const accountDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Account', {
-    'Account.json': getAccountJsonSchema(),
+  let accountParamDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+  let cartParamDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+  let sourceParameterMap: Map<string, IDocument>;
+  let targetDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+
+  beforeAll(() => {
+    const accountDefinition = new DocumentDefinition(
+      DocumentType.PARAM,
+      DocumentDefinitionType.JSON_SCHEMA,
+      'Account',
+      {
+        'Account.json': getAccountJsonSchema(),
+      },
+    );
+    const accountDocResult = JsonSchemaDocumentService.createJsonSchemaDocument(accountDefinition);
+    expect(accountDocResult.validationStatus).toBe('success');
+    accountParamDoc = accountDocResult.document!;
+    const cartDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Cart', {
+      'Cart.json': getCartJsonSchema(),
+    });
+    const cartDocResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
+    expect(cartDocResult.validationStatus).toBe('success');
+    cartParamDoc = cartDocResult.document!;
+    const orderSequenceParamDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'OrderSequence'),
+    );
+    sourceParameterMap = new Map<string, IDocument>([
+      ['OrderSequence', orderSequenceParamDoc],
+      ['Account', accountParamDoc],
+      ['Cart', cartParamDoc],
+    ]);
+    const targetDefinition = new DocumentDefinition(
+      DocumentType.TARGET_BODY,
+      DocumentDefinitionType.JSON_SCHEMA,
+      BODY_DOCUMENT_ID,
+      { 'ShipOrder.json': getShipOrderJsonSchema() },
+    );
+    const result = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
+    expect(result.validationStatus).toBe('success');
+    targetDoc = result.document!;
   });
-  const accountDocResult = JsonSchemaDocumentService.createJsonSchemaDocument(accountDefinition);
-  expect(accountDocResult.validationStatus).toBe('success');
-  const accountParamDoc = accountDocResult.document!;
-  const cartDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Cart', {
-    'Cart.json': getCartJsonSchema(),
-  });
-  const cartDocResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
-  expect(cartDocResult.validationStatus).toBe('success');
-  const cartParamDoc = cartDocResult.document!;
-  const orderSequenceParamDoc = new PrimitiveDocument(
-    new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'OrderSequence'),
-  );
-  const sourceParameterMap = new Map<string, IDocument>([
-    ['OrderSequence', orderSequenceParamDoc],
-    ['Account', accountParamDoc],
-    ['Cart', cartParamDoc],
-  ]);
-  const targetDefinition = new DocumentDefinition(
-    DocumentType.TARGET_BODY,
-    DocumentDefinitionType.JSON_SCHEMA,
-    BODY_DOCUMENT_ID,
-    { 'ShipOrder.json': getShipOrderJsonSchema() },
-  );
-  const result = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
-  expect(result.validationStatus).toBe('success');
-  const targetDoc = result.document!;
 
   describe('deserialize()', () => {
     it('should deserialize XSLT', () => {

--- a/packages/ui/src/services/visualization/visualization.service.json.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.json.test.ts
@@ -30,41 +30,52 @@ import { MappingActionService } from './mapping-action.service';
 import { VisualizationService } from './visualization.service';
 
 describe('VisualizationService / JSON', () => {
-  const accountDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Account', {
-    'Account.json': getAccountJsonSchema(),
-  });
-  const accountResult = JsonSchemaDocumentService.createJsonSchemaDocument(accountDefinition);
-  expect(accountResult.validationStatus).toBe('success');
-  const accountDoc = accountResult.document!;
-  const cartDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Cart', {
-    'Cart.json': getCartJsonSchema(),
-  });
-  const cartResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
-  expect(cartResult.validationStatus).toBe('success');
-  const cartDoc = cartResult.document!;
-  const orderSequenceDoc = new PrimitiveDocument(
-    new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'OrderSequence'),
-  );
-  const targetDefinition = new DocumentDefinition(
-    DocumentType.TARGET_BODY,
-    DocumentDefinitionType.JSON_SCHEMA,
-    BODY_DOCUMENT_ID,
-    { 'ShipOrder.json': getShipOrderJsonSchema() },
-  );
-  const result = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
-  expect(result.validationStatus).toBe('success');
-  const targetDoc = result.document!;
-
-  const sourceParameterMap = new Map<string, IDocument>([
-    ['OrderSequence', orderSequenceDoc],
-    ['Account', accountDoc],
-    ['Cart', cartDoc],
-  ]);
+  let accountDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+  let cartDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+  let targetDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+  let sourceParameterMap: Map<string, IDocument>;
 
   let mappingTree: MappingTree;
   let cartDocNode: DocumentNodeData;
   let accountDocNode: DocumentNodeData;
   let targetDocNode: TargetDocumentNodeData;
+
+  beforeAll(() => {
+    const accountDefinition = new DocumentDefinition(
+      DocumentType.PARAM,
+      DocumentDefinitionType.JSON_SCHEMA,
+      'Account',
+      {
+        'Account.json': getAccountJsonSchema(),
+      },
+    );
+    const accountResult = JsonSchemaDocumentService.createJsonSchemaDocument(accountDefinition);
+    expect(accountResult.validationStatus).toBe('success');
+    accountDoc = accountResult.document!;
+    const cartDefinition = new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.JSON_SCHEMA, 'Cart', {
+      'Cart.json': getCartJsonSchema(),
+    });
+    const cartResult = JsonSchemaDocumentService.createJsonSchemaDocument(cartDefinition);
+    expect(cartResult.validationStatus).toBe('success');
+    cartDoc = cartResult.document!;
+    const orderSequenceDoc = new PrimitiveDocument(
+      new DocumentDefinition(DocumentType.PARAM, DocumentDefinitionType.Primitive, 'OrderSequence'),
+    );
+    const targetDefinition = new DocumentDefinition(
+      DocumentType.TARGET_BODY,
+      DocumentDefinitionType.JSON_SCHEMA,
+      BODY_DOCUMENT_ID,
+      { 'ShipOrder.json': getShipOrderJsonSchema() },
+    );
+    const result = JsonSchemaDocumentService.createJsonSchemaDocument(targetDefinition);
+    expect(result.validationStatus).toBe('success');
+    targetDoc = result.document!;
+    sourceParameterMap = new Map<string, IDocument>([
+      ['OrderSequence', orderSequenceDoc],
+      ['Account', accountDoc],
+      ['Cart', cartDoc],
+    ]);
+  });
 
   beforeEach(() => {
     mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.JSON_SCHEMA);

--- a/packages/ui/src/services/visualization/visualization.service.json.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.json.test.ts
@@ -24,15 +24,16 @@ import {
   getShipOrderJsonSchema,
   getShipOrderJsonXslt,
 } from '../../stubs/datamapper/data-mapper';
+import { JsonSchemaDocument } from '../document/json-schema/json-schema-document.model';
 import { JsonSchemaDocumentService } from '../document/json-schema/json-schema-document.service';
 import { MappingSerializerService } from '../mapping/mapping-serializer.service';
 import { MappingActionService } from './mapping-action.service';
 import { VisualizationService } from './visualization.service';
 
 describe('VisualizationService / JSON', () => {
-  let accountDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
-  let cartDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
-  let targetDoc: ReturnType<typeof JsonSchemaDocumentService.createJsonSchemaDocument>['document'];
+  let accountDoc: JsonSchemaDocument;
+  let cartDoc: JsonSchemaDocument;
+  let targetDoc: JsonSchemaDocument;
   let sourceParameterMap: Map<string, IDocument>;
 
   let mappingTree: MappingTree;


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3698

Moves shared setup assertions from `describe()` body scope into `beforeAll()` hooks in two test files. Assertions at describe-scope run during suite collection rather than inside a named test, making failures invisible to the test runner's reporting.

## Changes

- `packages/ui/src/services/mapping/mapping-serializer.service.json.test.ts` — extracted 3 assertions + setup into `beforeAll()`; promoted `accountParamDoc`, `cartParamDoc`, `sourceParameterMap`, `targetDoc` to `let` at describe scope
- `packages/ui/src/services/visualization/visualization.service.json.test.ts` — extracted 3 assertions + setup into `beforeAll()`; promoted `accountDoc`, `cartDoc`, `targetDoc`, `sourceParameterMap` to `let` at describe scope