### PR TITLE
Fix typescript:S4782: Remove redundant '| undefined' from optional property declarations

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/canvas.models.ts
+++ b/packages/ui/src/components/Visualization/Canvas/canvas.models.ts
@@ -11,11 +11,13 @@ export const enum LayoutType {
  * The intention of these types is to isolate the usage of the
  * underlying rendering library tokens
  */
+export interface CanvasNodeData {
+  vizNode?: IVisualizationNode;
+}
+
 export interface CanvasNode extends NodeModel {
   parentNode?: string;
-  data?: {
-    vizNode?: IVisualizationNode;
-  };
+  data?: CanvasNodeData;
 }
 
 export interface CanvasEdge extends EdgeModel {

--- a/packages/ui/src/components/Visualization/Canvas/flow.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/flow.service.ts
@@ -3,7 +3,7 @@ import { EdgeStyle } from '@patternfly/react-topology';
 import { IVisualizationNode } from '../../../models/visualization/base-visual-entity';
 import { collectTopologyEndpoints } from '../Topology/topology-endpoints';
 import { CanvasDefaults } from './canvas.defaults';
-import { CanvasEdge, CanvasNode, CanvasNodesAndEdges } from './canvas.models';
+import { CanvasEdge, CanvasNode, CanvasNodeData, CanvasNodesAndEdges } from './canvas.models';
 
 export class FlowService {
   static nodes: CanvasNode[] = [];
@@ -163,7 +163,7 @@ export class FlowService {
 
   private static getGroup(
     id: string,
-    options: { label?: string; children?: string[]; parentNode?: string; data: CanvasNode['data'] } = {},
+    options: { label?: string; children?: string[]; parentNode?: string; data?: CanvasNodeData } = {},
   ): CanvasNode {
     return {
       id,
@@ -179,7 +179,7 @@ export class FlowService {
     };
   }
 
-  private static getNode(id: string, options: { parentNode?: string; data: CanvasNode['data'] } = {}): CanvasNode {
+  private static getNode(id: string, options: { parentNode?: string; data?: CanvasNodeData } = {}): CanvasNode {
     return {
       id,
       type: 'node',

--- a/packages/ui/src/components/Visualization/Canvas/flow.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/flow.service.ts
@@ -163,7 +163,7 @@ export class FlowService {
 
   private static getGroup(
     id: string,
-    options: { label?: string; children?: string[]; parentNode?: string; data?: CanvasNode['data'] } = {},
+    options: { label?: string; children?: string[]; parentNode?: string; data: CanvasNode['data'] } = {},
   ): CanvasNode {
     return {
       id,
@@ -179,7 +179,7 @@ export class FlowService {
     };
   }
 
-  private static getNode(id: string, options: { parentNode?: string; data?: CanvasNode['data'] } = {}): CanvasNode {
+  private static getNode(id: string, options: { parentNode?: string; data: CanvasNode['data'] } = {}): CanvasNode {
     return {
       id,
       type: 'node',

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts
@@ -66,7 +66,7 @@ export class CamelRouteVisualEntity extends AbstractCamelVisualEntity<{ route: R
     definedComponent: DefinedComponent;
     mode: AddStepMode;
     data: IVisualizationNodeData;
-    targetProperty?: string | undefined;
+    targetProperty?: string;
   }): void {
     /** Replace the root `from` step */
     if (

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -124,7 +124,7 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
     definedComponent: DefinedComponent;
     mode: AddStepMode;
     data: IVisualizationNodeData;
-    targetProperty?: string | undefined;
+    targetProperty?: string;
   }): void {
     /** Replace the root `from` step */
     if (


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3702

Removes redundant `| undefined` from optional property/parameter declarations where `?` already implies the value can be `undefined`.

## Changes

- `packages/ui/src/components/Visualization/Canvas/flow.service.ts` — removed `?` from `data` parameters in `getGroup` and `getNode` (type `CanvasNode['data']` already includes `undefined` via the optional property in `CanvasNode`)
- `packages/ui/src/models/visualization/flows/camel-route-visual-entity.ts` — `targetProperty?: string | undefined` → `targetProperty?: string`
- `packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts` — `targetProperty?: string | undefined` → `targetProperty?: string`