### PR TITLE
fix(ui): Replace in-place sort with sort on a copy

### DIFF
--- a/packages/ui/src/components/Catalog/filter-tiles.ts
+++ b/packages/ui/src/components/Catalog/filter-tiles.ts
@@ -56,7 +56,7 @@ export const filterTiles = (
   });
 
   // Step 3: Sort the filtered tiles by score in descending order
-  const tilesResult: ITile[] = filteredTiles.sort((a, b) => b.score - a.score).map(({ tile }) => tile);
+  const tilesResult: ITile[] = [...filteredTiles].sort((a, b) => b.score - a.score).map(({ tile }) => tile);
 
   return tilesResult;
 };

--- a/packages/ui/src/services/mapping/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.ts
@@ -126,7 +126,7 @@ export class MappingSerializerService {
     MappingSerializerService.populateStylesheetVariables(xslt, mappings);
     const root = MappingSerializerService.populateMappingRoot(xslt, mappings);
     MappingSerializerService.populateTemplateVariables(root, mappings);
-    mappings.children.sort(MappingSerializerService.sortMappingItem).forEach((mapping) => {
+    [...mappings.children].sort(MappingSerializerService.sortMappingItem).forEach((mapping) => {
       MappingSerializerService.populateMapping(root, mapping);
     });
     return xmlFormat(new XMLSerializer().serializeToString(xslt));


### PR DESCRIPTION
Fixes #3708.

Replaces the two in-place `.sort()` calls with spread-copy sorting:

- `packages/ui/src/components/Catalog/filter-tiles.ts`: `[...filteredTiles].sort(...)` before mapping — same result, no mutation of the intermediate array.
- `packages/ui/src/services/mapping/mapping-serializer.service.ts`: children are now sorted on a copy, so serializing no longer reorders the caller's `mappings.children` array as a side effect. The serialized output order is unchanged.

I used the spread-copy form rather than `toSorted()` because the ui package compiles against ES2020 (`tsconfig.lib.json`: target/lib ES2020) and `toSorted` is ES2023.