### PR TITLE
chore(refactor): move names checks to camel-uri-helper

### DIFF
--- a/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
@@ -22,11 +22,19 @@ export class BaseNodeMapper implements INodeMapper {
     componentLookup: IVisualizationNodeIds,
     entityDefinition: unknown,
   ): Promise<IVisualizationNode> {
-    const { componentName, kameletName } = this.getComponentAndKameletNames(
-      componentLookup.primaryNodeId,
-      entityDefinition,
-      path,
-    );
+    let componentName = undefined;
+    let kameletName = undefined;
+    if (componentLookup.primaryNodeId && URI_PROCESSORS.has(componentLookup.primaryNodeId.name)) {
+      const definition = safeGetValue(entityDefinition, path);
+      const uri = CamelUriHelper.getUriString(definition);
+      if (uri) {
+        const names = CamelUriHelper.getComponentAndKameletName(uri);
+        componentName = names.componentName;
+        if ('kameletName' in names) {
+          kameletName = names.kameletName;
+        }
+      }
+    }
 
     const { name, primaryNodeId, secondaryNodeId, tertiaryNodeId } = this.getCatalogAndNodeIds(
       componentLookup.primaryNodeId?.name,
@@ -67,33 +75,6 @@ export class BaseNodeMapper implements INodeMapper {
     }
 
     return vizNode;
-  }
-
-  private getComponentAndKameletNames(
-    primaryNodeId: NodeIdentity | undefined,
-    entityDefinition: unknown,
-    path: string,
-  ): { componentName?: string; kameletName?: string } {
-    if (!primaryNodeId || !URI_PROCESSORS.has(primaryNodeId.name)) {
-      return {};
-    }
-    const definition = safeGetValue(entityDefinition, path);
-    const uri = CamelUriHelper.getUriString(definition);
-    if (!uri) {
-      return {};
-    }
-    const names = CamelUriHelper.getComponentAndKameletName(uri);
-    if ('kameletName' in names) {
-      return { componentName: names.componentName, kameletName: names.kameletName };
-    }
-    if (names.componentName !== undefined) {
-      return { componentName: names.componentName };
-    }
-    const scheme = uri.split(':')[0].trim();
-    if (scheme) {
-      return { componentName: scheme };
-    }
-    return {};
   }
 
   private getCatalogAndNodeIds(

--- a/packages/ui/src/utils/camel-uri-helper.ts
+++ b/packages/ui/src/utils/camel-uri-helper.ts
@@ -271,12 +271,8 @@ export class CamelUriHelper {
       return { componentName: undefined };
     }
 
-    if (componentName !== 'kamelet') {
+    if (componentName !== 'kamelet' || separatorIndex === -1) {
       return { componentName };
-    }
-
-    if (separatorIndex === -1) {
-      return { componentName: undefined };
     }
 
     const kameletSegment = trimmedUri.slice(separatorIndex + 1);


### PR DESCRIPTION
### Summary
Refactors component and kamelet name resolution logic by consolidating it into `CamelUriHelper.getComponentAndKameletName()` rather than keeping it in a private method on `BaseNodeMapper`.

### Changes

- **`base-node-mapper.ts`**: Removes the private `getComponentAndKameletNames()` method and inlines the logic directly using `CamelUriHelper.getComponentAndKameletName()`. Simplifies the extraction to only proceed when a `primaryNodeId` is a URI processor and a URI string is present.

- **`camel-uri-helper.ts`**: Adds an early return in `getComponentAndKameletName()` when both `componentName` and `kameletName` are `'kamelet'` (i.e. `kamelet:kamelet`), returning just `{ componentName }` to avoid treating this as a valid kamelet reference.

- **`step-xml-serializer.ts`**: Adds a guard to skip kamelet URI resolution when the URI is `kamelet:kamelet`, preventing an unnecessary catalog lookup for this edge case.

fix: https://github.com/KaotoIO/kaoto/issues/3693

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component and Kamelet name resolution for URI-based processors.
  * Correctly recognizes valid component names when URIs do not include a separator.
  * Prevents incorrect fallback names from being derived from URI schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->