### PR TITLE
fix(ui): Replace identity arrow with Boolean in every()

### DIFF
--- a/packages/ui/src/providers/visible-flows.provider.tsx
+++ b/packages/ui/src/providers/visible-flows.provider.tsx
@@ -21,7 +21,7 @@ export const VisibleFlowsProvider: FunctionComponent<PropsWithChildren> = (props
   );
 
   const [visibleFlows, dispatch] = useReducer(VisibleFlowsReducer, {}, () => initVisibleFlows(visualEntitiesIds));
-  const allFlowsVisible = Object.values(visibleFlows).every((visible) => visible);
+  const allFlowsVisible = Object.values(visibleFlows).every(Boolean);
   const visualFlowsApi = useMemo(() => {
     return new VisualFlowsApi(dispatch);
   }, [dispatch]);


### PR DESCRIPTION
Fixes #3734.

`Object.values(visibleFlows).every((visible) => visible)` is equivalent to `.every(Boolean)` — `every()` coerces the callback's return to boolean, so the identity arrow and `Boolean` behave identically here (Sonar rule typescript:S7770).