### PR TITLE
fix(ui): Drop useless assignment to entity in MetadataPage

### DIFF
--- a/packages/ui/src/pages/Metadata/MetadataPage.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.tsx
@@ -29,9 +29,9 @@ export const MetadataPage: FunctionComponent = () => {
   const onChangeModel = useCallback(
     (model: Record<string, unknown>) => {
       if (Object.keys(model).length > 0) {
-        let entity = camelkResource.getMetadataEntity();
+        const entity = camelkResource.getMetadataEntity();
         if (!entity) {
-          entity = camelkResource.createMetadataEntity();
+          camelkResource.createMetadataEntity();
         } else {
           entity.parent.metadata = model;
           camelkResource.refreshVisualMetadata();


### PR DESCRIPTION
Fixes #3736.

In `MetadataPage`'s `onChangeModel`, the value assigned to `entity` from `createMetadataEntity()` was never read. The call itself is load-bearing though — it initializes `resource.metadata` so the entity shows up in the resource — so I kept the call, dropped only the unused assignment, and tightened `let` to `const` (Sonar rule typescript:S1854).