### PR TITLE
fix(ui): Replace single-case switch statements with if chains

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapperControl.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperControl.tsx
@@ -22,12 +22,10 @@ import { SourceTargetView } from '../View/SourceTargetView';
 export const DataMapperControl: FunctionComponent = () => {
   const { activeView } = useDataMapper();
   const currentView = useMemo(() => {
-    switch (activeView) {
-      case CanvasView.SOURCE_TARGET:
-        return <SourceTargetView />;
-      default:
-        return <>View {activeView} is not supported</>;
+    if (activeView === CanvasView.SOURCE_TARGET) {
+      return <SourceTargetView />;
     }
+    return <>View {activeView} is not supported</>;
   }, [activeView]);
 
   return <>{currentView}</>;

--- a/packages/ui/src/components/Visualization/Canvas/controller.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/controller.service.ts
@@ -73,11 +73,9 @@ export class ControllerService {
   }
 
   static baselineElementFactory(kind: ModelKind): GraphElement | undefined {
-    switch (kind) {
-      case ModelKind.edge:
-        return new NoBendpointsEdge();
-      default:
-        return undefined;
+    if (kind === ModelKind.edge) {
+      return new NoBendpointsEdge();
     }
+    return undefined;
   }
 }

--- a/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-default.service.ts
@@ -46,17 +46,15 @@ export class CamelComponentDefaultService {
   }
 
   private static getDefaultValueFromComponent(componentName: string): { to: Exclude<To, string> } {
-    switch (componentName) {
-      case 'log':
-        return parse(`
+    if (componentName === 'log') {
+      return parse(`
           to:
             id: ${getCamelRandomId('to')}
             uri: log:InfoLogger
             parameters: {}
         `);
-
-      default:
-        return parse(`
+    }
+    return parse(`
           to:
             id: ${getCamelRandomId('to')}
             uri: "${componentName}"
@@ -66,14 +64,11 @@ export class CamelComponentDefaultService {
   }
 
   private static getDefaultValueFromKamelet(kameletName: string): object {
-    switch (kameletName) {
-      default:
-        return parse(`
+    return parse(`
           to:
             uri: "${this.getPrefixedKameletName(kameletName)}"
             id: ${getCamelRandomId('to')}
         `);
-    }
   }
 
   private static getDefaultValueFromProcessor(processorName: keyof ProcessorDefinition): ProcessorDefinition {


### PR DESCRIPTION
Fixes #3738.

Converted four single/two-case switches to `if` chains (Sonar rule typescript:S1301):

- `DataMapperControl.tsx`: SOURCE_TARGET view selection
- `controller.service.ts`: `baselineElementFactory` edge case
- `camel-component-default.service.ts`: `getDefaultValueFromComponent` log special case, and `getDefaultValueFromKamelet` (default-only switch collapsed to a direct return)

No behavior change.