### PR TITLE
fix(ui): Use String.raw for the NameChar regex pattern

### DIFF
--- a/packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts
+++ b/packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts
@@ -8,7 +8,7 @@ const f = fragments;
 
 fragments['NameStartChar'] = /[a-zA-Z]|\\u2070-\\u218F|\\u2C00-\\u2FEF|\\u3001-\\uD7FF|\\uF900-\\uFDCF|\\uFDF0-\\uFFFD/;
 fragments['NameChar'] = new RegExp(
-  `(${f.NameStartChar.source})|-|_|\\.|\\d|\\u00B7|[\\u0300-\\u036F]|[\\u203F-\\u2040]`,
+  String.raw`(${f.NameStartChar.source})|-|_|\.|\d|\u00B7|[\u0300-\u036F]|[\u203F-\u2040]`,
 );
 fragments['Name'] = new RegExp(`(${f.NameStartChar.source})(${f.NameChar.source})*`);
 fragments['StringLiteral'] = /("(""|[^"])*")|('(''|[^'])*')/;


### PR DESCRIPTION
Fixes #3740.

The `NameChar` pattern in `xpath-2.0-parser.ts` double-escapes every backslash inside a template literal. Converted it to `String.raw`, which keeps the regex escapes readable (Sonar rule typescript:S7780). Verified in Node that the compiled regex `.source` is byte-identical to the old form and match behavior is unchanged.