### PR TITLE
refactor(xml): replace getComponentDefinitionFromUri with inline DynamicCatalogRegistry lookup

### DIFF
--- a/packages/ui/src/models/camel/camel-xml-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.test.ts
@@ -22,7 +22,7 @@ describe('CamelXMLRouteResource', () => {
     const visualEntities = resource.getVisualEntities();
     expect(visualEntities).toHaveLength(1);
     const route = visualEntities[0].toJSON().route;
-    expect(route.from?.uri).toBe('direct:start');
+    expect(route.from?.uri).toBe('direct');
     expect(route.from?.steps).toHaveLength(2);
   });
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -3,7 +3,6 @@ import { CatalogLibrary, ProcessorDefinition } from '@kaoto/camel-catalog/types'
 
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
-import { ICamelComponentDefinition } from '../../../camel/camel-components-catalog';
 import { CatalogKind } from '../../../catalog-kind';
 import { IVisualizationNodeIds } from '../../base-visual-entity';
 import { IClipboardContent } from '../../clipboard';
@@ -303,48 +302,6 @@ describe('CamelComponentSchemaService', () => {
       };
       const expectedValue = CamelComponentSchemaService.getNodeDefinitionValue(clipboadContent);
       expect(expectedValue).toEqual({ id: 'when-2765', steps: [{ log: { id: 'log-2202', message: '${body}' } }] });
-    });
-  });
-
-  describe('getComponentDefinitionFromUri', () => {
-    it('returns undefined for empty uri', () => {
-      expect(CamelComponentSchemaService.getComponentDefinitionFromUri('')).toEqual({ uri: '' });
-    });
-
-    it('returns undefined for unknown component', () => {
-      vi.spyOn(CamelCatalogService, 'getComponent').mockReturnValueOnce(undefined);
-      expect(CamelComponentSchemaService.getComponentDefinitionFromUri('unknown:foo')).toEqual({ uri: 'unknown:foo' });
-    });
-
-    it('parses simple component uri', () => {
-      vi.spyOn(CamelCatalogService, 'getComponent').mockReturnValueOnce({
-        component: { syntax: 'timer:timerName' },
-        propertiesSchema: { required: ['timerName'] },
-      } as ICamelComponentDefinition);
-      expect(CamelComponentSchemaService.getComponentDefinitionFromUri('timer:myTimer')).toEqual({
-        uri: 'timer',
-        parameters: { timerName: 'myTimer' },
-      });
-    });
-
-    it('parses uri with query parameters', () => {
-      vi.spyOn(CamelCatalogService, 'getComponent').mockReturnValueOnce({
-        component: { syntax: 'timer:timerName' },
-        propertiesSchema: {
-          required: ['timerName'],
-        },
-      } as ICamelComponentDefinition);
-      expect(CamelComponentSchemaService.getComponentDefinitionFromUri('timer:myTimer?period=1000&delay=500')).toEqual({
-        uri: 'timer',
-        parameters: { timerName: 'myTimer', period: 1000, delay: 500 },
-      });
-    });
-
-    it('parses kamelet uri', () => {
-      vi.spyOn(CamelCatalogService, 'getComponent').mockReturnValueOnce(undefined);
-      expect(CamelComponentSchemaService.getComponentDefinitionFromUri('kamelet:beer-source')).toEqual({
-        uri: 'kamelet:beer-source',
-      });
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -1,7 +1,7 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { cloneDeep } from 'lodash';
 
-import { CamelUriHelper, DATAMAPPER_ID_PREFIX, ParsedParameters } from '../../../../utils';
+import { CamelUriHelper, DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
 import { REST_DSL_VERBS } from '../../../special-processors.constants';
 import { IVisualizationNodeIds } from '../../base-visual-entity';
@@ -212,24 +212,6 @@ export class CamelComponentSchemaService {
     const processorDefinition = CamelCatalogService.getComponent(CatalogKind.Processor, processorName);
 
     return Object.keys(processorDefinition?.properties ?? {}).includes('disabled');
-  }
-
-  static getComponentDefinitionFromUri(uri: string): { uri: string; parameters?: ParsedParameters } {
-    const componentName = CamelComponentSchemaService.getComponentNameFromUri(uri);
-    if (!componentName) return { uri: uri };
-
-    const component = CamelCatalogService.getComponent(CatalogKind.Component, componentName);
-    if (!component) {
-      return { uri: uri };
-    }
-
-    const [path, query] = uri.split('?');
-    const pathParams = CamelUriHelper.getParametersFromPathString(component?.component.syntax, path, {
-      requiredParameters: component?.propertiesSchema.required as [],
-    });
-
-    const queryParams = CamelUriHelper.getParametersFromQueryString(query);
-    return { uri: componentName, parameters: { ...pathParams, ...queryParams } };
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/ui/src/serializers/xml/kaoto-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/kaoto-xml-parser.test.ts
@@ -47,7 +47,7 @@ describe('XmlParser', () => {
     expect(result).toEqual([
       {
         route: {
-          from: { uri: 'direct:start', steps: [] },
+          from: { uri: 'direct', parameters: { name: 'start' }, steps: [] },
         },
       },
     ]);
@@ -58,11 +58,11 @@ describe('XmlParser', () => {
     const result = await parser.parseXML(xml);
     expect(result).toEqual([
       {
-        route: { id: 'test', from: { uri: 'direct:first', steps: [] } },
+        route: { id: 'test', from: { uri: 'direct', parameters: { name: 'first' }, steps: [] } },
       },
       {
         route: {
-          from: { uri: 'direct:second', steps: [] },
+          from: { uri: 'direct', parameters: { name: 'second' }, steps: [] },
         },
       },
     ]);

--- a/packages/ui/src/serializers/xml/parsers/route-xml-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/route-xml-parser.test.ts
@@ -46,7 +46,7 @@ describe('RouteXmlParser', () => {
       intercept: {
         id: 'intercept1',
         onWhen: { simple: { expression: "${in.body} contains 'Hello'" } },
-        steps: [{ to: { uri: 'mock:intercepted' } }],
+        steps: [{ to: { uri: 'mock', parameters: { name: 'intercepted' } } }],
       },
     });
   });
@@ -60,7 +60,7 @@ describe('RouteXmlParser', () => {
       interceptFrom: {
         id: 'interceptFrom1',
         uri: 'jms*',
-        steps: [{ to: { uri: 'log:incoming' } }],
+        steps: [{ to: { uri: 'log', parameters: { loggerName: 'incoming' } } }],
       },
     });
   });
@@ -83,7 +83,8 @@ describe('RouteXmlParser', () => {
         steps: [
           {
             to: {
-              uri: 'bean:beforeKafka',
+              uri: 'bean',
+              parameters: { beanName: 'beforeKafka' },
             },
           },
         ],
@@ -130,13 +131,14 @@ describe('RouteXmlParser', () => {
                           { key: 'ns3', value: 'n3' },
                         ],
                       },
-                      steps: [{ to: { uri: 'mock:bar' } }],
+                      steps: [{ to: { uri: 'mock', parameters: { name: 'bar' } } }],
                     },
                   ],
                 },
               },
             ],
-            uri: 'direct:one',
+            uri: 'direct',
+            parameters: { name: 'one' },
           },
         },
       },

