### PR TITLE
fix(ui): Replace findIndex() with indexOf() in camel-route-resource.ts

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -257,7 +257,7 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
   }
 
   deleteBeansEntity(entity: BeansEntity): void {
-    const index = this.entities.findIndex((e) => e === entity);
+    const index = this.entities.indexOf(entity);
     if (index !== -1) {
       this.entities.splice(index, 1);
     }


### PR DESCRIPTION
Fixes #3742.

`this.entities.findIndex((e) => e === entity)` is equivalent to `this.entities.indexOf(entity)` and reads simpler (Sonar rule typescript:S7753). Identity comparison, so `indexOf` is exactly equivalent here.