### PR TITLE
fix(ui): Remove redundant return statement in integration-resource.ts

### DIFF
--- a/packages/ui/src/models/camel/integration-resource.ts
+++ b/packages/ui/src/models/camel/integration-resource.ts
@@ -15,7 +15,6 @@ export class IntegrationResource extends CamelKResource {
     } else {
       this.integration = this.resource as IntegrationType;
       this.integration.kind = SourceSchemaType.Integration;
-      return;
     }
   }
 


### PR DESCRIPTION
Fixes #3739.

The `return;` was the last statement in the `else` block before its natural end, so it was dead code (Sonar rule typescript:S3626). Removed it. No behavior change.