### PR TITLE
fix(e2e): removed unnecessary fixed cy.wait

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/branchingFlows/branchingStepAddition.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/branchingFlows/branchingStepAddition.cy.ts
@@ -12,8 +12,6 @@ describe('Test for Branching actions from the canvas', () => {
 
     cy.get('#otherwise').should('not.exist');
     cy.get('#when').should('be.visible').click();
-    // wait for the canvas rerender
-    cy.wait(1000);
     cy.checkNodeExist('when', 6);
   });
 
@@ -23,12 +21,8 @@ describe('Test for Branching actions from the canvas', () => {
 
     cy.checkNodeExist('when', 5);
     cy.removeNodeByName('when', 0);
-    // wait for the canvas rerender
-    cy.wait(1000);
     cy.checkNodeExist('otherwise', 2);
     cy.removeNodeByName('otherwise');
-    // wait for the canvas rerender
-    cy.wait(1000);
     cy.checkNodeExist('otherwise', 2);
     // once there are is no "otherwise" node in the canvas - it shuld be again selectable in the special node insert
     cy.selectInsertSpecialNode('choice');


### PR DESCRIPTION
fixes https://github.com/KaotoIO/kaoto/issues/3706

Removed three cy.wait(1000) calls from branchingStepAddition.cy.ts that were used to pause for canvas re-renders after branch add/delete  operations. Cypress retries .should() assertions automatically, so the subsequent cy.checkNodeExist() calls already synchronize on the observable DOM condition (node count) without any fixed delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved branching-flow end-to-end tests by removing unnecessary fixed delays.
  * Canvas node checks and branch deletion steps now run without artificial pauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->