### PR TITLE
fix(sonar): use indexOf() instead of findIndex() in camel-route-resource

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -257,7 +257,7 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
   }
 
   deleteBeansEntity(entity: BeansEntity): void {
-    const index = this.entities.findIndex((e) => e === entity);
+    const index = this.entities.indexOf(entity);
     if (index !== -1) {
       this.entities.splice(index, 1);
     }


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3742 (Sonar `typescript:S7753`).

### Change

`CamelRouteResource.deleteBeansEntity` searched for the entity by identity:

```ts
const index = this.entities.findIndex((e) => e === entity);
```

That predicate is exactly `Array#indexOf`'s semantics (strict equality / SameValueZero), so the callback adds nothing:

```ts
const index = this.entities.indexOf(entity);
```

Behaviour is identical — `indexOf` returns `-1` when the entity is absent, which the existing `if (index !== -1)` guard already handles. This is the only occurrence of the pattern in the repo.

### Validation

- `yarn workspace @kaoto/kaoto test camel-route-resource` → 95 passed, 2 todo (includes the four existing `deleteBeansEntity` cases: deleting an existing entity, deleting one of several, deleting the same entity twice, and deleting an entity that is not in the resource)
- `yarn workspace @kaoto/kaoto lint` → clean

<sub>Assisted by an AI coding agent; reviewed and submitted by me.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal entity lookup logic without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->