### PR TITLE
feat(DataMapper): S5 — Add xsi:type generation to XSLT serializer

### DIFF
--- a/packages/ui/src/services/document/document-util.service.ts
+++ b/packages/ui/src/services/document/document-util.service.ts
@@ -99,7 +99,7 @@ export class DocumentUtilService {
     return field;
   }
 
-  private static captureOriginalFieldState(field: IField): IOriginalFieldState {
+  static captureOriginalFieldState(field: IField): IOriginalFieldState {
     return {
       name: field.name,
       displayName: field.displayName,

--- a/packages/ui/src/services/mapping/mapping-serializer-xsi-type.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer-xsi-type.test.ts
@@ -1,0 +1,270 @@
+import { BODY_DOCUMENT_ID, DocumentDefinitionType, DocumentType } from '../../models/datamapper/document';
+import { FieldItem, MappingTree, VariableItem } from '../../models/datamapper/mapping';
+import { NS_XML_SCHEMA_INSTANCE, NS_XSL } from '../../models/datamapper/standard-namespaces';
+import { FieldOverrideVariant } from '../../models/datamapper/types';
+import { TestUtil } from '../../stubs/datamapper/data-mapper';
+import { QName } from '../../xml-schema-ts/QName';
+import { MappingSerializerService } from './mapping-serializer.service';
+
+describe('xsi:type serialization and deserialization', () => {
+  const domParser = new DOMParser();
+
+  function createMappingTreeWithSafeOverride(): MappingTree {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    mappingTree.namespaceMap = { ns0: 'urn:order', ns1: 'urn:ext', xsi: NS_XML_SCHEMA_INSTANCE };
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const field = targetDoc.fields[0]; // ShipOrder
+    field.typeOverride = FieldOverrideVariant.SAFE;
+    field.typeQName = new QName('urn:ext', 'ShipToExt');
+    const fieldItem = new FieldItem(mappingTree, field);
+    mappingTree.children.push(fieldItem);
+    return mappingTree;
+  }
+
+  it('SAFE override produces xsi:type in serialized XSLT output', () => {
+    const mappingTree = createMappingTreeWithSafeOverride();
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const xslt = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+    expect(xslt).toContain('xsi:type="ns1:ShipToExt"');
+  });
+
+  it('xsi namespace is declared and NOT in exclude-result-prefixes when SAFE override present', () => {
+    const mappingTree = createMappingTreeWithSafeOverride();
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const xslt = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+    const xsltDoc = domParser.parseFromString(xslt, 'application/xml');
+    const stylesheet = xsltDoc.documentElement;
+    // xsi namespace must be declared
+    expect(stylesheet.getAttribute('xmlns:xsi')).toBe(NS_XML_SCHEMA_INSTANCE);
+    // xsi prefix must NOT be in exclude-result-prefixes
+    const excluded = (stylesheet.getAttribute('exclude-result-prefixes') ?? '').split(' ');
+    expect(excluded).not.toContain('xsi');
+    // type's own namespace prefix ns1 must NOT be excluded either
+    expect(excluded).not.toContain('ns1');
+  });
+
+  it('no SAFE override produces no xsi:type and no xsi namespace declaration', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    mappingTree.namespaceMap = { ns0: 'urn:order' };
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const fieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+    mappingTree.children.push(fieldItem);
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const xslt = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+    expect(xslt).not.toContain('xsi:type');
+    expect(xslt).not.toContain(NS_XML_SCHEMA_INSTANCE);
+  });
+
+  it('round-trip: xsi:type survives deserialize → serialize', () => {
+    const NS_ORDER = 'io.kaoto.datamapper.poc.test';
+    const xsltInput = `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="${NS_XSL}" xmlns:ns0="${NS_ORDER}" xmlns:ns1="urn:ext" xmlns:xsi="${NS_XML_SCHEMA_INSTANCE}" exclude-result-prefixes="ns0">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ns0:ShipOrder xsi:type="ns1:ShipToExt">
+      <xsl:value-of select="/ns0:ShipOrder"/>
+    </ns0:ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>`;
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const { mappingTree: deserialized } = MappingSerializerService.deserialize(
+      xsltInput,
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
+
+    const shipOrderFieldItem = deserialized.children[0] as FieldItem;
+    expect(shipOrderFieldItem).toBeInstanceOf(FieldItem);
+    expect(shipOrderFieldItem.field.typeOverride).toBe(FieldOverrideVariant.SAFE);
+    expect(shipOrderFieldItem.field.typeQName?.getLocalPart()).toBe('ShipToExt');
+    expect(shipOrderFieldItem.field.typeQName?.getNamespaceURI()).toBe('urn:ext');
+
+    // Serialize back
+    const reserialized = MappingSerializerService.serialize(deserialized, sourceParameterMap);
+    expect(reserialized).toContain('xsi:type="ns1:ShipToExt"');
+  });
+
+  it('round-trip: hand-edited xsi:type on field with no schema override is preserved', () => {
+    const NS_ORDER = 'io.kaoto.datamapper.poc.test';
+    // Field has no schema-driven type override — xsi:type is purely hand-edited
+    const xsltInput = `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="${NS_XSL}" xmlns:ns0="${NS_ORDER}" xmlns:ns1="urn:hand" xmlns:xsi="${NS_XML_SCHEMA_INSTANCE}" exclude-result-prefixes="ns0">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ns0:ShipOrder xsi:type="ns1:HandEditedType">
+      <xsl:value-of select="/ns0:ShipOrder"/>
+    </ns0:ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>`;
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const { mappingTree: deserialized } = MappingSerializerService.deserialize(
+      xsltInput,
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
+    const shipOrderFieldItem = deserialized.children[0] as FieldItem;
+    expect(shipOrderFieldItem.field.typeOverride).toBe(FieldOverrideVariant.SAFE);
+    expect(shipOrderFieldItem.field.typeQName?.getLocalPart()).toBe('HandEditedType');
+
+    const reserialized = MappingSerializerService.serialize(deserialized, sourceParameterMap);
+    expect(reserialized).toContain('xsi:type="ns1:HandEditedType"');
+  });
+
+  it('backward compatibility: existing XSLT without xsi:type deserializes without errors or spurious xsi:type', () => {
+    const NS_ORDER = 'io.kaoto.datamapper.poc.test';
+    const xsltWithMapping = `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="${NS_XSL}" xmlns:ns0="${NS_ORDER}" exclude-result-prefixes="ns0">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ns0:ShipOrder>
+      <ns0:OrderPerson>
+        <xsl:value-of select="/ns0:ShipOrder/ns0:OrderPerson"/>
+      </ns0:OrderPerson>
+    </ns0:ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>`;
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const { mappingTree: deserialized, messages } = MappingSerializerService.deserialize(
+      xsltWithMapping,
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
+    expect(messages.filter((m) => m.variant === 'danger')).toHaveLength(0);
+    expect(deserialized.children).toHaveLength(1);
+    const shipOrderFieldItem = deserialized.children[0] as FieldItem;
+    expect(shipOrderFieldItem.field.typeOverride).toBe(FieldOverrideVariant.NONE);
+
+    const reserialized = MappingSerializerService.serialize(deserialized, sourceParameterMap);
+    expect(reserialized).not.toContain('xsi:type');
+    expect(reserialized).not.toContain(NS_XML_SCHEMA_INSTANCE);
+  });
+
+  it('element with xsi:type and children is marked isUserCreated after deserialization', () => {
+    const NS_ORDER = 'io.kaoto.datamapper.poc.test';
+    const xsltInput = `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="${NS_XSL}" xmlns:ns0="${NS_ORDER}" xmlns:ns1="urn:ext" xmlns:xsi="${NS_XML_SCHEMA_INSTANCE}" exclude-result-prefixes="ns0">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ns0:ShipOrder xsi:type="ns1:ShipToExt">
+      <ns0:OrderPerson>
+        <xsl:value-of select="/ns0:ShipOrder/ns0:OrderPerson"/>
+      </ns0:OrderPerson>
+    </ns0:ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>`;
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const { mappingTree: deserialized } = MappingSerializerService.deserialize(
+      xsltInput,
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
+    const shipOrderFieldItem = deserialized.children[0] as FieldItem;
+    expect(shipOrderFieldItem).toBeInstanceOf(FieldItem);
+    expect(shipOrderFieldItem.isUserCreated).toBe(true);
+  });
+
+  it('round-trip: xsi:type with non-xsi prefix survives deserialize → serialize', () => {
+    const NS_ORDER = 'io.kaoto.datamapper.poc.test';
+    // xsi prefix is taken by urn:custom, so XSI namespace uses ns2 prefix
+    const xsltInput = `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="${NS_XSL}" xmlns:ns0="${NS_ORDER}" xmlns:ns1="urn:ext" xmlns:xsi="urn:custom" xmlns:ns2="${NS_XML_SCHEMA_INSTANCE}" exclude-result-prefixes="ns0 xsi">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ns0:ShipOrder ns2:type="ns1:ShipToExt">
+      <xsl:value-of select="/ns0:ShipOrder"/>
+    </ns0:ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>`;
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const { mappingTree: deserialized } = MappingSerializerService.deserialize(
+      xsltInput,
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
+
+    const shipOrderFieldItem = deserialized.children[0] as FieldItem;
+    expect(shipOrderFieldItem).toBeInstanceOf(FieldItem);
+    expect(shipOrderFieldItem.field.typeOverride).toBe(FieldOverrideVariant.SAFE);
+    expect(shipOrderFieldItem.field.typeQName?.getLocalPart()).toBe('ShipToExt');
+    expect(shipOrderFieldItem.field.typeQName?.getNamespaceURI()).toBe('urn:ext');
+
+    const reserialized = MappingSerializerService.serialize(deserialized, sourceParameterMap);
+    const reserializedDoc = new DOMParser().parseFromString(reserialized, 'application/xml');
+    const shipOrder = reserializedDoc.getElementsByTagNameNS(NS_ORDER, 'ShipOrder')[0];
+    expect(shipOrder).toBeDefined();
+    const typeAttr = shipOrder.getAttributeNS(NS_XML_SCHEMA_INSTANCE, 'type');
+    expect(typeAttr).toContain('ShipToExt');
+  });
+
+  it('round-trip: unprefixed xsi:type resolves through default namespace', () => {
+    const NS_ORDER = 'io.kaoto.datamapper.poc.test';
+    const NS_TYPES = 'urn:types';
+    const xsltInput = `<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="${NS_XSL}" xmlns:ns0="${NS_ORDER}" xmlns:xsi="${NS_XML_SCHEMA_INSTANCE}" exclude-result-prefixes="ns0">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:template match="/">
+    <ns0:ShipOrder xmlns="${NS_TYPES}" xsi:type="Derived">
+      <xsl:value-of select="/ns0:ShipOrder"/>
+    </ns0:ShipOrder>
+  </xsl:template>
+</xsl:stylesheet>`;
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const { mappingTree: deserialized } = MappingSerializerService.deserialize(
+      xsltInput,
+      targetDoc,
+      mappingTree,
+      sourceParameterMap,
+    );
+
+    const shipOrderFieldItem = deserialized.children[0] as FieldItem;
+    expect(shipOrderFieldItem).toBeInstanceOf(FieldItem);
+    expect(shipOrderFieldItem.field.typeOverride).toBe(FieldOverrideVariant.SAFE);
+    expect(shipOrderFieldItem.field.typeQName?.getLocalPart()).toBe('Derived');
+    expect(shipOrderFieldItem.field.typeQName?.getNamespaceURI()).toBe(NS_TYPES);
+
+    const reserialized = MappingSerializerService.serialize(deserialized, sourceParameterMap);
+    const reserializedDoc = new DOMParser().parseFromString(reserialized, 'application/xml');
+    const shipOrder = reserializedDoc.getElementsByTagNameNS(NS_ORDER, 'ShipOrder')[0];
+    expect(shipOrder).toBeDefined();
+    const typeAttr = shipOrder.getAttributeNS(NS_XML_SCHEMA_INSTANCE, 'type');
+    expect(typeAttr).toContain('Derived');
+  });
+
+  it('SAFE override inside globalVariable is detected for xsi namespace preservation', () => {
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    mappingTree.namespaceMap = { ns0: 'urn:order', ns1: 'urn:ext', xsi: NS_XML_SCHEMA_INSTANCE };
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const field = targetDoc.fields[0];
+    field.typeOverride = FieldOverrideVariant.SAFE;
+    field.typeQName = new QName('urn:ext', 'ShipToExt');
+    const variable = new VariableItem(mappingTree, 'myVar');
+    const fieldItem = new FieldItem(variable, field);
+    variable.children.push(fieldItem);
+    mappingTree.globalVariables.push(variable);
+    const sourceParameterMap = TestUtil.createParameterMap();
+    const xslt = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+    const xsltDoc = domParser.parseFromString(xslt, 'application/xml');
+    const stylesheet = xsltDoc.documentElement;
+    expect(stylesheet.getAttribute('xmlns:xsi')).toBe(NS_XML_SCHEMA_INSTANCE);
+    const excluded = (stylesheet.getAttribute('exclude-result-prefixes') ?? '').split(' ');
+    expect(excluded).not.toContain('xsi');
+    expect(excluded).not.toContain('ns1');
+  });
+});

--- a/packages/ui/src/services/mapping/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.ts
@@ -23,13 +23,15 @@ import {
   VariableItem,
 } from '../../models/datamapper/mapping';
 import { DeserializeItemResult, DeserializeResult, MappingItemClass } from '../../models/datamapper/serialization';
-import { NS_XSL } from '../../models/datamapper/standard-namespaces';
+import { NS_XML_SCHEMA_INSTANCE, NS_XSL } from '../../models/datamapper/standard-namespaces';
 import { DEFAULT_DATAMAPPER_SETTINGS, FieldOverrideVariant, IDataMapperSettings } from '../../models/datamapper/types';
 import { SendAlertProps } from '../../models/datamapper/visualization';
+import { QName } from '../../xml-schema-ts/QName';
 import { DocumentUtilService } from '../document/document-util.service';
 import { FieldOverrideService } from '../document/field-override.service';
 import { FROM_JSON_SOURCE_SUFFIX, JsonSchemaDocument } from '../document/json-schema/json-schema-document.model';
 import { XmlSchemaDocumentUtilService } from '../document/xml-schema/xml-schema-document-util.service';
+import { ensureNamespaceRegistered, parseQNameString } from '../namespace-util';
 import { MappingService } from './mapping.service';
 import { MappingSerializerJsonAddon, TO_JSON_TARGET_VARIABLE } from './mapping-serializer-json-addon';
 import { deserializeHandlers, serializeHandlers } from './xslt-item-handlers';
@@ -121,7 +123,15 @@ export class MappingSerializerService {
     dataMapperSettings?: IDataMapperSettings,
   ): string {
     const xslt = MappingSerializerService.createNew(dataMapperSettings);
-    MappingSerializerService.populateNamespaces(xslt, mappings.namespaceMap);
+    const outputNamespaceURIs = MappingSerializerService.collectOutputNamespaceURIs(mappings);
+    for (const namespaceURI of outputNamespaceURIs) {
+      ensureNamespaceRegistered(
+        namespaceURI,
+        mappings.namespaceMap,
+        namespaceURI === NS_XML_SCHEMA_INSTANCE ? 'xsi' : undefined,
+      );
+    }
+    MappingSerializerService.populateNamespaces(xslt, mappings.namespaceMap, outputNamespaceURIs);
     MappingSerializerService.populateParam(xslt, sourceParameterMap);
     MappingSerializerService.populateStylesheetVariables(xslt, mappings);
     const root = MappingSerializerService.populateMappingRoot(xslt, mappings);
@@ -132,13 +142,21 @@ export class MappingSerializerService {
     return xmlFormat(new XMLSerializer().serializeToString(xslt));
   }
 
-  private static populateNamespaces(xslt: Document, namespaceMap: { [prefix: string]: string }) {
+  private static populateNamespaces(
+    xslt: Document,
+    namespaceMap: { [prefix: string]: string },
+    outputNamespaceURIs: Set<string> = new Set(),
+  ) {
     const rootElement = xslt.documentElement;
     const prefixes: string[] = [];
     Object.entries(namespaceMap).forEach(([prefix, uri]) => {
       if (prefix && uri) {
         rootElement.setAttribute(`xmlns:${prefix}`, uri);
-        prefixes.push(prefix);
+        // Prefixes whose namespace URIs appear in the output must NOT be excluded —
+        // the XSLT processor needs them to emit the correct namespace declarations.
+        if (!outputNamespaceURIs.has(uri)) {
+          prefixes.push(prefix);
+        }
       }
     });
     // These prefixes are only declared for matching the source document via XPath.
@@ -148,6 +166,29 @@ export class MappingSerializerService {
     // are not actually used by an output element, so this is safe.
     if (prefixes.length > 0) {
       rootElement.setAttribute('exclude-result-prefixes', prefixes.join(' '));
+    }
+  }
+
+  /** Collects namespace URIs that must appear in the output (i.e. must not be excluded). */
+  private static collectOutputNamespaceURIs(mappings: MappingTree): Set<string> {
+    const uris = new Set<string>();
+    const allRoots = [...mappings.children, ...mappings.globalVariables];
+    MappingSerializerService.walkMappingItems(allRoots, (item) => {
+      if (item instanceof FieldItem && item.field.typeOverride === FieldOverrideVariant.SAFE && item.field.typeQName) {
+        uris.add(NS_XML_SCHEMA_INSTANCE);
+        const typeNsURI = item.field.typeQName.getNamespaceURI();
+        if (typeNsURI) uris.add(typeNsURI);
+      }
+    });
+    return uris;
+  }
+
+  private static walkMappingItems(items: MappingItem[], visitor: (item: MappingItem) => void) {
+    for (const item of items) {
+      visitor(item);
+      if (item.children.length > 0) {
+        MappingSerializerService.walkMappingItems(item.children, visitor);
+      }
     }
   }
 
@@ -397,6 +438,7 @@ export class MappingSerializerService {
 
   private static isUserCreatedField(field: IField): boolean {
     if (field.typeOverride === FieldOverrideVariant.SUBSTITUTION) return true;
+    if (field.typeOverride === FieldOverrideVariant.SAFE) return true;
 
     let current: IParentType = field.parent;
     while ('ownerDocument' in current) {
@@ -463,9 +505,27 @@ export class MappingSerializerService {
     if (parentField instanceof PrimitiveDocument) return null;
     const field = MappingSerializerService.getOrCreateElementField(element, parentField);
     if (!field) return null;
+
+    // Preserve xsi:type literal attribute for round-trip support.
+    // Only apply when the field has no existing schema-driven override.
+    const xsiType = element.getAttributeNS(NS_XML_SCHEMA_INSTANCE, 'type');
+    if (xsiType && field.typeOverride === FieldOverrideVariant.NONE) {
+      MappingSerializerService.applyXsiTypeOverride(field, xsiType, element);
+    }
+
     const mappingItem = new FieldItem(parentMapping, field);
     MappingSerializerService.restoreCommentFromPreviousSibling(element, mappingItem);
     return { fieldItem: field, mappingItem };
+  }
+
+  private static applyXsiTypeOverride(field: IField, xsiTypeValue: string, element: Element): void {
+    const { prefix, localPart } = parseQNameString(xsiTypeValue);
+    const namespaceURI = element.lookupNamespaceURI(prefix || null) ?? '';
+    const typeQName = new QName(namespaceURI, localPart, prefix);
+
+    field.originalField ??= DocumentUtilService.captureOriginalFieldState(field);
+    field.typeQName = typeQName;
+    field.typeOverride = FieldOverrideVariant.SAFE;
   }
 
   private static restoreXslElement(

--- a/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.test.ts
@@ -14,13 +14,15 @@ import {
   ValueOfType,
   VariableItem,
 } from '../../models/datamapper/mapping';
-import { NS_XSL } from '../../models/datamapper/standard-namespaces';
+import { NS_XML_SCHEMA_INSTANCE, NS_XSL } from '../../models/datamapper/standard-namespaces';
+import { FieldOverrideVariant } from '../../models/datamapper/types';
 import {
   getForEachGroupEndingWithToShipOrderXslt,
   getForEachGroupStartingWithToShipOrderXslt,
   getForEachGroupToShipOrderXslt,
   TestUtil,
 } from '../../stubs/datamapper/data-mapper';
+import { QName } from '../../xml-schema-ts/QName';
 import { MappingSerializerService } from './mapping-serializer.service';
 import * as handlerModule from './xslt-item-handlers';
 import {
@@ -848,5 +850,115 @@ describe('UnknownMappingItemHandler', () => {
         expect(result.expression).toBe('');
       });
     });
+  });
+});
+
+describe('FieldItemHandler xsi:type emission', () => {
+  const handler = new FieldItemHandler();
+  let targetDoc: ReturnType<typeof TestUtil.createTargetOrderDoc>;
+
+  beforeEach(() => {
+    targetDoc = TestUtil.createTargetOrderDoc();
+  });
+
+  function createFieldItemWithOverride(
+    override: FieldOverrideVariant,
+    typeQName: QName | null,
+    namespaceMap: Record<string, string>,
+  ): FieldItem {
+    const field = targetDoc.fields[0];
+    field.typeOverride = override;
+    field.typeQName = typeQName;
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    mappingTree.namespaceMap = namespaceMap;
+    return new FieldItem(mappingTree, field);
+  }
+
+  it('should emit xsi:type attribute when typeOverride is SAFE', () => {
+    const namespaceMap = { xsi: NS_XML_SCHEMA_INSTANCE, ns0: 'urn:order', ns1: 'urn:ext' };
+    const fieldItem = createFieldItemWithOverride(
+      FieldOverrideVariant.SAFE,
+      new QName('urn:ext', 'ShipToExt'),
+      namespaceMap,
+    );
+    const xslt = MappingSerializerService.createNew();
+    const element = handler.serialize(xslt.documentElement, fieldItem);
+    expect(element.getAttribute('xsi:type')).toBe('ns1:ShipToExt');
+  });
+
+  it('should NOT emit xsi:type when typeOverride is NONE', () => {
+    const namespaceMap = { xsi: NS_XML_SCHEMA_INSTANCE, ns0: 'urn:order', ns1: 'urn:ext' };
+    const fieldItem = createFieldItemWithOverride(
+      FieldOverrideVariant.NONE,
+      new QName('urn:ext', 'ShipToExt'),
+      namespaceMap,
+    );
+    const xslt = MappingSerializerService.createNew();
+    const element = handler.serialize(xslt.documentElement, fieldItem);
+    expect(element.hasAttribute('xsi:type')).toBe(false);
+  });
+
+  it('should NOT emit xsi:type when typeOverride is FORCE', () => {
+    const namespaceMap = { xsi: NS_XML_SCHEMA_INSTANCE, ns0: 'urn:order', ns1: 'urn:ext' };
+    const fieldItem = createFieldItemWithOverride(
+      FieldOverrideVariant.FORCE,
+      new QName('urn:ext', 'ShipToExt'),
+      namespaceMap,
+    );
+    const xslt = MappingSerializerService.createNew();
+    const element = handler.serialize(xslt.documentElement, fieldItem);
+    expect(element.hasAttribute('xsi:type')).toBe(false);
+  });
+
+  it('should NOT emit xsi:type when typeOverride is SUBSTITUTION', () => {
+    const namespaceMap = { xsi: NS_XML_SCHEMA_INSTANCE, ns0: 'urn:order', ns1: 'urn:ext' };
+    const fieldItem = createFieldItemWithOverride(
+      FieldOverrideVariant.SUBSTITUTION,
+      new QName('urn:ext', 'ShipToExt'),
+      namespaceMap,
+    );
+    const xslt = MappingSerializerService.createNew();
+    const element = handler.serialize(xslt.documentElement, fieldItem);
+    expect(element.hasAttribute('xsi:type')).toBe(false);
+  });
+
+  it('should NOT emit xsi:type when typeQName is null', () => {
+    const namespaceMap = { xsi: NS_XML_SCHEMA_INSTANCE, ns0: 'urn:order' };
+    const fieldItem = createFieldItemWithOverride(FieldOverrideVariant.SAFE, null, namespaceMap);
+    const xslt = MappingSerializerService.createNew();
+    const element = handler.serialize(xslt.documentElement, fieldItem);
+    expect(element.hasAttribute('xsi:type')).toBe(false);
+  });
+
+  it('should NOT emit xsi:type for attribute fields', () => {
+    const namespaceMap = { xsi: NS_XML_SCHEMA_INSTANCE, ns0: 'urn:order', ns1: 'urn:ext' };
+    const field = targetDoc.fields[0];
+    field.isAttribute = true;
+    field.typeOverride = FieldOverrideVariant.SAFE;
+    field.typeQName = new QName('urn:ext', 'ShipToExt');
+    const mappingTree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    mappingTree.namespaceMap = namespaceMap;
+    const fieldItem = new FieldItem(mappingTree, field);
+    const xslt = MappingSerializerService.createNew();
+    // attribute fields produce an xsl:attribute element, not a literal element
+    const element = handler.serialize(xslt.documentElement, fieldItem);
+    expect(element.namespaceURI).toBe(NS_XSL);
+    expect(element.localName).toBe('attribute');
+    expect(element.hasAttribute('xsi:type')).toBe(false);
+  });
+
+  it('should use dynamically resolved prefix when xsi is taken by another URI', () => {
+    // xsi prefix is taken by a different namespace; NS_XML_SCHEMA_INSTANCE is registered under ns0
+    const namespaceMap = { xsi: 'urn:some-other-namespace', ns0: NS_XML_SCHEMA_INSTANCE, ns1: 'urn:ext' };
+    const fieldItem = createFieldItemWithOverride(
+      FieldOverrideVariant.SAFE,
+      new QName('urn:ext', 'ShipToExt'),
+      namespaceMap,
+    );
+    const xslt = MappingSerializerService.createNew();
+    const element = handler.serialize(xslt.documentElement, fieldItem);
+    // ns0 is the prefix that maps to NS_XML_SCHEMA_INSTANCE
+    expect(element.getAttribute('ns0:type')).toBe('ns1:ShipToExt');
+    expect(element.hasAttribute('xsi:type')).toBe(false);
   });
 });

--- a/packages/ui/src/services/mapping/xslt-item-handlers.ts
+++ b/packages/ui/src/services/mapping/xslt-item-handlers.ts
@@ -19,9 +19,11 @@ import {
   WhenItem,
 } from '../../models/datamapper/mapping';
 import { DeserializeItemResult, MappingItemClass, XsltItemHandler } from '../../models/datamapper/serialization';
-import { NS_XSL } from '../../models/datamapper/standard-namespaces';
+import { NS_XML_SCHEMA_INSTANCE, NS_XSL } from '../../models/datamapper/standard-namespaces';
+import { FieldOverrideVariant } from '../../models/datamapper/types';
 import { FROM_JSON_SOURCE_SUFFIX } from '../document/json-schema/json-schema-document.model';
 import { XmlSchemaDocumentUtilService } from '../document/xml-schema/xml-schema-document-util.service';
+import { formatQNameWithPrefix, getPrefixForNamespaceURI } from '../namespace-util';
 import { MappingSerializerJsonAddon, TO_JSON_TARGET_VARIABLE } from './mapping-serializer-json-addon';
 
 /** Handles {@link ValueOfSelector} — maps to `xsl:value-of` or `xsl:text`. */
@@ -199,6 +201,18 @@ export class FieldItemHandler implements XsltItemHandler<FieldItem> {
     const element = mapping.field.namespaceURI
       ? doc.createElementNS(mapping.field.namespaceURI, mapping.field.name)
       : doc.createElement(mapping.field.name);
+
+    // Emit xsi:type for SAFE type overrides — enables XML Schema validators
+    // to follow type hierarchy (extension/restriction) without schema regeneration.
+    if (mapping.field.typeOverride === FieldOverrideVariant.SAFE && mapping.field.typeQName) {
+      const namespaceMap = mapping.mappingTree.namespaceMap;
+      const xsiPrefix = getPrefixForNamespaceURI(NS_XML_SCHEMA_INSTANCE, namespaceMap);
+      const xsiTypeValue = formatQNameWithPrefix(mapping.field.typeQName, namespaceMap);
+      if (xsiPrefix && xsiTypeValue) {
+        element.setAttribute(`${xsiPrefix}:type`, xsiTypeValue);
+      }
+    }
+
     parent.appendChild(element);
     return element;
   }


### PR DESCRIPTION
### Description

Implements `xsi:type` attribute emission in the XSLT serializer for the DataMapper output validation feature.

When a SAFE type override is active on a target field, the serializer now emits `xsi:type` as a literal attribute on the output element. This makes the XSLT output self-documenting and enables XML Schema validators to follow the type hierarchy (extension/restriction) without schema regeneration.

**Before:**
```xml
<ns0:ShipTo>
  <ns0:ExtendedField>...</ns0:ExtendedField>  <!-- validator rejects: not in base type -->
</ns0:ShipTo>
```

**After:**
```xml
<ns0:ShipTo xsi:type="ns1:ShipToExt">
  <ns0:ExtendedField>...</ns0:ExtendedField>  <!-- validator accepts: ShipToExt extends ShipTo -->
</ns0:ShipTo>
```

#### Changes

**`FieldItemHandler.serialize()`** in `xslt-item-handlers.ts`:
- Emits `xsi:type` literal attribute when `field.typeOverride === SAFE` and `typeQName` is set
- Prefix resolved dynamically via `getPrefixForNamespaceURI()` — handles edge cases where `xsi` is already taken by another URI

**`MappingSerializerService`** in `mapping-serializer.service.ts`:
- `collectOutputNamespaceURIs()` + `walkMappingItems()`: scan full MappingTree (children + globalVariables) for SAFE overrides to collect output-needed namespace URIs
- `populateNamespaces()`: new `outputNamespaceURIs` parameter — prefixes whose URIs appear in the output are omitted from `exclude-result-prefixes` so the XSLT processor emits the correct namespace declarations
- `serialize()`: registers `xsi` namespace before populating namespaces
- `restoreNonXslElement()`: reads `xsi:type` attribute back and calls `applyXsiTypeOverride()` for round-trip support
- `applyXsiTypeOverride()`: captures `originalField` snapshot, sets `typeQName` and `typeOverride = SAFE`
- `isUserCreatedField()`: recognises SAFE override so elements with `xsi:type` and children are marked `isUserCreated` and survive pruning

Closes #3607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserves safe `xsi:type` values when mappings are serialized and deserialized.
  * Supports namespace-aware type values, including custom prefixes and default namespaces.
  * Retains user-created type definitions and nested safe type overrides during round trips.

* **Bug Fixes**
  * Prevents loss of `xsi:type` values and required namespace declarations in generated XSLT.
  * Avoids adding unnecessary XSI declarations when no type override is present.
  * Maintains compatibility with existing XSLT without `xsi:type` attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->