### PR TITLE
Fix typescript:S6481: Wrap React Context Provider values in useMemo for stable identity

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,6 +82,7 @@ export default [
       ],
       'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
       'react/self-closing-comp': 'error',
+      'react/jsx-no-constructed-context-values': 'error',
     },
   },
   eslintConfigPrettier,

--- a/packages/ui-tests/stories/navigation/Navigation.stories.tsx
+++ b/packages/ui-tests/stories/navigation/Navigation.stories.tsx
@@ -9,6 +9,7 @@ import {
   SourceSchemaType,
 } from '@kaoto/kaoto/testing';
 import { StoryFn } from '@storybook/react';
+import { useMemo } from 'react';
 
 export default {
   title: 'Navigation/Navigation',
@@ -31,16 +32,18 @@ const RouteNavigationTemplate: StoryFn<typeof Navigation> = () => {
 };
 
 const KameletNavigationTemplate: StoryFn<typeof Navigation> = () => {
+  const value = useMemo(() => ({ currentSchemaType: SourceSchemaType.Kamelet }) as EntitiesContextResult, []);
   return (
-    <EntitiesContext.Provider value={{ currentSchemaType: SourceSchemaType.Kamelet } as EntitiesContextResult}>
+    <EntitiesContext.Provider value={value}>
       <Navigation isNavOpen />
     </EntitiesContext.Provider>
   );
 };
 
 const PipeNavigationTemplate: StoryFn<typeof Navigation> = () => {
+  const value = useMemo(() => ({ currentSchemaType: SourceSchemaType.Pipe }) as EntitiesContextResult, []);
   return (
-    <EntitiesContext.Provider value={{ currentSchemaType: SourceSchemaType.Pipe } as EntitiesContextResult}>
+    <EntitiesContext.Provider value={value}>
       <Navigation isNavOpen />
     </EntitiesContext.Provider>
   );

--- a/packages/ui-tests/stories/settings/SettingsForm.stories.tsx
+++ b/packages/ui-tests/stories/settings/SettingsForm.stories.tsx
@@ -9,6 +9,7 @@ import {
   SourceCodeSync,
 } from '@kaoto/kaoto/testing';
 import { Meta, StoryFn } from '@storybook/react';
+import { useMemo } from 'react';
 
 export default {
   title: 'Settings/SettingsForm',
@@ -17,10 +18,10 @@ export default {
 } as Meta<typeof SettingsForm>;
 
 const Template: StoryFn<typeof SettingsForm> = (args) => {
-  const reloadPage = () => {};
   const settingsAdapter = new DefaultSettingsAdapter();
+  const reloadContextValue = useMemo(() => ({ reloadPage: () => {}, lastRender: 0 }), []);
   return (
-    <ReloadContext.Provider value={{ reloadPage, lastRender: 0 }}>
+    <ReloadContext.Provider value={reloadContextValue}>
       <SourceCodeSync initialSourceCode="">
         <KaotoResourceProvider>
           <RuntimeProvider

--- a/packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx
+++ b/packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useMemo } from 'react';
 
 import { CamelRouteResource, sourceSchemaConfig, SourceSchemaType } from '../../../../models/camel';
 import { KaotoSchemaDefinition } from '../../../../models/kaoto-schema';
@@ -25,16 +26,17 @@ const onSelect = vi.fn();
 const FlowTypeSelectorWithContext: React.FunctionComponent<{
   currentSchemaType?: SourceSchemaType;
 }> = ({ currentSchemaType }) => {
+  const value = useMemo(
+    () =>
+      ({
+        currentSchemaType: currentSchemaType ?? SourceSchemaType.Route,
+        visualEntities: [{ id: 'entity1' } as CamelRouteVisualEntity, { id: 'entity2' } as CamelRouteVisualEntity],
+        camelResource: new CamelRouteResource(undefined),
+      }) as unknown as EntitiesContextResult,
+    [currentSchemaType],
+  );
   return (
-    <EntitiesContext.Provider
-      value={
-        {
-          currentSchemaType: currentSchemaType ?? SourceSchemaType.Route,
-          visualEntities: [{ id: 'entity1' } as CamelRouteVisualEntity, { id: 'entity2' } as CamelRouteVisualEntity],
-          camelResource: new CamelRouteResource(undefined),
-        } as unknown as EntitiesContextResult
-      }
-    >
+    <EntitiesContext.Provider value={value}>
       <FlowTypeSelector onSelect={onSelect} />
     </EntitiesContext.Provider>
   );

--- a/packages/ui/src/providers/entities.provider.test.tsx
+++ b/packages/ui/src/providers/entities.provider.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { PropsWithChildren, useContext } from 'react';
+import { PropsWithChildren, useContext, useMemo } from 'react';
 import { parse } from 'yaml';
 
 import { SourceSchemaType } from '../models/camel';
@@ -49,11 +49,14 @@ const createMockResource = (overrides: Partial<KaotoResource> = {}): KaotoResour
 
 const buildMockResourceWrapper =
   (resource: KaotoResource) =>
-  ({ children }: PropsWithChildren) => (
-    <KaotoResourceContext.Provider value={{ kaotoResource: resource }}>
-      <EntitiesProvider>{children}</EntitiesProvider>
-    </KaotoResourceContext.Provider>
-  );
+  ({ children }: PropsWithChildren) => {
+    const value = useMemo(() => ({ kaotoResource: resource }), []); // resource is stable outer-scope reference
+    return (
+      <KaotoResourceContext.Provider value={value}>
+        <EntitiesProvider>{children}</EntitiesProvider>
+      </KaotoResourceContext.Provider>
+    );
+  };
 
 /**
  * Compose the real provider chain. Source code enters through the single ingress

--- a/packages/ui/src/stubs/TestRuntimeProviderWrapper.tsx
+++ b/packages/ui/src/stubs/TestRuntimeProviderWrapper.tsx
@@ -22,11 +22,7 @@ export const TestRuntimeProviderWrapper = (
       () => ({ basePath, catalogLibrary: catalogLibraryCasted, selectedCatalog, setSelectedCatalog }),
       [],
     );
-    return (
-      <RuntimeContext.Provider key={Date.now()} value={value}>
-        {props.children}
-      </RuntimeContext.Provider>
-    );
+    return <RuntimeContext.Provider value={value}>{props.children}</RuntimeContext.Provider>;
   };
 
   return { Provider, basePath, catalogLibrary: catalogLibraryCasted, selectedCatalog, setSelectedCatalog };

--- a/packages/ui/src/stubs/TestRuntimeProviderWrapper.tsx
+++ b/packages/ui/src/stubs/TestRuntimeProviderWrapper.tsx
@@ -1,6 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, CatalogLibraryEntry } from '@kaoto/camel-catalog/types';
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren, useMemo } from 'react';
 
 import { IRuntimeContext, RuntimeContext } from '../providers/runtime.provider';
 import { CatalogSchemaLoader } from '../utils';
@@ -17,19 +17,17 @@ export const TestRuntimeProviderWrapper = (
   const selectedCatalog = catalogSelect?.(catalogLibraryCasted) ?? catalogLibraryCasted.definitions[0];
   const setSelectedCatalog = vi.fn();
 
-  const Provider: FunctionComponent<PropsWithChildren> = (props) => (
-    <RuntimeContext.Provider
-      key={Date.now()}
-      value={{
-        basePath,
-        catalogLibrary: catalogLibraryCasted,
-        selectedCatalog,
-        setSelectedCatalog,
-      }}
-    >
-      {props.children}
-    </RuntimeContext.Provider>
-  );
+  const Provider: FunctionComponent<PropsWithChildren> = (props) => {
+    const value = useMemo(
+      () => ({ basePath, catalogLibrary: catalogLibraryCasted, selectedCatalog, setSelectedCatalog }),
+      [],
+    );
+    return (
+      <RuntimeContext.Provider key={Date.now()} value={value}>
+        {props.children}
+      </RuntimeContext.Provider>
+    );
+  };
 
   return { Provider, basePath, catalogLibrary: catalogLibraryCasted, selectedCatalog, setSelectedCatalog };
 };


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3700

Wraps all React Context `value` props that used inline object literals in `useMemo()` to prevent unnecessary consumer re-renders on every render cycle.

## Changes

### Original Sonar findings fixed
- `packages/ui-tests/stories/navigation/Navigation.stories.tsx` — 2 `EntitiesContext.Provider` values
- `packages/ui-tests/stories/settings/SettingsForm.stories.tsx` — `ReloadContext.Provider` value
- `packages/ui/src/stubs/TestRuntimeProviderWrapper.tsx` — `RuntimeContext.Provider` value

### Additional occurrences caught by new ESLint rule
- `packages/ui/src/components/Visualization/EmptyState/FlowType/FlowTypeSelector.test.tsx`
- `packages/ui/src/providers/entities.provider.test.tsx`

### ESLint rule added
`'react/jsx-no-constructed-context-values': 'error'` added to `eslint.config.mjs` — future occurrences will be caught at lint time before reaching Sonar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context handling to prevent unnecessary updates and rerenders.
  * Added linting safeguards for unstable context values.

* **Performance**
  * Optimized navigation, settings, visualization, and provider experiences by reusing context values when inputs remain unchanged.
  * Preserved existing provider behavior while reducing unnecessary rendering activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->