### PR TITLE
refactor(ExpressionField): migrate expression service to async DynamicCatalogRegistry

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
@@ -7,8 +7,11 @@ import {
   SchemaProvider,
 } from '@kaoto/forms';
 import { KaotoFormPageObject } from '@kaoto/forms/testing';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CamelLanguageProvider } from '../../../../../../dynamic-catalog/providers/camel-components.provider';
 import { CamelCatalogService, CatalogKind } from '../../../../../../models';
 import { setHeaderExpressionSchema } from '../../../../../../stubs/expression-definition-schema';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
@@ -19,9 +22,17 @@ describe('ExpressionField', () => {
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     CamelCatalogService.setCatalogKey(CatalogKind.Language, catalogsMap.languageCatalog);
+    DynamicCatalogRegistry.get().setCatalog(
+      CatalogKind.Language,
+      new DynamicCatalog(new CamelLanguageProvider(catalogsMap.languageCatalog)),
+    );
   });
 
-  it('renders empty expression field with schema', () => {
+  afterEach(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
+  });
+
+  it('renders empty expression field with schema', async () => {
     const { container } = render(
       <ModelContextProvider model={{ id: 'setHeader-1361' }} onPropertyChange={vi.fn()}>
         <SchemaProvider schema={setHeaderExpressionSchema}>
@@ -30,10 +41,15 @@ describe('ExpressionField', () => {
       </ModelContextProvider>,
     );
 
+    // Wait for the async parseExpressionModel effect to resolve
+    await waitFor(() => {
+      expect(container.firstChild).not.toBeNull();
+    });
+
     expect(container).toMatchSnapshot();
   });
 
-  it('renders expression field with selection', () => {
+  it('renders expression field with selection', async () => {
     const { container } = render(
       <FormComponentFactoryProvider>
         <ModelContextProvider
@@ -53,6 +69,11 @@ describe('ExpressionField', () => {
         </ModelContextProvider>
       </FormComponentFactoryProvider>,
     );
+
+    // Wait for the async parseExpressionModel effect to resolve
+    await waitFor(() => {
+      expect(container.firstChild).not.toBeNull();
+    });
 
     expect(container).toMatchSnapshot();
   });
@@ -79,6 +100,8 @@ describe('ExpressionField', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
+    // Wait for the async parseExpressionModel effect to populate the expression field
+    await screen.findByTestId(`${ROOT_PATH}__expression-list-typeahead-select-input`);
     await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
     await formPageObject.selectTypeaheadItem('csimple');
 
@@ -113,6 +136,8 @@ describe('ExpressionField', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
+    // Wait for the async parseExpressionModel effect to populate the expression field
+    await waitFor(() => formPageObject.getFieldByDisplayName('Expression'));
     await formPageObject.inputText('Expression', '');
 
     expect(onPropertyChangeSpy).toHaveBeenCalled();
@@ -147,6 +172,8 @@ describe('ExpressionField', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
+    // Wait for the async parseExpressionModel effect to populate the expression field
+    await screen.findByTestId(`${ROOT_PATH}__expression-list-typeahead-select-input`);
     await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
     await formPageObject.selectTypeaheadItem('csimple');
 
@@ -174,8 +201,13 @@ describe('ExpressionField', () => {
       </ModelContextProvider>,
     );
 
-    const clearButton = screen.getByTestId(`#__expression-list__clear`);
-    fireEvent.click(clearButton);
+    // Wait for the async parseExpressionModel effect to populate the expression list
+    const clearButton = await screen.findByTestId(`#__expression-list__clear`);
+    // Use act to flush the async onExpressionChange handler
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      fireEvent.click(clearButton);
+    });
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, { id: 'setHeader-1891' });
@@ -184,7 +216,7 @@ describe('ExpressionField', () => {
   it('should update the model with `undefined` when the model is empty after clearing the expression', async () => {
     const onPropertyChangeSpy = vi.fn();
 
-    const wrapper = render(
+    const { findByTestId } = render(
       <ModelContextProvider
         model={{
           expression: {
@@ -199,9 +231,14 @@ describe('ExpressionField', () => {
       </ModelContextProvider>,
     );
 
-    const clearButton = wrapper.getByTestId(`#__expression-list__clear`);
+    // Wait for the async parseExpressionModel effect to populate the expression list
+    const clearButton = await findByTestId(`#__expression-list__clear`);
 
-    fireEvent.click(clearButton);
+    // Use act to flush the async onExpressionChange handler
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      fireEvent.click(clearButton);
+    });
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
@@ -16,6 +16,7 @@ import { CamelCatalogService, CatalogKind } from '../../../../../../models';
 import { setHeaderExpressionSchema } from '../../../../../../stubs/expression-definition-schema';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
 import { ROOT_PATH } from '../../../../../../utils';
+import { ExpressionService } from './expression.service';
 import { ExpressionField } from './ExpressionField';
 
 describe('ExpressionField', () => {
@@ -242,5 +243,27 @@ describe('ExpressionField', () => {
 
     expect(onPropertyChangeSpy).toHaveBeenCalledTimes(1);
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);
+  });
+
+  it('should show the error boundary fallback when parseExpressionModel rejects', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(ExpressionService, 'parseExpressionModel').mockRejectedValue(new Error('catalog unavailable'));
+
+    render(
+      <ModelContextProvider model={{ id: 'setHeader-1361' }} onPropertyChange={vi.fn()}>
+        <SchemaProvider schema={setHeaderExpressionSchema}>
+          <ExpressionField propName={ROOT_PATH} required />
+        </SchemaProvider>
+      </ModelContextProvider>,
+    );
+
+    expect(await screen.findByText('Expression editor is unavailable')).toBeInTheDocument();
+    const expandableButton = await screen.findByLabelText('Show more');
+    expect(expandableButton).toBeInTheDocument();
+
+    fireEvent.click(expandableButton);
+    expect(await screen.findByText('catalog unavailable')).toBeInTheDocument();
+
+    vi.restoreAllMocks();
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
@@ -1,3 +1,4 @@
+import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
 import {
   FieldProps,
   FieldWrapper,
@@ -7,7 +8,7 @@ import {
   useFieldValue,
 } from '@kaoto/forms';
 import { isEmpty } from 'lodash';
-import { FunctionComponent, useContext, useMemo } from 'react';
+import { FunctionComponent, useContext, useEffect, useMemo, useState } from 'react';
 
 import { ROOT_PATH, setValue } from '../../../../../../utils';
 import { ExpressionService } from './expression.service';
@@ -34,13 +35,42 @@ export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, requi
   const { value: originalModel, onChange } = useFieldValue<Record<string, unknown>>(propName);
 
   const isRootExpression = schema.format === 'expression';
-  const parsedModel = ExpressionService.parseExpressionModel(originalModel);
+  const [parsedModel, setParsedModel] = useState<ExpressionDefinition | undefined>(undefined);
+  /**
+   * Whether the first async `parseExpressionModel` has resolved. `ExpressionFieldInner` relies on
+   * `useOneOfField`, which latches its selected schema from the model on its mount render only.
+   * Mounting it before the model is parsed would latch an empty selection that never recovers, so
+   * we hold rendering until the initial parse completes. The flag stays `true` afterwards so later
+   * `originalModel` changes re-parse without remounting (and thus without dropping the selection).
+   */
+  const [isModelParsed, setIsModelParsed] = useState(false);
   const expressionsSchema = useMemo(() => ExpressionService.getExpressionsSchema(schema), [schema]);
 
-  const onExpressionChange = (propName: string, model: unknown) => {
+  useEffect(() => {
+    let cancelled = false;
+    ExpressionService.parseExpressionModel(originalModel)
+      .then((model) => {
+        if (!cancelled) {
+          setParsedModel(model);
+          setIsModelParsed(true);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to parse expression model:', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [originalModel]);
+
+  if (!isModelParsed) {
+    return null;
+  }
+
+  const onExpressionChange = async (propName: string, model: unknown) => {
     let localValue = parsedModel ?? {};
 
-    ExpressionService.updateExpressionFromModel(parsedModel, model as Record<string, unknown>);
+    await ExpressionService.updateExpressionFromModel(parsedModel, model as Record<string, unknown>);
     let updatedValue = model;
     if (typeof model === 'string' && model.trim() === '') {
       updatedValue = undefined;

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
@@ -11,6 +11,7 @@ import { isEmpty } from 'lodash';
 import { FunctionComponent, useContext, useEffect, useMemo, useState } from 'react';
 
 import { ROOT_PATH, setValue } from '../../../../../../utils';
+import { ErrorBoundary } from '../../../../../ErrorBoundary';
 import { ExpressionService } from './expression.service';
 import { ExpressionFieldInner } from './ExpressionFieldInner';
 
@@ -30,11 +31,12 @@ import { ExpressionFieldInner } from './ExpressionFieldInner';
  * - ObjectField -> property resolution -> FormComponentFactoryProvider -> ExpressionField
  * this brings an entire schema with a `anyOf` array where the languages are specified.
  */
-export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, required }) => {
+const ExpressionFieldImpl: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema } = useContext(SchemaContext);
   const { value: originalModel, onChange } = useFieldValue<Record<string, unknown>>(propName);
 
   const isRootExpression = schema.format === 'expression';
+  const [parseError, setParseError] = useState<Error | undefined>(undefined);
   const [parsedModel, setParsedModel] = useState<ExpressionDefinition | undefined>(undefined);
   /**
    * Whether the first async `parseExpressionModel` has resolved. `ExpressionFieldInner` relies on
@@ -55,13 +57,17 @@ export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, requi
           setIsModelParsed(true);
         }
       })
-      .catch((error) => {
-        console.error('Failed to parse expression model:', error);
+      .catch((error: Error) => {
+        if (!cancelled) setParseError(error);
       });
     return () => {
       cancelled = true;
     };
   }, [originalModel]);
+
+  if (parseError) {
+    throw parseError;
+  }
 
   if (!isModelParsed) {
     return null;
@@ -111,3 +117,9 @@ export const ExpressionField: FunctionComponent<FieldProps> = ({ propName, requi
     </FieldWrapper>
   );
 };
+
+export const ExpressionField: FunctionComponent<FieldProps> = (props) => (
+  <ErrorBoundary fallback={<p>Expression editor is unavailable</p>}>
+    <ExpressionFieldImpl {...props} />
+  </ErrorBoundary>
+);

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.test.ts
@@ -1,6 +1,8 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
+import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CamelCatalogService, CatalogKind, KaotoSchemaDefinition } from '../../../../../../models';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
 import { ExpressionService } from './expression.service';
@@ -9,7 +11,14 @@ describe('ExpressionService', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     const languageCatalog = catalogsMap.languageCatalog;
-    CamelCatalogService.setCatalogKey(CatalogKind.Language, languageCatalog);
+
+    // Set up DynamicCatalogRegistry with a catalog backed by the language catalog map
+    const mockProvider = {
+      id: 'language-mock',
+      fetch: async (key: string) => languageCatalog[key],
+      fetchAll: async () => languageCatalog,
+    };
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Language, new DynamicCatalog(mockProvider));
   });
 
   describe('getExpressionsSchema', () => {
@@ -189,8 +198,8 @@ describe('ExpressionService', () => {
     ],
   ];
 
-  it.each(expressionsArray)('should parse %s', (parentModel, expected) => {
-    const result = ExpressionService.parseExpressionModel(parentModel);
+  it.each(expressionsArray)('should parse %s', async (parentModel, expected) => {
+    const result = await ExpressionService.parseExpressionModel(parentModel);
 
     expect(result).toEqual(expected);
   });
@@ -201,20 +210,20 @@ describe('ExpressionService', () => {
       CamelCatalogService.setCatalogKey(CatalogKind.Language, languageCatalog);
     });
 
-    it('should update the target model expression if supported', () => {
+    it('should update the target model expression if supported', async () => {
       const sourceModel = { simple: { expression: 'sourceExpr' } };
       const targetModel = { csimple: { expression: undefined } };
 
-      ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
+      await ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
 
       expect(targetModel.csimple.expression).toBe('sourceExpr');
     });
 
-    it('should not update the target model if language does not support expression', () => {
+    it('should not update the target model if language does not support expression', async () => {
       const sourceModel = { simple: { expression: 'sourceExpr' } };
       const targetModel = { bean: { expression: undefined } };
 
-      ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
+      await ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
 
       expect(targetModel.bean.expression).toBeUndefined();
     });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
@@ -1,6 +1,7 @@
 import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { KaotoSchemaDefinition } from '../../../../../../models/kaoto-schema';
 import { CamelCatalogService } from '../../../../../../models/visualization/flows/camel-catalog.service';
@@ -64,7 +65,7 @@ export class ExpressionService {
    * </ul>
    * @param parentModel The parent step model object which has expression as its parameter. For example `setBody` contents.
    * */
-  static parseExpressionModel(parentModel?: Record<string, unknown>): ExpressionDefinition | undefined {
+  static async parseExpressionModel(parentModel?: Record<string, unknown>): Promise<ExpressionDefinition | undefined> {
     if (!isDefined(parentModel)) {
       return undefined;
     }
@@ -78,7 +79,7 @@ export class ExpressionService {
       return { ...model, ...parsedModel };
     }
 
-    const languageNames = this.getLanguageNames();
+    const languageNames = await this.getLanguageNames();
     return Object.entries(parentModel).reduce((acc, [key, value]) => {
       if (languageNames.includes(key)) {
         acc[key] = this.parseLanguageModel({ [key]: value }, key)[key];
@@ -90,12 +91,8 @@ export class ExpressionService {
     }, {} as ExpressionDefinition);
   }
 
-  private static getLanguageNames(): string[] {
-    const languageCatalogMap = CamelCatalogService.getLanguageMap();
-
-    if (Object.keys(languageCatalogMap).length === 0) {
-      throw new Error('Language catalog is not initialized');
-    }
+  private static async getLanguageNames(): Promise<string[]> {
+    const languageCatalogMap = (await DynamicCatalogRegistry.get().getCatalog(CatalogKind.Language)?.getAll()) ?? {};
 
     return Object.values(languageCatalogMap).map((lang) => lang.model.name);
   }
@@ -118,14 +115,14 @@ export class ExpressionService {
     }
   }
 
-  static updateExpressionFromModel(
+  static async updateExpressionFromModel(
     sourceModel: Record<string, unknown> | undefined,
     targetModel: Record<string, unknown>,
-  ): void {
+  ): Promise<void> {
     if (!isDefined(sourceModel) || !isDefined(targetModel)) {
       return;
     }
-    const languageNames = this.getLanguageNames();
+    const languageNames = await this.getLanguageNames();
     const sourceKey = Object.keys(sourceModel).find((key) => languageNames.includes(key));
     const sourceExpressionString = sourceKey
       ? (sourceModel[sourceKey] as Record<string, unknown>)?.expression

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
@@ -4,7 +4,6 @@ import { isDefined } from '@kaoto/forms';
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { KaotoSchemaDefinition } from '../../../../../../models/kaoto-schema';
-import { CamelCatalogService } from '../../../../../../models/visualization/flows/camel-catalog.service';
 
 export class ExpressionService {
   static getExpressionsSchema(schema: KaotoSchemaDefinition['schema']): KaotoSchemaDefinition['schema'] {
@@ -130,10 +129,12 @@ export class ExpressionService {
 
     if (typeof sourceExpressionString === 'string') {
       const targetKey = Object.keys(targetModel).find((key) => languageNames.includes(key));
-      const exprModel = CamelCatalogService.getComponent(CatalogKind.Language, targetKey)?.properties;
-
-      if (targetKey && isDefined(exprModel) && 'expression' in exprModel) {
-        (targetModel[targetKey] as Record<string, unknown>).expression = sourceExpressionString;
+      if (targetKey) {
+        const exprModel =
+          (await DynamicCatalogRegistry.get().getEntity(CatalogKind.Language, targetKey))?.properties ?? {};
+        if (isDefined(exprModel) && 'expression' in exprModel) {
+          (targetModel[targetKey] as Record<string, unknown>).expression = sourceExpressionString;
+        }
       }
     }
   }

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
@@ -115,7 +115,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('Choice');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue(undefined);
 
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
@@ -144,7 +144,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('Choice');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue(undefined);
 
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
@@ -167,7 +167,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('Choice');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue('Some validation warning');
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue('Some validation warning');
 
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
@@ -190,7 +190,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('when-setHeader');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue(undefined);
 
     vi.spyOn(element, 'getData').mockReturnValue({ vizNode });
     vi.spyOn(element, 'getAllNodeChildren').mockReturnValue([]);
@@ -222,7 +222,7 @@ describe('CustomGroupExpanded', () => {
     }) as IVisualizationNode;
     vi.spyOn(groupVizNode, 'getNodeLabel').mockReturnValue('Choice');
     vi.spyOn(groupVizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(groupVizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(groupVizNode, 'getNodeValidationText').mockResolvedValue(undefined);
 
     const draggedVizNode = createVisualizationNode('when-0', {
       name: 'when',

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.tsx
@@ -46,6 +46,7 @@ import {
   NODE_DRAG_TYPE,
 } from '../customComponentUtils';
 import { FloatingCircle } from '../FloatingCircle/FloatingCircle';
+import { useNodeValidationText } from '../hooks/use-node-validation-text.hook';
 import { CustomNodeContainer } from '../Node/CustomNodeContainer';
 import {
   checkNodeDropCompatibility,
@@ -73,7 +74,7 @@ export const CustomGroupExpandedInner: FunctionComponent<CustomGroupProps> = obs
     const ProcessorIcon = getProcessorIcon(processorName);
     const processorDescription = groupVizNode?.data?.processorIconTooltip ?? '';
     const isDisabled = !!groupVizNode?.getNodeDefinition()?.disabled;
-    const validationText = groupVizNode?.getNodeValidationText();
+    const validationText = useNodeValidationText(groupVizNode);
     const doesHaveWarnings = !isDisabled && !!validationText;
     const { childCount, hasGroupChildren } = getVizNodeChildrenInfo(groupVizNode);
     const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.test.tsx
@@ -84,7 +84,7 @@ describe('CustomNode', () => {
     }) as IVisualizationNode;
     vi.spyOn(vizNode, 'getNodeLabel').mockReturnValue('log');
     vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue(undefined);
-    vi.spyOn(vizNode, 'getNodeValidationText').mockReturnValue(undefined);
+    vi.spyOn(vizNode, 'getNodeValidationText').mockResolvedValue(undefined);
     vi.spyOn(vizNode, 'canDragNode').mockReturnValue(false);
     vi.spyOn(vizNode, 'canDropOnNode').mockReturnValue(false);
 

--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNode.tsx
@@ -40,6 +40,7 @@ import { CanvasNode } from '../../Canvas/canvas.models';
 import { StepToolbar } from '../../Canvas/StepToolbar/StepToolbar';
 import { NodeContextMenuFn } from '../ContextMenu/NodeContextMenu';
 import { getDropTargetContainerClassNames, GROUP_DRAG_TYPE, NODE_DRAG_TYPE } from '../customComponentUtils';
+import { useNodeValidationText } from '../hooks/use-node-validation-text.hook';
 import { TargetAnchor } from '../target-anchor';
 import { CustomNodeContainer } from './CustomNodeContainer';
 import { CustomNodeLabel } from './CustomNodeLabel';
@@ -87,7 +88,7 @@ const CustomNodeInner: FunctionComponent<CustomNodeProps> = observer(
     const ProcessorIcon = processorName ? getProcessorIcon(processorName as keyof ProcessorDefinition) : null;
     const processorDescription = vizNode?.data.processorIconTooltip ?? '';
     const isDisabled = !!vizNode?.getNodeDefinition()?.disabled;
-    const validationText = vizNode?.getNodeValidationText();
+    const validationText = useNodeValidationText(vizNode);
     const doesHaveWarnings = !isDisabled && !!validationText;
     const [isGHover, gHoverRef] = useHover<SVGGElement>(CanvasDefaults.HOVER_DELAY_IN, CanvasDefaults.HOVER_DELAY_OUT);
     const [isToolbarHover, toolbarHoverRef] = useHover<SVGForeignObjectElement>(

--- a/packages/ui/src/components/Visualization/Custom/Node/TopologyNode.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Node/TopologyNode.tsx
@@ -6,6 +6,7 @@ import { IVisualizationNode } from '../../../../models/visualization/base-visual
 import { getProcessorIcon } from '../../../../utils/processor-icon';
 import { CanvasDefaults } from '../../Canvas/canvas.defaults';
 import { CanvasNode } from '../../Canvas/canvas.models';
+import { useNodeValidationText } from '../hooks/use-node-validation-text.hook';
 import { TopologySourceAnchor, TopologyTargetAnchor } from '../topology-anchor';
 import { CustomNodeContainer } from './CustomNodeContainer';
 import { CustomNodeLabel } from './CustomNodeLabel';
@@ -29,6 +30,7 @@ export const TopologyNode: FunctionComponent<TopologyRouteNodeProps> = observer(
   );
 
   const vizNode: IVisualizationNode | undefined = element.getData()?.vizNode;
+  const validationText = useNodeValidationText(vizNode);
   if (!vizNode) {
     return null;
   }
@@ -41,7 +43,6 @@ export const TopologyNode: FunctionComponent<TopologyRouteNodeProps> = observer(
   const bounds = element.getBounds();
   const width = bounds.width;
   const isDisabled = !!vizNode?.getNodeDefinition()?.disabled;
-  const validationText = vizNode?.getNodeValidationText();
   const doesHaveWarnings = !isDisabled && !!validationText;
   const labelX = (width - CanvasDefaults.DEFAULT_LABEL_WIDTH) / 2;
 

--- a/packages/ui/src/components/Visualization/Custom/hooks/use-node-validation-text.hook.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/hooks/use-node-validation-text.hook.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { IVisualizationNode } from '../../../../models';
+import { useNodeValidationText } from './use-node-validation-text.hook';
+
+interface FakeNode {
+  lastUpdate: number;
+  getNodeValidationText: ReturnType<typeof vi.fn>;
+}
+
+const createNode = (text: string | undefined): FakeNode => ({
+  lastUpdate: 0,
+  getNodeValidationText: vi.fn().mockResolvedValue(text),
+});
+
+describe('useNodeValidationText', () => {
+  it('should return undefined before the async validation resolves', () => {
+    const node = createNode('Some warning');
+    const { result } = renderHook(() => useNodeValidationText(node as unknown as IVisualizationNode));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return the resolved validation text', async () => {
+    const node = createNode('Some warning');
+    const { result } = renderHook(() => useNodeValidationText(node as unknown as IVisualizationNode));
+
+    await waitFor(() => {
+      expect(result.current).toBe('Some warning');
+    });
+  });
+
+  it('should re-resolve when the node is edited in place (lastUpdate changes)', async () => {
+    const node = createNode(undefined);
+    const { result, rerender } = renderHook(() => useNodeValidationText(node as unknown as IVisualizationNode));
+
+    await waitFor(() => {
+      expect(node.getNodeValidationText).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current).toBeUndefined();
+
+    // Simulate an in-place edit: same node reference, new validation result, bumped lastUpdate.
+    node.getNodeValidationText.mockResolvedValue('Now invalid');
+    node.lastUpdate = 1;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current).toBe('Now invalid');
+    });
+    expect(node.getNodeValidationText).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return undefined when no node is provided', () => {
+    const { result } = renderHook(() => useNodeValidationText());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should log and not throw when validation rejects', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const node = createNode(undefined);
+    node.getNodeValidationText.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useNodeValidationText(node as unknown as IVisualizationNode));
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to get node validation text:', expect.any(Error));
+    });
+    expect(result.current).toBeUndefined();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/components/Visualization/Custom/hooks/use-node-validation-text.hook.ts
+++ b/packages/ui/src/components/Visualization/Custom/hooks/use-node-validation-text.hook.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+import { IVisualizationNode } from '../../../../models';
+
+/**
+ * Resolves the validation text for a node via the async `getNodeValidationText` API.
+ *
+ * The node's validation depends on its current definition, which is mutated in place on edits while
+ * bumping `lastUpdate`. Keying the effect on `lastUpdate` (in addition to the node itself) ensures the
+ * validation text is recomputed whenever the node changes, not only when a different node is provided.
+ *
+ * @param vizNode The visualization node to validate.
+ * @returns The validation text, or `undefined` while it resolves or when there is nothing to report.
+ */
+export const useNodeValidationText = (vizNode?: IVisualizationNode): string | undefined => {
+  const [validationText, setValidationText] = useState<string | undefined>(undefined);
+  const lastUpdate = vizNode?.lastUpdate;
+
+  useEffect(() => {
+    let cancelled = false;
+    setValidationText(undefined);
+    vizNode
+      ?.getNodeValidationText()
+      .then((text) => {
+        if (!cancelled) setValidationText(text);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error('Failed to get node validation text:', error);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // `lastUpdate` is intentionally included so the text re-resolves when the node is edited in place.
+  }, [vizNode, lastUpdate]);
+
+  return validationText;
+};

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -81,7 +81,7 @@ export interface BaseVisualEntity extends BaseEntity {
     path?: string,
     schema?: KaotoSchemaDefinition['schema'],
     ids?: IVisualizationNodeIds,
-  ): string | undefined;
+  ): Promise<string | undefined>;
 
   /** Generates a IVisualizationNode from the underlying Camel entity */
   toVizNode: () => Promise<IVisualizationNode>;
@@ -163,7 +163,7 @@ export interface IVisualizationNode<T extends IVisualizationNodeData = IVisualiz
   removeChild(): void;
 
   /** Retrieve the node's validation status, relying into the underlying entity */
-  getNodeValidationText(): string | undefined;
+  getNodeValidationText(): Promise<string | undefined>;
 }
 
 /**

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -147,14 +147,14 @@ describe('AbstractCamelVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return an `undefined` if the path is `undefined`', () => {
-      const result = abstractVisualEntity.getNodeValidationText(undefined);
+    it('should return an `undefined` if the path is `undefined`', async () => {
+      const result = await abstractVisualEntity.getNodeValidationText(undefined);
 
       expect(result).toBeUndefined();
     });
 
-    it('should return an `undefined` if the path is empty', () => {
-      const result = abstractVisualEntity.getNodeValidationText('');
+    it('should return an `undefined` if the path is empty', async () => {
+      const result = await abstractVisualEntity.getNodeValidationText('');
 
       expect(result).toBeUndefined();
     });
@@ -168,7 +168,7 @@ describe('AbstractCamelVisualEntity', () => {
         primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
         secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
       });
-      const result = abstractVisualEntity.getNodeValidationText('route.from', schema, fromStepIds);
+      const result = await abstractVisualEntity.getNodeValidationText('route.from', schema, fromStepIds);
 
       expect(result).toBe('2 required parameters are not yet configured: [ uri,timerName ]');
     });

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -281,15 +281,15 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     };
   }
 
-  getNodeValidationText(
+  async getNodeValidationText(
     path?: string | undefined,
     schema?: KaotoSchemaDefinition['schema'],
     ids?: IVisualizationNodeIds,
-  ): string | undefined {
+  ): Promise<string | undefined> {
     const definition = this.getNodeDefinition(path, ids);
     if (!schema || !definition) return undefined;
 
-    return ModelValidationService.validateNodeStatus(schema, definition);
+    return await ModelValidationService.validateNodeStatus(schema, definition);
   }
 
   async toVizNode(): Promise<IVisualizationNode> {

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
@@ -3,26 +3,17 @@ import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { ICamelComponentDefinition } from '../../camel/camel-components-catalog';
-import { ICamelDataformatDefinition } from '../../camel/camel-dataformats-catalog';
-import { ICamelLanguageDefinition } from '../../camel/camel-languages-catalog';
-import { ICamelLoadBalancerDefinition } from '../../camel/camel-loadbalancers-catalog';
 import { IKameletDefinition } from '../../camel/kamelets-catalog';
 import { CatalogKind } from '../../catalog-kind';
 import { CamelCatalogService } from './camel-catalog.service';
 
 describe('CamelCatalogService', () => {
   let componentCatalogMap: Record<string, ICamelComponentDefinition>;
-  let dataformatsCatalogMap: Record<string, ICamelDataformatDefinition>;
-  let languagesCatalogMap: Record<string, ICamelLanguageDefinition>;
-  let loadbalancersMap: Record<string, ICamelLoadBalancerDefinition>;
   let kameletCatalogMap: Record<string, IKameletDefinition>;
 
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     componentCatalogMap = catalogsMap.componentCatalogMap;
-    dataformatsCatalogMap = catalogsMap.dataformatCatalog;
-    languagesCatalogMap = catalogsMap.languageCatalog;
-    loadbalancersMap = catalogsMap.loadbalancerCatalog;
     kameletCatalogMap = catalogsMap.kameletsCatalogMap;
     CamelCatalogService.setCatalogKey(CatalogKind.Component, catalogsMap.componentCatalogMap);
   });
@@ -43,57 +34,6 @@ describe('CamelCatalogService', () => {
       const component = CamelCatalogService.getComponent(CatalogKind.Component);
 
       expect(component).toBeUndefined();
-    });
-  });
-
-  describe('getLanguageMap', () => {
-    it('should return an empty object if there is no language map', () => {
-      const map = CamelCatalogService.getLanguageMap();
-      expect(map).toEqual({});
-    });
-
-    it('should return a language map', () => {
-      CamelCatalogService.setCatalogKey(
-        CatalogKind.Language,
-        languagesCatalogMap as unknown as Record<string, ICamelLanguageDefinition>,
-      );
-
-      const map = CamelCatalogService.getLanguageMap();
-      expect(map).toEqual(languagesCatalogMap);
-    });
-  });
-
-  describe('getDataFormatMap', () => {
-    it('should return an empty object if there is no data format map', () => {
-      const map = CamelCatalogService.getDataFormatMap();
-      expect(map).toEqual({});
-    });
-
-    it('should return a data format map', () => {
-      CamelCatalogService.setCatalogKey(
-        CatalogKind.Dataformat,
-        dataformatsCatalogMap as unknown as Record<string, ICamelLanguageDefinition>,
-      );
-
-      const map = CamelCatalogService.getDataFormatMap();
-      expect(map).toEqual(dataformatsCatalogMap);
-    });
-  });
-
-  describe('getLoadBalancerMap', () => {
-    it('should return an empty object if there is no load balancer map', () => {
-      const map = CamelCatalogService.getLoadBalancerMap();
-      expect(map).toEqual({});
-    });
-
-    it('should return a load balancer map', () => {
-      CamelCatalogService.setCatalogKey(
-        CatalogKind.Loadbalancer,
-        loadbalancersMap as unknown as Record<string, ICamelLanguageDefinition>,
-      );
-
-      const map = CamelCatalogService.getLoadBalancerMap();
-      expect(map).toEqual(loadbalancersMap);
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
@@ -69,18 +69,6 @@ export class CamelCatalogService {
     return this.catalogs[catalogKey]?.[componentName];
   }
 
-  static getLanguageMap(): Record<string, ICamelLanguageDefinition> {
-    return this.catalogs[CatalogKind.Language] || {};
-  }
-
-  static getDataFormatMap(): Record<string, ICamelDataformatDefinition> {
-    return this.catalogs[CatalogKind.Dataformat] || {};
-  }
-
-  static getLoadBalancerMap(): Record<string, ICamelLoadBalancerDefinition> {
-    return this.catalogs[CatalogKind.Loadbalancer] || {};
-  }
-
   /**
    * Public only as a convenience method for test
    * not meant to be used in production code

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.test.ts
@@ -152,10 +152,10 @@ describe('CamelErrorHandlerVisualEntity', () => {
     });
   });
 
-  it('should return undefined validation text', () => {
+  it('should return undefined validation text', async () => {
     const entity = new CamelErrorHandlerVisualEntity(errorHandlerDef);
 
-    expect(entity.getNodeValidationText()).toBeUndefined();
+    expect(await entity.getNodeValidationText()).toBeUndefined();
   });
 
   it('toVizNode should return visualization node', async () => {

--- a/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-error-handler-visual-entity.ts
@@ -154,7 +154,7 @@ export class CamelErrorHandlerVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(): string | undefined {
+  async getNodeValidationText(): Promise<string | undefined> {
     return undefined;
   }
 

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.test.ts
@@ -93,13 +93,13 @@ describe('CamelInterceptFromVisualEntity', () => {
     });
   });
 
-  it('should delegate the validation text to the ModelValidationService', () => {
-    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus');
+  it('should delegate the validation text to the ModelValidationService', async () => {
+    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus').mockResolvedValue('');
 
     const interceptFromVisualEntity = new CamelInterceptFromVisualEntity({
       interceptFrom: { id: 'id', uri: 'direct:a-reference' },
     });
-    interceptFromVisualEntity.getNodeValidationText('interceptFrom', { type: 'object', properties: {} });
+    await interceptFromVisualEntity.getNodeValidationText('interceptFrom', { type: 'object', properties: {} });
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.test.ts
@@ -92,13 +92,13 @@ describe('CamelInterceptSendToEndpointVisualEntity', () => {
     });
   });
 
-  it('should delegate the validation text to the ModelValidationService', () => {
-    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus');
+  it('should delegate the validation text to the ModelValidationService', async () => {
+    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus').mockResolvedValue('');
 
     const interceptSendToEndpointVisualEntity = new CamelInterceptSendToEndpointVisualEntity({
       interceptSendToEndpoint: { id: 'id', uri: 'direct:a-reference' },
     });
-    interceptSendToEndpointVisualEntity.getNodeValidationText('interceptSendToEndpoint', {
+    await interceptSendToEndpointVisualEntity.getNodeValidationText('interceptSendToEndpoint', {
       type: 'object',
       properties: {},
     });

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.test.ts
@@ -86,13 +86,13 @@ describe('CamelInterceptVisualEntity', () => {
     });
   });
 
-  it('should delegate the validation text to the ModelValidationService', () => {
-    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus');
+  it('should delegate the validation text to the ModelValidationService', async () => {
+    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus').mockResolvedValue('');
 
     const interceptVisualEntity = new CamelInterceptVisualEntity({
       intercept: { id: 'id', disabled: false },
     });
-    interceptVisualEntity.getNodeValidationText('intercept', { type: 'object', properties: {} });
+    await interceptVisualEntity.getNodeValidationText('intercept', { type: 'object', properties: {} });
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.test.ts
@@ -91,13 +91,13 @@ describe('CamelOnCompletionVisualEntity', () => {
     });
   });
 
-  it('should delegate the validation text to the ModelValidationService', () => {
-    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus');
+  it('should delegate the validation text to the ModelValidationService', async () => {
+    const validateNodeStatusSpy = vi.spyOn(ModelValidationService, 'validateNodeStatus').mockResolvedValue('');
 
     const onCompletionVisualEntity = new CamelOnCompletionVisualEntity({
       onCompletion: { id: 'id', mode: 'AfterConsumer' },
     });
-    onCompletionVisualEntity.getNodeValidationText('onCompletion', { type: 'object', properties: {} });
+    await onCompletionVisualEntity.getNodeValidationText('onCompletion', { type: 'object', properties: {} });
 
     expect(validateNodeStatusSpy).toHaveBeenCalled();
   });

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
@@ -151,7 +151,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
         primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
       });
 
-      expect(entity.getNodeValidationText(undefined, schema)).toBeUndefined();
+      expect(await entity.getNodeValidationText(undefined, schema)).toBeUndefined();
     });
 
     it('should not modify the original definition when validating', async () => {
@@ -161,7 +161,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
         primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
       });
 
-      entity.getNodeValidationText(undefined, schema);
+      await entity.getNodeValidationText(undefined, schema);
 
       expect(restConfigurationDef.restConfiguration).toEqual(originalRestConfigurationDef);
     });
@@ -183,7 +183,7 @@ describe('CamelRestConfigurationVisualEntity', () => {
         primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
       });
 
-      expect(entity.getNodeValidationText(undefined, schema)).toBe(`'/useXForwardHeaders' must be boolean,
+      expect(await entity.getNodeValidationText(undefined, schema)).toBe(`'/useXForwardHeaders' must be boolean,
 '/apiVendorExtension' must be boolean,
 '/skipBindingOnErrorCode' must be boolean,
 '/clientRequestValidation' must be boolean,

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -134,7 +134,7 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(_path?: string, schema?: KaotoSchemaDefinition['schema']): string | undefined {
+  async getNodeValidationText(_path?: string, schema?: KaotoSchemaDefinition['schema']): Promise<string | undefined> {
     if (!schema) return undefined;
 
     this.schemaValidator ??= getValidator<RestConfiguration>(schema, { useDefaults: 'empty' });

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
@@ -419,7 +419,7 @@ describe('CamelRestVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return undefined for valid definitions', () => {
+    it('should return undefined for valid definitions', async () => {
       const entity = new CamelRestVisualEntity({
         rest: {
           ...restDef.rest,
@@ -427,19 +427,19 @@ describe('CamelRestVisualEntity', () => {
         },
       });
 
-      expect(entity.getNodeValidationText()).toBeUndefined();
+      expect(await entity.getNodeValidationText()).toBeUndefined();
     });
 
-    it('should not modify the original definition when validating', () => {
+    it('should not modify the original definition when validating', async () => {
       const originalRestDef: Rest = { ...restDef.rest };
       const entity = new CamelRestVisualEntity(restDef);
 
-      entity.getNodeValidationText();
+      await entity.getNodeValidationText();
 
       expect(restDef.rest).toEqual(originalRestDef);
     });
 
-    it('should NOT return errors when there is an invalid property', () => {
+    it('should NOT return errors when there is an invalid property', async () => {
       const invalidRestDef: Rest = {
         ...restDef.rest,
         bindingMode: 'true' as unknown as Rest['bindingMode'],
@@ -447,7 +447,7 @@ describe('CamelRestVisualEntity', () => {
       };
       const entity = new CamelRestVisualEntity({ rest: invalidRestDef });
 
-      expect(entity.getNodeValidationText()).toBeUndefined();
+      expect(await entity.getNodeValidationText()).toBeUndefined();
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-configuration-visual-entity.test.ts
@@ -235,23 +235,23 @@ describe('CamelRouteConfigurationVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return undefined for valid definitions', () => {
+    it('should return undefined for valid definitions', async () => {
       const entity = new CamelRouteConfigurationVisualEntity({
         routeConfiguration: {
           ...routeConfigurationDef.routeConfiguration,
         },
       });
 
-      expect(entity.getNodeValidationText()).toBeUndefined();
+      expect(await entity.getNodeValidationText()).toBeUndefined();
     });
 
-    it('should not modify the original definition when validating', () => {
+    it('should not modify the original definition when validating', async () => {
       const originalRouteConfigurationDef: RouteConfigurationDefinition = {
         ...routeConfigurationDef.routeConfiguration,
       };
       const entity = new CamelRouteConfigurationVisualEntity(routeConfigurationDef);
 
-      entity.getNodeValidationText();
+      await entity.getNodeValidationText();
 
       expect(routeConfigurationDef.routeConfiguration).toEqual(originalRouteConfigurationDef);
     });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -901,25 +901,25 @@ describe('CitrusTestVisualEntity', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return an `undefined` if the path is `undefined`', () => {
-      const result = citrusTestEntity.getNodeValidationText();
+    it('should return an `undefined` if the path is `undefined`', async () => {
+      const result = await citrusTestEntity.getNodeValidationText();
 
       expect(result).toBeUndefined();
     });
 
-    it('should return an `undefined` if the path is empty', () => {
-      const result = citrusTestEntity.getNodeValidationText('');
+    it('should return an `undefined` if the path is empty', async () => {
+      const result = await citrusTestEntity.getNodeValidationText('');
 
       expect(result).toBeUndefined();
     });
 
-    it('should return a validation text relying on the `validateNodeStatus` method', () => {
+    it('should return a validation text relying on the `validateNodeStatus` method', async () => {
       const invalidModel = cloneDeep(citrusTestJson);
       setValue(invalidModel, 'actions[0].print.message', undefined);
       const entity = new CitrusTestVisualEntity(invalidModel);
       const schema = CitrusTestSchemaService.getNodeSchema('print');
 
-      const result = entity.getNodeValidationText('actions.0.print', schema, printActionIds);
+      const result = await entity.getNodeValidationText('actions.0.print', schema, printActionIds);
 
       expect(result).toBe('1 required parameter is not yet configured: [ message ]');
     });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -346,15 +346,15 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(
+  async getNodeValidationText(
     path?: string,
     schema?: KaotoSchemaDefinition['schema'],
     ids?: IVisualizationNodeIds,
-  ): string | undefined {
+  ): Promise<string | undefined> {
     const definition = this.getNodeDefinition(path, ids);
     if (!schema || !definition) return undefined;
 
-    return ModelValidationService.validateNodeStatus(schema, definition);
+    return await ModelValidationService.validateNodeStatus(schema, definition);
   }
 
   getGroupIcons(): { icon: string; title: string }[] {

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.test.ts
@@ -518,14 +518,14 @@ describe('Pipe', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return an `undefined` if the path is `undefined`', () => {
-      const result = pipeVisualEntity.getNodeValidationText();
+    it('should return an `undefined` if the path is `undefined`', async () => {
+      const result = await pipeVisualEntity.getNodeValidationText();
 
       expect(result).toBeUndefined();
     });
 
-    it('should return an `undefined` if the path is empty', () => {
-      const result = pipeVisualEntity.getNodeValidationText('');
+    it('should return an `undefined` if the path is empty', async () => {
+      const result = await pipeVisualEntity.getNodeValidationText('');
 
       expect(result).toBeUndefined();
     });
@@ -538,7 +538,7 @@ describe('Pipe', () => {
       const schema = await pipeVisualEntity.fetchNodeSchema({
         primaryNodeId: { name: 'delay-action', catalogKind: CatalogKind.Kamelet },
       });
-      const result = pipeVisualEntity.getNodeValidationText('steps.0', schema);
+      const result = await pipeVisualEntity.getNodeValidationText('steps.0', schema);
 
       expect(result).toBe('1 required parameter is not yet configured: [ milliseconds ]');
     });

--- a/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/pipe-visual-entity.ts
@@ -220,11 +220,11 @@ export class PipeVisualEntity implements BaseVisualEntity {
     };
   }
 
-  getNodeValidationText(path?: string, schema?: KaotoSchemaDefinition['schema']): string | undefined {
+  async getNodeValidationText(path?: string, schema?: KaotoSchemaDefinition['schema']): Promise<string | undefined> {
     const definition = this.getNodeDefinition(path);
     if (!schema || !definition) return undefined;
 
-    return ModelValidationService.validateNodeStatus(schema, definition);
+    return await ModelValidationService.validateNodeStatus(schema, definition);
   }
 
   async toVizNode(): Promise<IVisualizationNode> {

--- a/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.test.ts
@@ -1,12 +1,10 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { DynamicCatalog } from '../../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../../../stubs/test-load-catalog';
 import { CatalogKind } from '../../../../catalog-kind';
 import { KaotoSchemaDefinition } from '../../../../kaoto-schema';
-import { CamelCatalogService } from '../../camel-catalog.service';
 import { CamelRouteVisualEntity } from '../../camel-route-visual-entity';
 import { ModelValidationService } from './model-validation.service';
 
@@ -49,22 +47,10 @@ describe('ModelValidationService', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     setupDynamicCatalogRegistry(catalogsMap);
-    /** ExpressionService.parseExpressionModel (called during setHeader validation) still reads from CamelCatalogService */
-    CamelCatalogService.setCatalogKey(CatalogKind.Language, catalogsMap.languageCatalog);
-
-    // Set up DynamicCatalogRegistry so that ExpressionService.parseExpressionModel can resolve language names
-    const languageCatalog = catalogsMap.languageCatalog;
-    const mockProvider = {
-      id: 'language-mock',
-      fetch: async (key: string) => languageCatalog[key],
-      fetchAll: async () => languageCatalog,
-    };
-    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Language, new DynamicCatalog(mockProvider));
   });
 
   afterAll(() => {
     DynamicCatalogRegistry.get().clearRegistry();
-    CamelCatalogService.clearCatalogs();
   });
 
   beforeEach(() => {

--- a/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.test.ts
@@ -1,6 +1,7 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
+import { DynamicCatalog } from '../../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../../../stubs/test-load-catalog';
 import { CatalogKind } from '../../../../catalog-kind';
@@ -50,6 +51,15 @@ describe('ModelValidationService', () => {
     setupDynamicCatalogRegistry(catalogsMap);
     /** ExpressionService.parseExpressionModel (called during setHeader validation) still reads from CamelCatalogService */
     CamelCatalogService.setCatalogKey(CatalogKind.Language, catalogsMap.languageCatalog);
+
+    // Set up DynamicCatalogRegistry so that ExpressionService.parseExpressionModel can resolve language names
+    const languageCatalog = catalogsMap.languageCatalog;
+    const mockProvider = {
+      id: 'language-mock',
+      fetch: async (key: string) => languageCatalog[key],
+      fetchAll: async () => languageCatalog,
+    };
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Language, new DynamicCatalog(mockProvider));
   });
 
   afterAll(() => {
@@ -70,7 +80,7 @@ describe('ModelValidationService', () => {
       });
       const model = camelRoute.route.from.steps[0].to;
 
-      const result = ModelValidationService.validateNodeStatus(schema!, model);
+      const result = await ModelValidationService.validateNodeStatus(schema!, model);
 
       expect(result).toBe('1 required parameter is not yet configured: [ destinationName ]');
     });
@@ -83,7 +93,7 @@ describe('ModelValidationService', () => {
       });
       const model = camelRoute.route.from.steps[2].to;
 
-      const result = ModelValidationService.validateNodeStatus(schema!, model);
+      const result = await ModelValidationService.validateNodeStatus(schema!, model);
 
       expect(result).toBe('1 required parameter is not yet configured: [ templateId ]');
     });
@@ -94,7 +104,7 @@ describe('ModelValidationService', () => {
       });
       const model = camelRoute.route.from.steps[1].setHeader;
 
-      const result = ModelValidationService.validateNodeStatus(schema!, model);
+      const result = await ModelValidationService.validateNodeStatus(schema!, model);
 
       expect(result).toBe('2 required parameters are not yet configured: [ expression,name ]');
     });
@@ -108,7 +118,7 @@ describe('ModelValidationService', () => {
         constant: 'Hello Camel',
       };
 
-      const result = ModelValidationService.validateNodeStatus(schema!, model);
+      const result = await ModelValidationService.validateNodeStatus(schema!, model);
 
       expect(result).toBe('');
     });
@@ -120,13 +130,13 @@ describe('ModelValidationService', () => {
       });
       const model = { ...camelRoute.route.from.steps[0].to, parameters: { destinationName: 'myQueue' } };
 
-      const result = ModelValidationService.validateNodeStatus(schema!, model);
+      const result = await ModelValidationService.validateNodeStatus(schema!, model);
 
       expect(result).toBe('');
     });
 
-    it('should return an empty string if the schema is undefined', () => {
-      const result = ModelValidationService.validateNodeStatus(
+    it('should return an empty string if the schema is undefined', async () => {
+      const result = await ModelValidationService.validateNodeStatus(
         undefined as unknown as KaotoSchemaDefinition['schema'],
         {},
       );
@@ -146,21 +156,21 @@ describe('ModelValidationService', () => {
       definitions: {},
     };
 
-    it('should report missing required array property when not present', () => {
+    it('should report missing required array property when not present', async () => {
       const model = {};
-      const result = ModelValidationService.validateNodeStatus(arraySchema, model);
+      const result = await ModelValidationService.validateNodeStatus(arraySchema, model);
       expect(result).toBe('1 required parameter is not yet configured: [ items ]');
     });
 
-    it('should report missing required array property when empty', () => {
+    it('should report missing required array property when empty', async () => {
       const model = { items: [] };
-      const result = ModelValidationService.validateNodeStatus(arraySchema, model);
+      const result = await ModelValidationService.validateNodeStatus(arraySchema, model);
       expect(result).toBe('1 required parameter is not yet configured: [ items ]');
     });
 
-    it('should not report missing required array property when array is non-empty', () => {
+    it('should not report missing required array property when array is non-empty', async () => {
       const model = { items: [1, 2, 3] };
-      const result = ModelValidationService.validateNodeStatus(arraySchema, model);
+      const result = await ModelValidationService.validateNodeStatus(arraySchema, model);
       expect(result).toBe('');
     });
   });

--- a/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.ts
@@ -14,6 +14,23 @@ interface IValidationResult {
 function isEmptyOrNotArray(value: unknown): boolean {
   return !Array.isArray(value) || value.length === 0;
 }
+
+function isMissingRequired(
+  schema: KaotoSchemaDefinition['schema'],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  model: any,
+  propertyName: string,
+  propertySchema: KaotoSchemaDefinition['schema'],
+): boolean {
+  return (
+    Array.isArray(schema.required) &&
+    schema.required.includes(propertyName) &&
+    propertySchema.default === undefined &&
+    propertySchema.$ref === undefined &&
+    (!model?.[propertyName] || (propertySchema.type === 'array' && isEmptyOrNotArray(model[propertyName])))
+  );
+}
+
 /**
  * Service for validating the model of a node.
  * Ideally, this should be done with a JSON schema validator, like ajv, but for our use case, it's not possible,
@@ -29,11 +46,11 @@ function isEmptyOrNotArray(value: unknown): boolean {
  * property file.
  */
 export class ModelValidationService {
-  static validateNodeStatus(schema: KaotoSchemaDefinition['schema'], definition: unknown): string {
+  static async validateNodeStatus(schema: KaotoSchemaDefinition['schema'], definition: unknown): Promise<string> {
     if (!schema) return '';
     let message = '';
 
-    const validationResult = this.validateRequiredProperties(schema, definition, '', schema.definitions);
+    const validationResult = await this.validateRequiredProperties(schema, definition, '', schema.definitions);
     const missingProperties = validationResult
       .filter((result) => result.type === 'missingRequired')
       .map((result) => result.propertyName);
@@ -48,73 +65,110 @@ export class ModelValidationService {
     return message;
   }
 
-  private static validateRequiredProperties(
+  private static async validateRequiredProperties(
     schema: KaotoSchemaDefinition['schema'],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     model: any,
     parentPath: string,
     definitions?: Record<string, KaotoSchemaDefinition['schema']>,
-  ): IValidationResult[] {
-    const answer = [] as IValidationResult[];
+  ): Promise<IValidationResult[]> {
+    const answer: IValidationResult[] = [];
 
-    const resolvedSchema = schema;
-    if (Array.isArray(resolvedSchema.anyOf)) {
-      let parsedModel = model;
-      resolvedSchema.anyOf.forEach((anyOfSchema) => {
-        if (isDefined(anyOfSchema.format) && anyOfSchema.format === 'expression') {
-          parsedModel = ExpressionService.parseExpressionModel(model);
-        }
-        answer.push(...this.validateRequiredProperties(anyOfSchema, parsedModel, parentPath, definitions));
-      });
+    answer.push(
+      ...(await this.validateAnyOf(schema, model, parentPath, definitions)),
+      ...(await this.validateOneOf(schema, model, parentPath, definitions)),
+      ...(await this.validateRef(schema, model, parentPath, definitions)),
+      ...(await this.validateProperties(schema, model, parentPath, definitions)),
+    );
+
+    return answer;
+  }
+
+  private static async validateAnyOf(
+    schema: KaotoSchemaDefinition['schema'],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    model: any,
+    parentPath: string,
+    definitions?: Record<string, KaotoSchemaDefinition['schema']>,
+  ): Promise<IValidationResult[]> {
+    if (!Array.isArray(schema.anyOf)) return [];
+
+    const answer: IValidationResult[] = [];
+    let parsedModel = model;
+    for (const anyOfSchema of schema.anyOf) {
+      if (isDefined(anyOfSchema.format) && anyOfSchema.format === 'expression') {
+        parsedModel = await ExpressionService.parseExpressionModel(model);
+      }
+      answer.push(...(await this.validateRequiredProperties(anyOfSchema, parsedModel, parentPath, definitions)));
     }
+    return answer;
+  }
 
-    if (Array.isArray(resolvedSchema.oneOf)) {
-      resolvedSchema.oneOf.forEach((oneOfSchema) =>
-        answer.push(...this.validateRequiredProperties(oneOfSchema, model, parentPath, definitions)),
-      );
+  private static async validateOneOf(
+    schema: KaotoSchemaDefinition['schema'],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    model: any,
+    parentPath: string,
+    definitions?: Record<string, KaotoSchemaDefinition['schema']>,
+  ): Promise<IValidationResult[]> {
+    if (!Array.isArray(schema.oneOf)) return [];
+
+    const answer: IValidationResult[] = [];
+    for (const oneOfSchema of schema.oneOf) {
+      answer.push(...(await this.validateRequiredProperties(oneOfSchema, model, parentPath, definitions)));
     }
+    return answer;
+  }
 
-    if (!schema.properties && schema.$ref) {
-      // resolve the ref
-      const resolvedSchema = resolveSchemaWithRef(schema, definitions!);
-      answer.push(...this.validateRequiredProperties(resolvedSchema, model, parentPath, definitions));
+  private static async validateRef(
+    schema: KaotoSchemaDefinition['schema'],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    model: any,
+    parentPath: string,
+    definitions?: Record<string, KaotoSchemaDefinition['schema']>,
+  ): Promise<IValidationResult[]> {
+    if (schema.properties || !schema.$ref) return [];
+
+    const resolvedSchema = resolveSchemaWithRef(schema, definitions!);
+    return this.validateRequiredProperties(resolvedSchema, model, parentPath, definitions);
+  }
+
+  private static async validateProperties(
+    schema: KaotoSchemaDefinition['schema'],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    model: any,
+    parentPath: string,
+    definitions?: Record<string, KaotoSchemaDefinition['schema']>,
+  ): Promise<IValidationResult[]> {
+    if (!schema.properties) return [];
+
+    const answer: IValidationResult[] = [];
+    for (const [propertyName, propertyValue] of Object.entries(schema.properties)) {
+      const propertySchema = propertyValue as KaotoSchemaDefinition['schema'];
+      const path = parentPath ? `${parentPath}.${propertyName}` : propertyName;
+
+      if (isMissingRequired(schema, model, propertyName, propertySchema)) {
+        answer.push({
+          level: 'error',
+          type: 'missingRequired',
+          parentPath,
+          propertyName,
+          message: `Missing required property ${propertyName}`,
+        });
+        continue;
+      }
+
+      if (model?.[propertyName] && propertySchema.$ref) {
+        const resolvedPropertySchema = resolveSchemaWithRef(propertySchema, definitions!);
+        answer.push(
+          ...(await this.validateRequiredProperties(resolvedPropertySchema, model[propertyName], path, definitions)),
+        );
+      }
+
+      if (propertySchema.type === 'object' && model) {
+        answer.push(...(await this.validateRequiredProperties(propertySchema, model[propertyName], path, definitions)));
+      }
     }
-
-    if (schema.properties) {
-      Object.entries(schema.properties).forEach(([propertyName, propertyValue]) => {
-        const propertySchema = propertyValue as KaotoSchemaDefinition['schema'];
-        const path = parentPath ? `${parentPath}.${propertyName}` : propertyName;
-
-        if (
-          Array.isArray(schema.required) &&
-          schema.required.includes(propertyName) &&
-          propertySchema.default === undefined &&
-          propertySchema.$ref === undefined &&
-          (!model?.[propertyName] || (propertySchema.type === 'array' && isEmptyOrNotArray(model[propertyName])))
-        ) {
-          answer.push({
-            level: 'error',
-            type: 'missingRequired',
-            parentPath: parentPath,
-            propertyName: propertyName,
-            message: `Missing required property ${propertyName}`,
-          });
-          return;
-        }
-        if (model?.[propertyName] && propertySchema.$ref) {
-          const resolvedPropertySchema = resolveSchemaWithRef(propertySchema, definitions!);
-          answer.push(
-            ...this.validateRequiredProperties(resolvedPropertySchema, model[propertyName], path, definitions),
-          );
-        }
-        if (propertySchema.type === 'object') {
-          if (model) {
-            answer.push(...this.validateRequiredProperties(propertySchema, model[propertyName], path, definitions));
-          }
-        }
-      });
-    }
-
     return answer;
   }
 }

--- a/packages/ui/src/models/visualization/visualization-node.test.ts
+++ b/packages/ui/src/models/visualization/visualization-node.test.ts
@@ -413,7 +413,7 @@ describe('VisualizationNode', () => {
   });
 
   describe('getNodeValidationText', () => {
-    it('should return undefined when the underlying BaseVisualCamelEntity is not defined', () => {
+    it('should return undefined when the underlying BaseVisualCamelEntity is not defined', async () => {
       node = createVisualizationNode('test', {
         name: 'log',
         isGroup: false,
@@ -422,13 +422,13 @@ describe('VisualizationNode', () => {
         description: '',
         iconUrl: '',
       });
-      const validationText = node.getNodeValidationText();
+      const validationText = await node.getNodeValidationText();
 
       expect(validationText).toBeUndefined();
     });
 
-    it('should return the validation text from the underlying BaseVisualCamelEntity', () => {
-      const getNodeValidationTextSpy = vi.fn().mockReturnValue('test-validation-text');
+    it('should return the validation text from the underlying BaseVisualCamelEntity', async () => {
+      const getNodeValidationTextSpy = vi.fn().mockResolvedValue('test-validation-text');
       const visualEntity = {
         getNodeValidationText: getNodeValidationTextSpy,
       } as unknown as BaseVisualEntity;
@@ -445,7 +445,7 @@ describe('VisualizationNode', () => {
         schema: { type: 'object' },
         primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
       });
-      const validationText = node.getNodeValidationText();
+      const validationText = await node.getNodeValidationText();
 
       expect(getNodeValidationTextSpy).toHaveBeenCalledWith(node.data.path, node.data.schema, {
         primaryNodeId: node.data.primaryNodeId,

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -183,7 +183,7 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
     }
   }
 
-  getNodeValidationText(): string | undefined {
+  async getNodeValidationText(): Promise<string | undefined> {
     const ids: IVisualizationNodeIds = {
       primaryNodeId: this.data.primaryNodeId,
       secondaryNodeId: this.data.secondaryNodeId,


### PR DESCRIPTION
### Context

Partial backport of #3447, scoped to the `ExpressionField` folder only.
fix https://github.com/KaotoIO/kaoto/issues/3442

### Changes

- **`ExpressionService`**: `getLanguageNames()`, `parseExpressionModel()`, and `updateExpressionFromModel()` are now `async`, sourcing languages from `DynamicCatalogRegistry.get().getCatalog(CatalogKind.Language)?.getAll()` instead of the removed `CamelCatalogService.getLanguageMap()`.
- **`ExpressionField`**: Parses the model in a `useEffect` and gates rendering on an `isModelParsed` flag, so the third-party `useOneOfField` mounts with the resolved model (otherwise it latches an empty selection that never recovers).
- **Tests**: Set up `DynamicCatalogRegistry` in test fixtures; `await` the now-async service APIs; use `waitFor`/`findBy` to wait for async rendering effects before asserting.

### Files changed
- `ExpressionField.tsx`
- `expression.service.ts`
- `ExpressionField.test.tsx`
- `expression.service.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved expression-field loading and updates during asynchronous parsing.
  - Validation messages now refresh reliably as visual elements change.
  - Prevented outdated validation results from replacing newer results.
  - Applications remain usable when language catalog information is unavailable.
  - Added a clear fallback when the expression editor cannot be loaded.

- **Tests**
  - Expanded coverage for asynchronous parsing, validation updates, error handling, and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->