### PR TITLE
fix(ui): Replace Object.assign with object spread syntax

### DIFF
--- a/packages/ui/src/utils/pipe-custom-schema.ts
+++ b/packages/ui/src/utils/pipe-custom-schema.ts
@@ -32,8 +32,8 @@ export const updatePipeFromCustomSchema = (pipe: Pipe, value: Record<string, unk
   const previousAnnotations: Record<string, unknown> = getValue(pipe, 'metadata.annotations', {});
   const previousLabels: Record<string, unknown> = getValue(pipe, 'metadata.labels', {});
 
-  const newLabels = Object.assign({}, getValue(value, 'labels', previousLabels));
-  const newAnnotations = Object.assign({}, getValue(value, 'annotations', previousAnnotations));
+  const newLabels = { ...getValue(value, 'labels', previousLabels) };
+  const newAnnotations = { ...getValue(value, 'annotations', previousAnnotations) };
 
   setValue(pipe, 'metadata.labels', newLabels);
   setValue(pipe, 'metadata.annotations', newAnnotations);


### PR DESCRIPTION
Fixes #3711.

Replaces the two `Object.assign({}, ...)` calls in `updatePipeFromCustomSchema` with object spread syntax, per Sonar rule typescript:S6661.

Behavior is equivalent: spreading `undefined` inside an object literal is a no-op, exactly like `Object.assign({}, undefined)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal label and annotation cloning implementation without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->