### PR TITLE
test(e2e): extend camelRouteRoundTrip with XML DSL round-trip scenarios

### DIFF
--- a/packages/ui-tests/cypress/e2e/codeEditor/camelRouteRoundTrip.cy.ts
+++ b/packages/ui-tests/cypress/e2e/codeEditor/camelRouteRoundTrip.cy.ts
@@ -3,102 +3,211 @@ describe('Test Camel Route source-to-canvas-to-source round trip', () => {
     cy.openHomePage();
   });
 
-  const getRouteLines = (sourceCode: string, routeId: string): string[] => {
-    const routeStart = sourceCode.indexOf(`id: ${routeId}`);
-    const nextRouteStart = sourceCode.indexOf('\n- route:', routeStart);
-    const routeSlice = sourceCode.slice(routeStart, nextRouteStart === -1 ? sourceCode.length : nextRouteStart);
-    return routeSlice.split('\n').map((l) => l.trim());
-  };
+  const runRoundTripTest = (
+    fixture: string,
+    getRouteLines: (sourceCode: string, routeId: string) => string[],
+    variant: {
+      routeId: string;
+      stepName: string;
+      stepIndex: number;
+      sourceCheckLines: string[];
+      updatedSourceCheckLines?: string[];
+      editViaUriInput?: boolean;
+      uriInputValue?: string;
+    },
+  ) => {
+    cy.uploadFixture(fixture);
 
-  const toDslVariants = [
-    {
-      name: 'expanded to with separated uri and parameters',
-      routeId: 'route-expanded-uri-parameters',
-      stepName: 'log',
-      stepIndex: 0,
-      sourceCheckLines: ['- to:', 'uri: log', 'loggerName: testing', "showHeaders: 'true'"],
-      updatedSourceCheckLines: ['- to:', 'uri: log', 'loggerName: changed-testing', 'showHeaders: "true"'],
-    },
-    {
-      name: 'expanded to with inline uri path',
-      routeId: 'route-expanded-inline-uri',
-      stepName: 'log',
-      stepIndex: 1,
-      sourceCheckLines: ['- to:', 'uri: log:testing?showHeaders=true'],
-      updatedSourceCheckLines: ['- to:', 'uri: log', 'showHeaders: true', 'loggerName: changed-testing'],
-    },
-    {
-      name: 'scalar to with separated uri parameters in query',
-      routeId: 'route-scalar-uri-parameters',
-      stepName: 'to',
-      stepIndex: 0,
-      sourceCheckLines: ['- to: log?loggerName=testing&showHeaders=true'],
-      updatedSourceCheckLines: ['- to:', 'uri: log?loggerName=changed-testing&showHeaders=true'],
-    },
-    {
-      name: 'scalar to with inline uri path and query',
-      routeId: 'route-scalar-inline-uri',
-      stepName: 'log',
-      stepIndex: 2,
-      sourceCheckLines: ['- to: log:testing?showHeaders=true'],
-      updatedSourceCheckLines: ['- to:', 'uri: log', 'showHeaders: true', 'loggerName: changed-testing'],
-    },
-  ];
+    // Check the initial source lines are correct for this route
+    cy.openSourceCode();
+    cy.getMonacoValue().then(({ sourceCode }) => {
+      const routeLines = getRouteLines(sourceCode, variant.routeId);
+      variant.sourceCheckLines.forEach((line) => {
+        expect(routeLines).to.include(line.trim());
+      });
+    });
 
-  it('renders the shared fixture in the canvas', () => {
-    cy.uploadFixture('flows/camelRoute/camelRouteRoundTrip.yaml');
+    if (!variant.updatedSourceCheckLines) return;
 
+    // Open the design page, select the step and update loggerName via the form
     cy.openDesignPage();
     cy.showAllRoutes();
-    cy.checkNodeExist('timer', 4);
-    cy.checkNodeExist('log', 3);
-    cy.checkNodeExist('to', 1);
-    cy.get('[data-testid="flows-list-route-count"]').should('have.text', '4/4');
-  });
+    cy.openStepConfigurationTab(variant.stepName, variant.stepIndex);
+    cy.selectFormTab('All');
+    if (variant.editViaUriInput) {
+      cy.get('[data-testid="#.uri--edit"]').click();
+      cy.get('[data-testid="#.uri--text-input"]').clear().type(variant.uriInputValue!);
+      cy.get('[data-testid="#.uri--save"]').click();
+    } else {
+      cy.interactWithConfigInputObject('parameters.loggerName', 'changed-testing');
+    }
+    cy.closeStepConfigurationTab();
 
-  toDslVariants.forEach(({ name, routeId, stepName, stepIndex, sourceCheckLines, updatedSourceCheckLines }) => {
-    it('loads ' + name + ' from source code and preserves valid DSL after form edits', () => {
-      cy.uploadFixture('flows/camelRoute/camelRouteRoundTrip.yaml');
-
-      // Check the initial source lines are correct for this route
-      cy.openSourceCode();
-      cy.getMonacoValue().then(({ sourceCode }) => {
-        const routeLines = getRouteLines(sourceCode, routeId);
-        sourceCheckLines.forEach((line) => {
-          expect(routeLines).to.include(line.trim());
+    // Check the updated source lines are correct for this route only.
+    // Assert that original lines not carried over into the updated representation are absent,
+    // then verify the expected updated representation is present.
+    cy.openSourceCode();
+    cy.getMonacoValue().then(({ sourceCode }) => {
+      const routeLines = getRouteLines(sourceCode, variant.routeId);
+      // updatedSourceCheckLines is guaranteed defined here — the early return above guards this branch
+      const updatedLines = variant.updatedSourceCheckLines!;
+      const updatedTrimmed = updatedLines.map((l) => l.trim());
+      variant.sourceCheckLines
+        .map((l) => l.trim())
+        .filter((l) => !updatedTrimmed.includes(l))
+        .forEach((line) => {
+          expect(routeLines, `original line still present after edit: "${line}"`).to.not.include(line);
         });
+      updatedLines.forEach((line) => {
+        expect(routeLines, `expected updated line missing: "${line.trim()}"`).to.include(line.trim());
       });
+    });
+  };
 
-      // Open the design page, select the step and update loggerName via the form
+  describe('YAML', () => {
+    const fixture = 'flows/camelRoute/camelRouteRoundTrip.yaml';
+
+    const getRouteLines = (sourceCode: string, routeId: string): string[] => {
+      const routeStart = sourceCode.indexOf(`id: ${routeId}`);
+      const nextRouteStart = sourceCode.indexOf('\n- route:', routeStart);
+      const routeSlice = sourceCode.slice(routeStart, nextRouteStart === -1 ? sourceCode.length : nextRouteStart);
+      return routeSlice.split('\n').map((l) => l.trim());
+    };
+
+    const toDslVariants = [
+      {
+        name: 'expanded to with separated uri and parameters',
+        routeId: 'route-expanded-uri-parameters',
+        stepName: 'log',
+        stepIndex: 0,
+        sourceCheckLines: ['- to:', 'uri: log', 'loggerName: testing', "showHeaders: 'true'"],
+        updatedSourceCheckLines: ['- to:', 'uri: log', 'loggerName: changed-testing', 'showHeaders: "true"'],
+      },
+      {
+        name: 'expanded to with inline uri path',
+        routeId: 'route-expanded-inline-uri',
+        stepName: 'log',
+        stepIndex: 1,
+        sourceCheckLines: ['- to:', 'uri: log:testing?showHeaders=true'],
+        updatedSourceCheckLines: ['- to:', 'uri: log', 'showHeaders: true', 'loggerName: changed-testing'],
+      },
+      {
+        name: 'scalar to with separated uri parameters in query',
+        routeId: 'route-scalar-uri-parameters',
+        stepName: 'to',
+        stepIndex: 0,
+        sourceCheckLines: ['- to: log?loggerName=testing&showHeaders=true'],
+        updatedSourceCheckLines: ['- to:', 'uri: log?loggerName=changed-testing&showHeaders=true'],
+        editViaUriInput: true,
+        uriInputValue: 'log?loggerName=changed-testing&showHeaders=true',
+      },
+      {
+        name: 'scalar to with inline uri path and query',
+        routeId: 'route-scalar-inline-uri',
+        stepName: 'log',
+        stepIndex: 2,
+        sourceCheckLines: ['- to: log:testing?showHeaders=true'],
+        updatedSourceCheckLines: ['- to:', 'uri: log', 'showHeaders: true', 'loggerName: changed-testing'],
+      },
+    ];
+
+    it('renders the shared fixture in the canvas', () => {
+      cy.uploadFixture(fixture);
+
       cy.openDesignPage();
       cy.showAllRoutes();
-      cy.openStepConfigurationTab(stepName, stepIndex);
-      cy.selectFormTab('All');
-      if (routeId === 'route-scalar-uri-parameters') {
-        cy.get('[data-testid="#.uri--edit"]').click();
-        cy.get('[data-testid="#.uri--text-input"]').clear().type('log?loggerName=changed-testing&showHeaders=true');
-        cy.get('[data-testid="#.uri--save"]').click();
-      } else {
-        cy.interactWithConfigInputObject('parameters.loggerName', 'changed-testing');
-      }
-      cy.closeStepConfigurationTab();
+      cy.checkNodeExist('timer', 4);
+      cy.checkNodeExist('log', 3);
+      cy.checkNodeExist('to', 1);
+      cy.get('[data-testid="flows-list-route-count"]').should('have.text', '4/4');
+    });
 
-      // Check the updated source lines are correct for this route only.
-      // Assert that original lines not carried over into the updated representation are absent,
-      // then verify the expected updated representation is present.
-      cy.openSourceCode();
-      cy.getMonacoValue().then(({ sourceCode }) => {
-        const routeLines = getRouteLines(sourceCode, routeId);
-        const updatedTrimmed = updatedSourceCheckLines.map((l) => l.trim());
-        sourceCheckLines
-          .map((l) => l.trim())
-          .filter((l) => !updatedTrimmed.includes(l))
-          .forEach((line) => {
-            expect(routeLines, `original line still present after edit: "${line}"`).to.not.include(line);
-          });
-        updatedSourceCheckLines.forEach((line) => {
-          expect(routeLines, `expected updated line missing: "${line.trim()}"`).to.include(line.trim());
-        });
+    toDslVariants.forEach((variant) => {
+      it('loads ' + variant.name + ' from source code and preserves valid DSL after form edits', () => {
+        runRoundTripTest(fixture, getRouteLines, variant);
+      });
+    });
+  });
+
+  describe('XML', () => {
+    const fixture = 'flows/camelRoute/camelRouteRoundTrip.xml';
+
+    const getRouteLines = (sourceCode: string, routeId: string): string[] => {
+      const routeStart = sourceCode.indexOf(`id="${routeId}"`);
+      const nextRouteStart = sourceCode.indexOf('<route ', routeStart + 1);
+      const routeSlice = sourceCode.slice(routeStart, nextRouteStart === -1 ? sourceCode.length : nextRouteStart);
+      return routeSlice.split('\n').map((l) => l.trim());
+    };
+
+    const toDslVariants = [
+      {
+        name: 'loggerName in query string, showHeaders in query string',
+        routeId: 'route-query-logger-query-headers',
+        stepName: 'to',
+        stepIndex: 0,
+        sourceCheckLines: [
+          '<to id="to-query-logger-query-headers" uri="log?loggerName=testing&amp;showHeaders=true"/>',
+        ],
+        updatedSourceCheckLines: [
+          '<to id="to-query-logger-query-headers" uri="log?loggerName=changed-testing&amp;showHeaders=true"/>',
+        ],
+        editViaUriInput: true,
+        uriInputValue: 'log?loggerName=changed-testing&showHeaders=true',
+      },
+      {
+        name: 'loggerName as path component, showHeaders in query string',
+        routeId: 'route-path-logger-query-headers',
+        stepName: 'log',
+        stepIndex: 0,
+        sourceCheckLines: ['<to id="to-path-logger-query-headers" uri="log:testing?showHeaders=true"/>'],
+        updatedSourceCheckLines: ['<to id="to-path-logger-query-headers" uri="log:changed-testing?showHeaders=true"/>'],
+      },
+      {
+        name: 'loggerName as path component, no query string',
+        routeId: 'route-path-logger-only',
+        stepName: 'log',
+        stepIndex: 1,
+        sourceCheckLines: ['<to id="to-path-logger-only" uri="log:testing"/>'],
+        updatedSourceCheckLines: ['<to id="to-path-logger-only" uri="log:changed-testing"/>'],
+      },
+      {
+        name: 'loggerName in query string only, no showHeaders',
+        routeId: 'route-query-logger-only',
+        stepName: 'to',
+        stepIndex: 1,
+        sourceCheckLines: ['<to id="to-query-logger-only" uri="log?loggerName=testing"/>'],
+        updatedSourceCheckLines: ['<to id="to-query-logger-only" uri="log?loggerName=changed-testing"/>'],
+        editViaUriInput: true,
+        uriInputValue: 'log?loggerName=changed-testing',
+      },
+      {
+        name: 'loggerName as path component, multiple query params',
+        routeId: 'route-path-logger-multi-params',
+        stepName: 'log',
+        stepIndex: 2,
+        sourceCheckLines: [
+          '<to id="to-path-logger-multi-params" uri="log:testing?showHeaders=true&amp;logMask=true&amp;level=WARN"/>',
+        ],
+        updatedSourceCheckLines: [
+          '<to id="to-path-logger-multi-params" uri="log:changed-testing?showHeaders=true&amp;logMask=true&amp;level=WARN"/>',
+        ],
+      },
+    ];
+
+    it('renders the shared fixture in the canvas', () => {
+      cy.uploadFixture(fixture);
+
+      cy.openDesignPage();
+      cy.showAllRoutes();
+      cy.checkNodeExist('timer', 5);
+      cy.checkNodeExist('log', 3);
+      cy.checkNodeExist('to', 2);
+      cy.get('[data-testid="flows-list-route-count"]').should('have.text', '5/5');
+    });
+
+    toDslVariants.forEach((variant) => {
+      it('loads ' + variant.name + ' from source code and preserves valid DSL after form edits', () => {
+        runRoundTripTest(fixture, getRouteLines, variant);
       });
     });
   });

--- a/packages/ui-tests/cypress/fixtures/flows/camelRoute/camelRouteRoundTrip.xml
+++ b/packages/ui-tests/cypress/fixtures/flows/camelRoute/camelRouteRoundTrip.xml
@@ -1,0 +1,31 @@
+<camel xmlns="http://camel.apache.org/schema/xml-io">
+  <!-- loggerName in query string, showHeaders in query string -->
+  <route id="route-query-logger-query-headers">
+    <from id="from-query-logger-query-headers" uri="timer:template?period=1000"/>
+    <to id="to-query-logger-query-headers" uri="log?loggerName=testing&amp;showHeaders=true"/>
+  </route>
+
+  <!-- loggerName as path component, showHeaders in query string -->
+  <route id="route-path-logger-query-headers">
+    <from id="from-path-logger-query-headers" uri="timer:template?period=1000"/>
+    <to id="to-path-logger-query-headers" uri="log:testing?showHeaders=true"/>
+  </route>
+
+  <!-- loggerName as path component, no query string -->
+  <route id="route-path-logger-only">
+    <from id="from-path-logger-only" uri="timer:template?period=1000"/>
+    <to id="to-path-logger-only" uri="log:testing"/>
+  </route>
+
+  <!-- loggerName in query string only, no showHeaders -->
+  <route id="route-query-logger-only">
+    <from id="from-query-logger-only" uri="timer:template?period=1000"/>
+    <to id="to-query-logger-only" uri="log?loggerName=testing"/>
+  </route>
+
+  <!-- loggerName as path component, multiple query params -->
+  <route id="route-path-logger-multi-params">
+    <from id="from-path-logger-multi-params" uri="timer:template?period=1000"/>
+    <to id="to-path-logger-multi-params" uri="log:testing?showHeaders=true&amp;logMask=true&amp;level=WARN"/>
+  </route>
+</camel>


### PR DESCRIPTION
## Summary

Extends the existing `camelRouteRoundTrip` e2e test to cover the XML DSL, alongside the existing YAML coverage.

## Changes

- **`camelRouteRoundTrip.cy.ts`** — refactored into a shared `runRoundTripTest` helper consumed by two nested `describe` blocks (`YAML` and `XML`). The `getRouteLines` extractor and variant data are the only format-specific parts.
- **`camelRouteRoundTrip.xml`** (new fixture) — 5 routes exercising distinct XML URI forms: loggerName in query string with and without extra params (currently parsed as raw URI due to `getComponentNameFromUri` not stripping `?`), loggerName as path component with/without query params, and multiple query params combined.

## Test coverage added

| Route | URI form | Edit method |
|---|---|---|
| `route-query-logger-query-headers` | `log?loggerName=testing&showHeaders=true` | URI text input |
| `route-path-logger-query-headers` | `log:testing?showHeaders=true` | form field |
| `route-path-logger-only` | `log:testing` | form field |
| `route-query-logger-only` | `log?loggerName=testing` | URI text input |
| `route-path-logger-multi-params` | `log:testing?showHeaders=true&logMask=true&level=WARN` | form field |

Relates to https://github.com/KaotoIO/kaoto/issues/3769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded round-trip coverage for Camel routes in YAML and XML formats.
  - Added validation for logger configurations using path-based and query-based parameters.
  - Covered multiple query parameters, URI editing, fixture reuse, and route-step selection.
  - Preserved canvas rendering assertions across supported fixture formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->