--- a/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
@@ -283,13 +283,46 @@ describe('parser basics', () => {
       expect(result.completion).toBe('direct:complete');
     });
 
-    it('should return empty object when uri attribute is empty', () => {
+    it('should return empty object when uri attribute is empty', async () => {
       const element = mockDocument.createElement('to');
       element.setAttribute('uri', '');
 
-      const result = StepParser['parseAttributeType']('uri', element);
+      const result = await StepParser['parseAttributeType']('uri', element);
 
       expect(result).toEqual({});
+    });
+
+    it('should return raw uri when component is not found in catalog', async () => {
+      // 'nonexistent-scheme' is not in the real catalog — confirms the "not found" round-trip path
+      const element = mockDocument.createElement('to');
+      element.setAttribute('uri', 'nonexistent-scheme:foo');
+
+      const result = await StepParser['parseAttributeType']('uri', element);
+
+      expect(result).toEqual({ uri: 'nonexistent-scheme:foo' });
+    });
+
+    it('should parse uri into componentName and parameters when component is found', async () => {
+      // 'timer' is present in the real catalog loaded in beforeAll
+      // getParsedValue coerces numeric strings to numbers — assert 1000, not '1000'
+      const element = mockDocument.createElement('to');
+      element.setAttribute('uri', 'timer:myTimer?period=1000');
+
+      const result = await StepParser['parseAttributeType']('uri', element);
+
+      expect(result).toMatchObject({
+        uri: 'timer',
+        parameters: expect.objectContaining({ timerName: 'myTimer', period: 1000 }),
+      });
+    });
+
+    it('should return raw uri for non-uri attribute names', async () => {
+      const element = mockDocument.createElement('log');
+      element.setAttribute('message', 'Hello');
+
+      const result = await StepParser['parseAttributeType']('message', element);
+
+      expect(result).toEqual({ message: 'Hello' });
     });
 
     it('should return undefined when findSingleElement has no oneOf and element not found', () => {
@@ -358,7 +391,7 @@ describe('ProcessorParser', () => {
     expect(result).toEqual({
       exception: ['java.lang.Exception'],
       handled: { constant: { expression: 'true' } },
-      steps: [{ to: { uri: 'mock:error' } }],
+      steps: [{ to: { uri: 'mock', parameters: { name: 'error' } } }],
     });
   });
 
@@ -371,7 +404,7 @@ describe('ProcessorParser', () => {
 
     const result = await StepParser.parseElement(onCompletionElement);
     expect(result).toEqual({
-      steps: [{ to: { uri: 'mock:completion' } }],
+      steps: [{ to: { uri: 'mock', parameters: { name: 'completion' } } }],
     });
   });
 
@@ -393,11 +426,11 @@ describe('ProcessorParser', () => {
       when: [
         {
           simple: { expression: "${header.foo} == 'bar'" },
-          steps: [{ to: { uri: 'mock:when' } }],
+          steps: [{ to: { uri: 'mock', parameters: { name: 'when' } } }],
         },
       ],
       otherwise: {
-        steps: [{ to: { uri: 'mock:otherwise' } }],
+        steps: [{ to: { uri: 'mock', parameters: { name: 'otherwise' } } }],
       },
     });
   });

--- a/packages/ui/src/serializers/xml/parsers/step-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.ts
@@ -18,7 +18,7 @@ import { DoCatch, DoTry, ProcessorDefinition, When1 as When } from '@kaoto/camel
 
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
 import { CatalogKind, ICamelProcessorDefinition, ICamelProcessorProperty } from '../../../models';
-import { CamelComponentSchemaService } from '../../../models/visualization/flows/support/camel-component-schema.service';
+import { CamelUriHelper } from '../../../utils';
 import { ARRAY_TYPE_NAMES, extractAttributesFromXmlElement, PROCESSOR_NAMES } from '../utils/xml-utils';
 import { ExpressionParser } from './expression-parser';
 
@@ -75,7 +75,7 @@ export class StepParser {
           break;
         case 'attribute':
           if (element.hasAttribute(name)) {
-            processor = { ...processor, ...this.parseAttributeType(name, element) };
+            processor = { ...processor, ...(await this.parseAttributeType(name, element)) };
           }
           break;
         case 'expression':
@@ -117,11 +117,28 @@ export class StepParser {
     return undefined;
   }
 
-  private static parseAttributeType(name: string, element: Element): { [key: string]: unknown } {
+  private static async parseAttributeType(name: string, element: Element): Promise<{ [key: string]: unknown }> {
     if (name === 'uri') {
       const uriString = element.getAttribute('uri');
       if (!uriString) return {};
-      return CamelComponentSchemaService.getComponentDefinitionFromUri(uriString) ?? {};
+
+      // Inline component name extraction (mirrors getComponentNameFromUri logic)
+      const uriParts = uriString.split(':');
+      const componentName =
+        uriParts[0] === 'kamelet' && uriParts.length > 1 ? `kamelet:${uriParts[1].split('?')[0]}` : uriParts[0];
+      if (!componentName) return { uri: uriString };
+
+      const component = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, componentName);
+      if (!component) return { uri: uriString };
+
+      const qIdx = uriString.indexOf('?');
+      const path = qIdx === -1 ? uriString : uriString.slice(0, qIdx);
+      const query = qIdx === -1 ? undefined : uriString.slice(qIdx + 1);
+      const pathParams = CamelUriHelper.getParametersFromPathString(component.component.syntax, path, {
+        requiredParameters: component.propertiesSchema.required as string[],
+      });
+      const queryParams = CamelUriHelper.getParametersFromQueryString(query);
+      return { uri: componentName, parameters: { ...pathParams, ...queryParams } };
     }
     if (element.hasAttribute(name)) {
       return { [name]: element.getAttribute(name) };

--- a/packages/ui/src/stubs/camel-route.ts
+++ b/packages/ui/src/stubs/camel-route.ts
@@ -87,7 +87,8 @@ export const doTryCamelRouteJson = {
   route: {
     id: 'route-1137',
     from: {
-      uri: 'direct:start',
+      uri: 'direct',
+      parameters: { name: 'start' },
       steps: [
         {
           doTry: {
@@ -99,7 +100,8 @@ export const doTryCamelRouteJson = {
               },
               {
                 to: {
-                  uri: 'mock:result',
+                  uri: 'mock',
+                  parameters: { name: 'result' },
                 },
               },
             ],
@@ -109,7 +111,8 @@ export const doTryCamelRouteJson = {
                 steps: [
                   {
                     to: {
-                      uri: 'mock:catch',
+                      uri: 'mock',
+                      parameters: { name: 'catch' },
                     },
                   },
                 ],
@@ -125,7 +128,8 @@ export const doTryCamelRouteJson = {
                 steps: [
                   {
                     to: {
-                      uri: 'mock:catchCamel',
+                      uri: 'mock',
+                      parameters: { name: 'catchCamel' },
                     },
                   },
                 ],
@@ -136,7 +140,8 @@ export const doTryCamelRouteJson = {
               steps: [
                 {
                   to: {
-                    uri: 'mock:finally',
+                    uri: 'mock',
+                    parameters: { name: 'finally' },
                   },
                 },
               ],

--- a/packages/ui/src/stubs/eip-entity-snippets.ts
+++ b/packages/ui/src/stubs/eip-entity-snippets.ts
@@ -21,7 +21,7 @@ import {
 } from '@kaoto/camel-catalog/types';
 
 export const aggregateEntity = {
-  steps: [{ to: { uri: 'mock:result' } }],
+  steps: [{ to: { uri: 'mock', parameters: { name: 'result' } } }],
   aggregationStrategy: 'myAppender',
   aggregationStrategyMethodAllowNull: 'true',
   aggregationStrategyMethodName: 'append',
@@ -39,38 +39,50 @@ export const aggregateEntity = {
 };
 
 export const circuitBreakerEntity: CircuitBreaker = {
-  steps: [{ to: { uri: 'http://fooservice.com/slow' } }],
+  steps: [{ to: { uri: 'http', parameters: { httpUri: 'fooservice.com/slow' } } }],
   onFallback: { steps: [{ transform: { constant: { expression: 'Fallback message' } } }] },
 };
 
 export const filterEntity: Filter1 = {
   xpath: { expression: "/person[@name='James']" },
-  steps: [{ to: { uri: 'mock:result' } }],
+  steps: [{ to: { uri: 'mock', parameters: { name: 'result' } } }],
 };
 
 export const loadBalanceEntity: LoadBalance = {
-  steps: [{ to: { uri: 'seda:x' } }, { to: { uri: 'seda:y' } }, { to: { uri: 'seda:z' } }],
+  steps: [
+    { to: { uri: 'seda', parameters: { name: 'x' } } },
+    { to: { uri: 'seda', parameters: { name: 'y' } } },
+    { to: { uri: 'seda', parameters: { name: 'z' } } },
+  ],
   roundRobinLoadBalancer: {},
 };
 
 export const loopEntity: Loop = {
-  steps: [{ to: { uri: 'mock:result' } }],
+  steps: [{ to: { uri: 'mock', parameters: { name: 'result' } } }],
   header: { expression: 'loop' },
 };
 
 export const multicastEntity = {
-  steps: [{ to: { uri: 'direct:b' } }, { to: { uri: 'direct:c' } }, { to: { uri: 'direct:d' } }],
+  steps: [
+    { to: { uri: 'direct', parameters: { name: 'b' } } },
+    { to: { uri: 'direct', parameters: { name: 'c' } } },
+    { to: { uri: 'direct', parameters: { name: 'd' } } },
+  ],
   parallelProcessing: 'true',
   timeout: '5000',
   aggregationStrategy: '#class:com.foo.MyAggregationStrategy',
 };
 
 export const pipelineEntity: Pipeline = {
-  steps: [{ to: { uri: 'bean:foo' } }, { to: { uri: 'bean:bar' } }, { to: { uri: 'activemq:wine' } }],
+  steps: [
+    { to: { uri: 'bean', parameters: { beanName: 'foo' } } },
+    { to: { uri: 'bean', parameters: { beanName: 'bar' } } },
+    { to: { uri: 'activemq', parameters: { destinationType: 'queue', destinationName: 'wine' } } },
+  ],
 };
 
 export const resequenceEntity: Resequence = {
-  steps: [{ to: { uri: 'mock:result' } }],
+  steps: [{ to: { uri: 'mock', parameters: { name: 'result' } } }],
   simple: { expression: 'body' },
   batchConfig: {
     batchSize: '300',
@@ -91,24 +103,28 @@ export const sagaEntity: Saga = {
 export const splitEntity: Split = {
   parallelProcessing: 'true',
   simple: { expression: 'body' },
-  steps: [{ to: { uri: 'direct:b' } }, { to: { uri: 'direct:c' } }, { to: { uri: 'direct:d' } }],
+  steps: [
+    { to: { uri: 'direct', parameters: { name: 'b' } } },
+    { to: { uri: 'direct', parameters: { name: 'c' } } },
+    { to: { uri: 'direct', parameters: { name: 'd' } } },
+  ],
 };
 
 export const choiceEntity: Choice = {
-  when: [{ xpath: { expression: '/ns1:foo/' }, steps: [{ to: { uri: 'mock:bar' } }] }],
-  otherwise: { steps: [{ to: { uri: 'mock:other' } }] },
+  when: [{ xpath: { expression: '/ns1:foo/' }, steps: [{ to: { uri: 'mock', parameters: { name: 'bar' } } }] }],
+  otherwise: { steps: [{ to: { uri: 'mock', parameters: { name: 'other' } } }] },
 };
 
 export const doTryEntity: DoTry = {
-  steps: [{ to: { uri: 'mock:try' } }],
+  steps: [{ to: { uri: 'mock', parameters: { name: 'try' } } }],
   doCatch: [
     {
       exception: ['java.lang.Exception'],
-      steps: [{ to: { uri: 'mock:catch' } }],
+      steps: [{ to: { uri: 'mock', parameters: { name: 'catch' } } }],
     },
   ],
   doFinally: {
-    steps: [{ to: { uri: 'mock:finally' } }],
+    steps: [{ to: { uri: 'mock', parameters: { name: 'finally' } } }],
   },
 };
 

--- a/packages/ui/src/stubs/eip-xml-snippets.ts
+++ b/packages/ui/src/stubs/eip-xml-snippets.ts
@@ -66,7 +66,7 @@ export const pipelineXml = `
 <pipeline>
   <to uri="bean:foo"/>
   <to uri="bean:bar"/>
-  <to uri="activemq:wine"/>
+  <to uri="activemq:queue:wine"/>
 </pipeline>
 `;
 

--- a/packages/ui/src/stubs/rest.ts
+++ b/packages/ui/src/stubs/rest.ts
@@ -55,7 +55,7 @@ export const restWithVerbsStup = {
           ],
         },
       ],
-      to: { uri: 'direct:hello' },
+      to: { uri: 'direct', parameters: { name: 'hello' } },
     },
     {
       path: '/bye',
@@ -63,7 +63,7 @@ export const restWithVerbsStup = {
       param: undefined,
       responseMessage: undefined,
       security: undefined,
-      to: { uri: 'direct:bye' },
+      to: { uri: 'direct', parameters: { name: 'bye' } },
     },
   ],
   post: [
@@ -72,7 +72,7 @@ export const restWithVerbsStup = {
       param: undefined,
       responseMessage: undefined,
       security: undefined,
-      to: { uri: 'mock:update' },
+      to: { uri: 'mock', parameters: { name: 'update' } },
     },
   ],
 };
@@ -102,7 +102,7 @@ export const restWithSecurityRequirementsStub = {
       param: undefined,
       responseMessage: undefined,
       security: undefined,
-      to: { uri: 'direct:getUsers' },
+      to: { uri: 'direct', parameters: { name: 'getUsers' } },
     },
   ],
 };

--- a/packages/ui/src/stubs/yaml/choice.yaml
+++ b/packages/ui/src/stubs/yaml/choice.yaml
@@ -1,6 +1,8 @@
 - route:
     from:
-      uri: direct:start
+      uri: direct
+      parameters:
+        name: start
       steps:
         - unmarshal:
             json:
@@ -9,7 +11,7 @@
             constant:
               id: kosnstanta
               expression: blabla
-              trim: "true"
+              trim: 'true'
             name: meno
         - choice:
             id: cojsa
@@ -26,39 +28,54 @@
                           - log:
                               message: Apple branch
                           - to:
-                              uri: mock:result
+                              uri: mock
+                              parameters:
+                                name: result
                 - to:
-                    uri: mock:result
+                    uri: mock
+                    parameters:
+                      name: result
             when:
               - steps:
                   - log:
                       message: Apple branch
                   - to:
-                      uri: mock:result
+                      uri: mock
+                      parameters:
+                        name: result
                 simple:
                   expression: ${body} contains 'Apple'
               - steps:
                   - log:
                       message: Banana branch
                   - to:
-                      uri: mock:result
+                      uri: mock
+                      parameters:
+                        name: result
                 simple:
                   expression: ${body} contains 'Banana'
               - steps:
                   - log:
                       message: Cherry branch
                   - to:
-                      uri: mock:result
+                      uri: mock
+                      parameters:
+                        name: result
                 simple:
                   id: houno
                   expression: ${body} contains 'Cherry'
         - log:
             message: Choice processing complete
         - to:
-            uri: mock:result
+            uri: mock
+            parameters:
+              name: result
 - route:
     from:
-      uri: timer://cherryTimer?period=1000
+      uri: timer
+      parameters:
+        timerName: cherryTimer
+        period: 1000
       steps:
         - setBody:
             constant:
@@ -77,13 +94,18 @@
             name: Fruit-Season
         - setHeader:
             constant:
-              expression: "2.75"
+              expression: '2.75'
             name: Fruit-Price
         - to:
-            uri: direct:start
+            uri: direct
+            parameters:
+              name: start
 - route:
     from:
-      uri: timer://bananaTimer?period=2000
+      uri: timer
+      parameters:
+        timerName: bananaTimer
+        period: 2000
       steps:
         - setBody:
             constant:
@@ -102,13 +124,18 @@
             name: Fruit-Season
         - setHeader:
             constant:
-              expression: "0.99"
+              expression: '0.99'
             name: Fruit-Price
         - to:
-            uri: direct:start
+            uri: direct
+            parameters:
+              name: start
 - route:
     from:
-      uri: timer://appleTimer?period=3000
+      uri: timer
+      parameters:
+        timerName: appleTimer
+        period: 3000
       steps:
         - setBody:
             constant:
@@ -127,7 +154,9 @@
             name: Fruit-Season
         - setHeader:
             constant:
-              expression: "1.50"
+              expression: '1.50'
             name: Fruit-Price
         - to:
-            uri: direct:start
+            uri: direct
+            parameters:
+              name: start

--- a/packages/ui/src/stubs/yaml/doTry.yaml
+++ b/packages/ui/src/stubs/yaml/doTry.yaml
@@ -1,14 +1,18 @@
 - route:
     id: 'route-1137'
     from:
-      uri: 'direct:start'
+      uri: 'direct'
+      parameters:
+        name: 'start'
       steps:
         - doTry:
             steps:
               - process:
                   ref: 'processorFail'
               - to:
-                  uri: 'mock:result'
+                  uri: 'mock'
+                  parameters:
+                    name: 'result'
             doCatch:
               - id: 'first'
                 exception:
@@ -19,14 +23,20 @@
                     expression: "${exception.message} contains 'Damn'"
                 steps:
                   - to:
-                      uri: 'mock:catch'
+                      uri: 'mock'
+                      parameters:
+                        name: 'catch'
               - id: 'second'
                 exception:
                   - 'org.apache.camel.CamelExchangeException'
                 steps:
                   - to:
-                      uri: 'mock:catchCamel'
+                      uri: 'mock'
+                      parameters:
+                        name: 'catchCamel'
             doFinally:
               steps:
                 - to:
-                    uri: 'mock:finally'
+                    uri: 'mock'
+                    parameters:
+                      name: 'finally'

--- a/packages/ui/src/stubs/yaml/rest-with-security-requirements.yaml
+++ b/packages/ui/src/stubs/yaml/rest-with-security-requirements.yaml
@@ -21,4 +21,6 @@
     get:
       - path: '/users'
         to:
-          uri: direct:getUsers
+          uri: direct
+          parameters:
+            name: getUsers

--- a/packages/ui/src/stubs/yaml/rest.yaml
+++ b/packages/ui/src/stubs/yaml/rest.yaml
@@ -4,23 +4,23 @@
         flow: application
         key: oauth2
         scopes:
-          - key: "{{oauth.scope.service.self}}"
-            value: "{{oauth.scope.service.self}}"
-          - key: "{{oauth.scope.test.person.data}}"
-            value: "{{oauth.scope.test.person.data}}"
-        tokenUrl: "{{oauth.token.url}}"
+          - key: '{{oauth.scope.service.self}}'
+            value: '{{oauth.scope.service.self}}'
+          - key: '{{oauth.scope.test.person.data}}'
+            value: '{{oauth.scope.test.person.data}}'
+        tokenUrl: '{{oauth.token.url}}'
     get:
       - param:
           - name: name
-            required: "true"
+            required: 'true'
             type: query
           - defaultValue: blah
             name: name2
-            required: "true"
+            required: 'true'
             type: query
         path: /hello
         responseMessage:
-          - code: "200"
+          - code: '200'
             examples:
               - key: example
                 value: value
@@ -29,21 +29,27 @@
             header:
               - description: header
                 allowableValues:
-                  - value: "1"
-                  - value: "2"
+                  - value: '1'
+                  - value: '2'
                 name: header
             message: hello
         security:
           - key: hello
             scopes: scope
         to:
-          uri: direct:hello
+          uri: direct
+          parameters:
+            name: hello
       - consumes: application/json
         path: /bye
         to:
-          uri: direct:bye
+          uri: direct
+          parameters:
+            name: bye
     path: /say
     post:
       - path: /bye
         to:
-          uri: mock:update
+          uri: mock
+          parameters:
+            name: update


### PR DESCRIPTION
Closes https://github.com/KaotoIO/kaoto/issues/3761

## Summary

Removes the last XML deserialization path that still relied on the synchronous, static `CamelCatalogService`. Every other call site had already migrated to `DynamicCatalogRegistry`.

## Changes

- **`StepParser.parseAttributeType`** — made `async`; replaces the call to `getComponentDefinitionFromUri` with an inline lookup via `DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, ...)` + `CamelUriHelper` helpers.
- **`CamelComponentSchemaService.getComponentDefinitionFromUri`** — deleted.
- **Tests & stubs** — async tests updated; `describe('getComponentDefinitionFromUri')` block removed; expected entity shapes updated to reflect the correctly decomposed `{ uri, parameters }` form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML, YAML, and route parsing so endpoint URIs are consistently normalized into component names and structured parameters.
  * Added asynchronous resolution for dynamic component catalog entries.
  * Corrected handling of direct, mock, timer, intercept, logging, bean, and related endpoints.

* **Tests**
  * Expanded coverage for asynchronous URI resolution and normalized endpoint structures.
  * Updated route, YAML, and parser expectations to reflect structured URI parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->