### PR TITLE
fix(ui-tests): add explicit type to button in ActionConfirmationModal story

### DIFF
--- a/packages/ui-tests/stories/modal/ActionConfirmationModal.stories.tsx
+++ b/packages/ui-tests/stories/modal/ActionConfirmationModal.stories.tsx
@@ -30,7 +30,7 @@ const TestComponent: FunctionComponent<TestComponentProps> = (props) => {
 
   return (
     <p>
-      <button onClick={handleDelete}>{props.btnTitle ?? props.title}</button>
+      <button type="button" onClick={handleDelete}>{props.btnTitle ?? props.title}</button>
       <br />
       <h4>{confirmationResult}</h4>
     </p>


### PR DESCRIPTION
Fixes #3710.

Adds `type="button"` to the button in the ActionConfirmationModal story. Without an explicit type, a `<button>` inside a form defaults to `type="submit"`, which can fire unintended form submissions (Sonar rule typescript:S9011).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the confirmation action in the modal from unintentionally submitting a surrounding form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->