### PR TITLE
fix(ui): Use nullish coalescing assignment in five spots

### DIFF
--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
@@ -70,9 +70,7 @@ export class BeansEntityHandler {
     }
 
     let entity = this.getBeansEntity();
-    if (!entity) {
-      entity = this.createBeansEntity();
-    }
+    entity ??= this.createBeansEntity();
     if (entity) {
       entity.parent.beans = model;
     }

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
@@ -37,9 +37,7 @@ export const PipeErrorHandlerPage: FunctionComponent = () => {
     (model: Record<string, unknown>) => {
       if (Object.keys(model).length > 0) {
         let entity = pipeResource.getErrorHandlerEntity();
-        if (!entity) {
-          entity = pipeResource.createErrorHandlerEntity();
-        }
+        entity ??= pipeResource.createErrorHandlerEntity();
         entity.parent.errorHandler = model;
       } else {
         pipeResource!.deleteErrorHandlerEntity();

--- a/packages/ui/src/utils/event-notifier.ts
+++ b/packages/ui/src/utils/event-notifier.ts
@@ -11,9 +11,7 @@ export class EventNotifier extends EventTarget {
   }
 
   static getInstance(): EventNotifier {
-    if (!this.instance) {
-      this.instance = new EventNotifier();
-    }
+    this.instance ??= new EventNotifier();
 
     return this.instance;
   }

--- a/packages/ui/src/xml-schema-ts/extensions/DefaultExtensionDeserializer.ts
+++ b/packages/ui/src/xml-schema-ts/extensions/DefaultExtensionDeserializer.ts
@@ -23,9 +23,7 @@ export class DefaultExtensionDeserializer implements ExtensionDeserializer {
     // elements or the attributes
 
     let metaInfoMap = schemaObject.getMetaInfoMap();
-    if (metaInfoMap == null) {
-      metaInfoMap = new Map<string, object>();
-    }
+    metaInfoMap ??= new Map<string, object>();
 
     if (node.nodeType == Node.ATTRIBUTE_NODE) {
       let attribMap: Map<QName, Node>;

--- a/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.ts
+++ b/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.ts
@@ -16,9 +16,7 @@ export class NodeNamespaceContext implements NamespacePrefixList {
   }
 
   getDeclaredPrefixes(): string[] {
-    if (this.prefixes === undefined) {
-      this.prefixes = Object.keys(this.declarations);
-    }
+    this.prefixes ??= Object.keys(this.declarations);
     return this.prefixes;
   }
 


### PR DESCRIPTION
Fixes #3737.

Replaced `if (x == null) x = ...`-style initialization with `??=` (Sonar rule typescript:S6606):

- `beans-entity-handler.ts`: lazy beans-entity creation
- `PipeErrorHandlerPage.tsx`: lazy error-handler-entity creation
- `event-notifier.ts`: singleton instantiation
- `DefaultExtensionDeserializer.ts`: `metaInfoMap` fallback
- `NodeNamespaceContext.ts`: prefixes memoization

All five variables hold object/array-or-nullish values, so `??=` is exactly equivalent — the lazy-create calls still run precisely when the value is missing. No behavior change.