### PR TITLE
fix(ui): make duplicate test titles unique within their suites

### DIFF
--- a/packages/ui/src/pages/RestDslImport/RestDslImportPage.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportPage.test.tsx
@@ -42,7 +42,7 @@ describe('RestDslImportPage', () => {
     expect(screen.getByText('Rest Editor')).toBeInTheDocument();
   });
 
-  it('navigates back to the Home page when closing the wizard', async () => {
+  it('navigates back to the Home page when closing the wizard via the Designer', async () => {
     render(
       <MemoryRouter initialEntries={[Links.RestImport]}>
         <Routes>

--- a/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
@@ -221,7 +221,7 @@ describe('parser basics', () => {
       expect(result.onWhen).toBeDefined();
     });
 
-    it('should handle intercept elements', async () => {
+    it('should handle intercept elements with an onWhen child', async () => {
       const interceptElement = getDocument(
         '<intercept id="intercept1"><onWhen><simple>${in.body} contains \'Hello\'</simple></onWhen><to uri="mock:intercepted"/></intercept>',
       ).documentElement;


### PR DESCRIPTION
Fixes #3709.

Two suites had duplicate `it()` titles (Sonar rule typescript:S8754):

- `RestDslImportPage.test.tsx`: the second wizard-close test routes through the Designer and lands on the Home page, so it's now titled `navigates back to the Home page when closing the wizard via the Designer` (the first test continues to the Rest Editor).
- `step-parser.test.ts`: inside `describe('special cases')`, the intercept test that parses a full `<intercept>` with an `onWhen` child is now `should handle intercept elements with an onWhen child`.

Test logic unchanged.