### PR TITLE
chore(clean): delete unused code + more migration to IVisualizationNo…

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/customComponentUtils.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/customComponentUtils.test.ts
@@ -2,9 +2,12 @@ import { Edge, EdgeModel } from '@patternfly/react-topology';
 import type { Mock } from 'vitest';
 
 import { CatalogModalContextValue } from '../../../dynamic-catalog/catalog-modal.provider';
-import { AddStepMode, IVisualizationNode } from '../../../models/visualization/base-visual-entity';
+import {
+  AddStepMode,
+  IVisualizationNode,
+  IVisualizationNodeData,
+} from '../../../models/visualization/base-visual-entity';
 import { CamelComponentSchemaService } from '../../../models/visualization/flows/support/camel-component-schema.service';
-import { CamelRouteVisualEntityData } from '../../../models/visualization/flows/support/camel-component-types';
 import { EntitiesContextResult } from '../../../providers';
 import { canDragGroup, canDropOnEdge, getDropTargetContainerClassNames } from './customComponentUtils';
 
@@ -240,7 +243,7 @@ describe('canDropOnEdge', () => {
 describe('canDragGroup', () => {
   const getMockGroupVizNode = (path: string, name: string, parentProcessorName?: string): IVisualizationNode => {
     const parentData = parentProcessorName
-      ? ({ processorName: parentProcessorName } as CamelRouteVisualEntityData)
+      ? ({ processorName: parentProcessorName } as unknown as IVisualizationNodeData)
       : undefined;
     return {
       id: 'group-1',

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -23,7 +23,11 @@ import { insertYamlComments } from '../../utils/yaml-comments';
 import { CatalogKind } from '../catalog-kind';
 import { BaseEntity, EntityType } from '../entities';
 import { BaseVisualEntityDefinition, BeansAwareResource, KaotoResource } from '../kaoto-resource';
-import { AddStepMode, BaseVisualCamelEntityConstructor } from '../visualization/base-visual-entity';
+import {
+  AddStepMode,
+  BaseVisualCamelEntityConstructor,
+  IVisualizationNodeData,
+} from '../visualization/base-visual-entity';
 import { CamelCatalogService, CamelRouteVisualEntity } from '../visualization/flows';
 import { CamelErrorHandlerVisualEntity } from '../visualization/flows/camel-error-handler-visual-entity';
 import { CamelInterceptFromVisualEntity } from '../visualization/flows/camel-intercept-from-visual-entity';
@@ -36,7 +40,6 @@ import { CamelRestVisualEntity } from '../visualization/flows/camel-rest-visual-
 import { CamelRouteConfigurationVisualEntity } from '../visualization/flows/camel-route-configuration-visual-entity';
 import { NonVisualEntity } from '../visualization/flows/non-visual-entity';
 import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
-import { CamelRouteVisualEntityData } from '../visualization/flows/support/camel-component-types';
 import { FlowTemplateService } from '../visualization/flows/support/flow-templates-service';
 import { BeansEntity, isBeans } from '../visualization/metadata';
 import { EntityOrderingService } from './entity-ordering.service';
@@ -271,7 +274,7 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
   /** Components Catalog related methods */
   getCompatibleComponents(
     mode: AddStepMode,
-    visualEntityData: CamelRouteVisualEntityData,
+    visualEntityData: IVisualizationNodeData,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter {

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -3,9 +3,8 @@ import { parse } from 'yaml';
 import { TileFilter } from '../../components/Catalog/Catalog.models';
 import { setValue } from '../../utils';
 import { RouteTemplateBeansAwareResource } from '../kaoto-resource';
-import { AddStepMode } from '../visualization/base-visual-entity';
+import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
-import { CamelRouteVisualEntityData } from '../visualization/flows/support/camel-component-types';
 import { FlowTemplateService } from '../visualization/flows/support/flow-templates-service';
 import {
   RouteTemplateBeansEntity,
@@ -78,7 +77,7 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
   /** Components Catalog related methods */
   getCompatibleComponents(
     mode: AddStepMode,
-    visualEntityData: CamelRouteVisualEntityData,
+    visualEntityData: IVisualizationNodeData,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter {

--- a/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/node-enrichment.service.test.ts
@@ -3,9 +3,8 @@ import type { MockInstance } from 'vitest';
 import { CatalogKind } from '../../../catalog-kind';
 import { EntityType } from '../../../entities';
 import { KaotoSchemaDefinition } from '../../../kaoto-schema';
-import { BaseVisualEntity, IVisualizationNode } from '../../base-visual-entity';
+import { BaseVisualEntity, IVisualizationNode, IVisualizationNodeData } from '../../base-visual-entity';
 import { createVisualizationNode } from '../../visualization-node';
-import { CamelRouteVisualEntityData } from '../support/camel-component-types';
 import { NodeEnrichmentService } from './node-enrichment.service';
 import { getIconRequest } from './resolvers/icon-resolver/getIconRequest';
 import { getTitleRequest } from './resolvers/title-resolver/getTitleRequest';
@@ -36,7 +35,7 @@ describe('NodeEnrichmentService', () => {
 
   const createMockVizNode = (
     fetchSchemaImpl?: () => Promise<KaotoSchemaDefinition['schema'] | undefined>,
-  ): IVisualizationNode<CamelRouteVisualEntityData> => {
+  ): IVisualizationNode<IVisualizationNodeData> => {
     const data = {
       name: 'log',
       description: 'Logs messages',
@@ -45,7 +44,7 @@ describe('NodeEnrichmentService', () => {
       isGroup: false,
       iconUrl: '',
       title: '',
-    } as unknown as CamelRouteVisualEntityData;
+    } as unknown as IVisualizationNodeData;
     const vizNode = createVisualizationNode('test-node', data);
 
     // Mock fetchSchema method
@@ -292,7 +291,7 @@ describe('NodeEnrichmentService', () => {
       title: '',
       description: '',
       primaryNodeId: { catalogKind: CatalogKind.Entity, name: 'route' },
-    } as unknown as CamelRouteVisualEntityData);
+    } as unknown as IVisualizationNodeData);
 
     vizNode.fetchSchema = vi.fn(async () => rootSchema);
 
@@ -326,7 +325,7 @@ describe('NodeEnrichmentService', () => {
       title: '',
       description: '',
       primaryNodeId: { catalogKind: CatalogKind.Pattern, name: 'log' },
-    } as unknown as CamelRouteVisualEntityData);
+    } as unknown as IVisualizationNodeData);
 
     vizNode.fetchSchema = vi.fn(async () => standardSchema);
 
@@ -402,7 +401,7 @@ describe('NodeEnrichmentService', () => {
         title: '',
         description: '',
         primaryNodeId: { catalogKind: CatalogKind.Entity, name: 'route' },
-      } as unknown as CamelRouteVisualEntityData);
+      } as unknown as IVisualizationNodeData);
 
       const child = createVisualizationNode('route.from.steps.0.log', {
         name: 'log',
@@ -413,7 +412,7 @@ describe('NodeEnrichmentService', () => {
         title: '',
         description: '',
         primaryNodeId: { catalogKind: CatalogKind.Pattern, name: 'log' },
-      } as unknown as CamelRouteVisualEntityData);
+      } as unknown as IVisualizationNodeData);
       child.fetchSchema = vi.fn(async () => mockSchema);
 
       const placeholder = createVisualizationNode('route.from.steps.1.placeholder', {
@@ -425,7 +424,7 @@ describe('NodeEnrichmentService', () => {
         title: '',
         description: '',
         primaryNodeId: { catalogKind: CatalogKind.Pattern, name: 'placeholder' },
-      } as unknown as CamelRouteVisualEntityData);
+      } as unknown as IVisualizationNodeData);
 
       root.addChild(child);
       root.addChild(placeholder);

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.ts
@@ -5,8 +5,7 @@ import {
   REST_ELEMENT_NAME,
   SPECIAL_PROCESSORS_PARENTS_MAP,
 } from '../../../special-processors.constants';
-import { AddStepMode } from '../../base-visual-entity';
-import { CamelRouteVisualEntityData } from './camel-component-types';
+import { AddStepMode, IVisualizationNodeData } from '../../base-visual-entity';
 
 export class CamelComponentFilterService {
   private static readonly SPECIAL_PROCESSORS = [
@@ -29,7 +28,7 @@ export class CamelComponentFilterService {
 
   static getCamelCompatibleComponents(
     mode: AddStepMode,
-    visualEntityData: CamelRouteVisualEntityData,
+    visualEntityData: IVisualizationNodeData,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter {
@@ -57,7 +56,7 @@ export class CamelComponentFilterService {
 
   static getKameletCompatibleComponents(
     mode: AddStepMode,
-    visualEntityData: CamelRouteVisualEntityData,
+    visualEntityData: IVisualizationNodeData,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     definition?: any,
   ): TileFilter {
@@ -80,10 +79,7 @@ export class CamelComponentFilterService {
     };
   }
 
-  private static replaceFilter(
-    mode: AddStepMode,
-    visualEntityData: CamelRouteVisualEntityData,
-  ): TileFilter | undefined {
+  private static replaceFilter(mode: AddStepMode, visualEntityData: IVisualizationNodeData): TileFilter | undefined {
     if (
       mode === AddStepMode.ReplaceStep &&
       (visualEntityData.path === 'route.from' || visualEntityData.path === 'template.from')
@@ -116,7 +112,7 @@ export class CamelComponentFilterService {
     return undefined;
   }
 
-  private static specialChildrenFilter(visualEntityData: CamelRouteVisualEntityData, definition: unknown): TileFilter {
+  private static specialChildrenFilter(visualEntityData: IVisualizationNodeData, definition: unknown): TileFilter {
     const processorName = visualEntityData.primaryNodeId?.name;
     if (!processorName || !(processorName in this.SPECIAL_PROCESSORS_PARENTS_MAP)) {
       return () => false;

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -2,7 +2,7 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary, ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
-import { DATAMAPPER_ID_PREFIX, XSLT_COMPONENT_NAME } from '../../../../utils';
+import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { ICamelComponentDefinition } from '../../../camel/camel-components-catalog';
 import { CatalogKind } from '../../../catalog-kind';
 import { IVisualizationNodeIds } from '../../base-visual-entity';
@@ -253,42 +253,6 @@ describe('CamelComponentSchemaService', () => {
         },
         uri: 'non-existing-component',
       });
-    });
-  });
-
-  describe('getCamelComponentLookup', () => {
-    it.each([
-      ['route', { from: { uri: 'timer' } }, { processorName: 'route' }],
-      ['intercept', { id: 'intercept-8888', steps: [] }, { processorName: 'intercept' }],
-      ['from', { uri: 'timer' }, { processorName: 'from', componentName: 'timer' }],
-      ['from.steps.0.to', { uri: 'log' }, { processorName: 'to', componentName: 'log' }],
-      ['from.steps.1.toD', { uri: 'log' }, { processorName: 'toD', componentName: 'log' }],
-      ['from.steps.2.poll', { uri: 'http://localhost:5173' }, { processorName: 'poll', componentName: 'http' }],
-      ['from.steps.0.to', 'log', { processorName: 'to', componentName: 'log' }],
-      ['from.steps.1.toD', 'log', { processorName: 'toD', componentName: 'log' }],
-      ['from.steps.1.poll', 'log', { processorName: 'poll', componentName: 'log' }],
-      ['from.steps.2.log', { message: 'Hello World' }, { processorName: 'log' }],
-      ['from.steps.3.choice', {}, { processorName: 'choice' }],
-      ['from.steps.3.choice.when.0', {}, { processorName: 'when' }],
-      ['from.steps.3.choice.otherwise', {}, { processorName: 'otherwise' }],
-      ['from.steps.3.choice.otherwise', undefined, { processorName: 'otherwise' }],
-      ['from.steps.0.step', undefined, { processorName: 'step' }],
-      ['from.steps.0.step', { id: 'step-1234' }, { processorName: 'step' }],
-      ['from.steps.0.step', { id: `${DATAMAPPER_ID_PREFIX}-1234`, steps: [] }, { processorName: 'step' }],
-      [
-        'from.steps.0.step',
-        { id: `modified-${DATAMAPPER_ID_PREFIX}-1234`, steps: [{ to: { uri: `${XSLT_COMPONENT_NAME}:mapping.xsl` } }] },
-        { processorName: 'step' },
-      ],
-      [
-        'from.steps.0.step',
-        { id: `${DATAMAPPER_ID_PREFIX}-1234`, steps: [{ to: { uri: `${XSLT_COMPONENT_NAME}:mapping.xsl` } }] },
-        { processorName: DATAMAPPER_ID_PREFIX },
-      ],
-    ])('should return the processor and component name for %s', (path, definition, result) => {
-      const camelElementLookup = CamelComponentSchemaService.getCamelComponentLookup(path, definition);
-
-      expect(camelElementLookup).toEqual(result);
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -1,8 +1,7 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
-import { isDefined } from '@kaoto/forms';
 import { cloneDeep } from 'lodash';
 
-import { CamelUriHelper, DATAMAPPER_ID_PREFIX, isDataMapperNode, ParsedParameters } from '../../../../utils';
+import { CamelUriHelper, DATAMAPPER_ID_PREFIX, ParsedParameters } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
 import { KaotoSchemaDefinition } from '../../../kaoto-schema';
 import { REST_DSL_VERBS } from '../../../special-processors.constants';
@@ -80,30 +79,6 @@ export class CamelComponentSchemaService {
     removeHeaders: 'pattern',
     kamelet: 'name',
   };
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static getCamelComponentLookup(path: string, definition: any): ICamelElementLookupResult {
-    const splitPath = path.split('.');
-    const lastPathSegment = splitPath[splitPath.length - 1];
-    const pathAsIndex = Number.parseInt(lastPathSegment, 10);
-
-    /**
-     * If the last path segment is NaN, it means this is a Camel Processor
-     * for instance, `from`, `otherwise` or `to` properties in a Route
-     * and we can just return the path as the name of the component
-     */
-    if (Number.isNaN(pathAsIndex)) {
-      return this.getCamelElement(lastPathSegment as keyof ProcessorDefinition, definition);
-    }
-
-    /**
-     * The last path segment is a number, it means is an array of objects
-     * and we need to look for the previous path segment to get the name of the processor
-     * for instance, a `when` property in a `Choice` processor
-     */
-    const previousPathSegment = splitPath[splitPath.length - 2];
-    return this.getCamelElement(previousPathSegment as keyof ProcessorDefinition, definition);
-  }
 
   static canHavePreviousStep(processorName: keyof ProcessorDefinition): boolean {
     return !this.DISABLED_SIBLING_STEPS.includes(processorName);
@@ -310,51 +285,6 @@ export class CamelComponentSchemaService {
 
     const queryParams = CamelUriHelper.getParametersFromQueryString(query);
     return { uri: componentName, parameters: { ...pathParams, ...queryParams } };
-  }
-
-  /**
-   * If the processor is a `from` or `to` processor, we need to extract the component name from the uri property
-   * and return both the processor name and the underlying component name to build the combined schema
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private static getCamelElement(processorName: keyof ProcessorDefinition, definition: any): ICamelElementLookupResult {
-    if (!isDefined(definition)) {
-      return { processorName };
-    }
-
-    if (processorName === 'step' && isDataMapperNode(definition)) {
-      return {
-        processorName: DATAMAPPER_ID_PREFIX,
-      };
-    }
-
-    switch (processorName) {
-      case 'from' as keyof ProcessorDefinition:
-        return {
-          processorName,
-          componentName: this.getComponentNameFromUri(definition?.uri),
-        };
-
-      case 'to':
-      case 'toD':
-      case 'poll':
-        /** The To processor is using `to: timer:tick?period=1000` form */
-        if (typeof definition === 'string') {
-          return {
-            processorName,
-            componentName: this.getComponentNameFromUri(definition),
-          };
-        }
-
-        /** The To processor is using `to: { uri: 'timer:tick?period=1000' }` form */
-        return {
-          processorName,
-          componentName: this.getComponentNameFromUri(definition?.uri),
-        };
-
-      default:
-        return { processorName };
-    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
…deData

Delete getCamelElement and getCamelComponentLookup
Move some instances from the deprecated CamelRouteVisualEntityData to IVisualizationNodeData

fix: https://github.com/KaotoIO/kaoto/issues/3685