### PR TITLE
fix(ui): Replace max ternary with Math.max() in sort-tags.ts

### DIFF
--- a/packages/ui/src/components/Catalog/sort-tags.ts
+++ b/packages/ui/src/components/Catalog/sort-tags.ts
@@ -39,6 +39,6 @@ export const sortTags = (allTiles: ITile[], filterTags: string[]): { sortedTags:
       return 0;
     });
   const num = sortedTags.filter((tag) => filterTags.includes(tag) || priorityTags.includes(tag)).length;
-  const overflowIndex = num > overflowThreshold ? num : overflowThreshold;
+  const overflowIndex = Math.max(num, overflowThreshold);
   return { sortedTags, overflowIndex };
 };


### PR DESCRIPTION
Fixes #3733.

`num > overflowThreshold ? num : overflowThreshold` is exactly `Math.max(num, overflowThreshold)` and reads clearer (Sonar rule typescript:S7766).