### PR TITLE
feat(DataMapper): add UI toggle and step synchronization for output validation (S6, S7)

### DIFF
--- a/packages/ui/src/components/DataMapper/DataMapper.sync.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.sync.test.tsx
@@ -47,7 +47,8 @@ vi.mock('../../components/DataMapper/DataMapperControl', () => ({
   },
 }));
 
-describe('DataMapper sync — onUpdateDocument validation step synchronization', () => {
+// Output validation auto-sync: skipped until feature is complete
+describe.skip('DataMapper sync — onUpdateDocument validation step synchronization', () => {
   const mockEntitiesContext = {
     updateSourceCodeFromEntities: vi.fn(),
     updateEntitiesFromCamelResource: vi.fn(),
@@ -87,7 +88,7 @@ describe('DataMapper sync — onUpdateDocument validation step synchronization',
   let metadata: IDataMapperMetadata;
   let fileContents: Record<string, string>;
 
-  const api: IMetadataApi = {
+  const api = {
     getMetadata: (_key: string) => Promise.resolve(metadata),
     setMetadata: (_key: string, meta: IDataMapperMetadata) => {
       Object.assign(metadata, meta);
@@ -99,7 +100,7 @@ describe('DataMapper sync — onUpdateDocument validation step synchronization',
       fileContents[path] = content;
       return Promise.resolve();
     },
-  };
+  } as IMetadataApi;
 
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/packages/ui/src/components/DataMapper/DataMapper.sync.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.sync.test.tsx
@@ -1,0 +1,318 @@
+/*
+    Copyright (C) 2024 Red Hat, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+import { useDataMapper } from '../../hooks/useDataMapper';
+import { IVisualizationNode } from '../../models';
+import {
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentType,
+  PrimitiveDocument,
+} from '../../models/datamapper/document';
+import { IDataMapperMetadata } from '../../models/datamapper/metadata';
+import { EntitiesContext, EntitiesContextResult, IMetadataApi, MetadataProvider } from '../../providers';
+import { IDataMapperContext } from '../../providers/datamapper.provider';
+import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
+import { DataMapperValidationStepService } from '../../services/datamapper-validation-step.service';
+import { EMPTY_XSL } from '../../services/mapping/mapping-serializer.service';
+import { DataMapper } from './DataMapper';
+
+vi.mock('monaco-editor', () => ({
+  languages: {
+    CompletionItemKind: { Keyword: 17, Function: 1 },
+    CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+  },
+}));
+
+let capturedContext: IDataMapperContext;
+
+vi.mock('../../components/DataMapper/DataMapperControl', () => ({
+  DataMapperControl: () => {
+    capturedContext = useDataMapper();
+    return <div data-testid="source-parameters-header" />;
+  },
+}));
+
+describe('DataMapper sync — onUpdateDocument validation step synchronization', () => {
+  const mockEntitiesContext = {
+    updateSourceCodeFromEntities: vi.fn(),
+    updateEntitiesFromCamelResource: vi.fn(),
+    entities: [],
+    currentSchemaType: 'Route',
+    visualEntities: [],
+    camelResource: {},
+  } as unknown as EntitiesContextResult;
+
+  /** vizNode with both XSLT and validator steps already present */
+  const createVizNodeWithValidator = (...stepUris: string[]) =>
+    ({
+      getId: () => 'route-1234',
+      getNodeDefinition: () => ({
+        id: 'kaoto-datamapper-1234',
+        steps: stepUris.map((uri) => ({ to: { id: `id-${uri}`, uri } })),
+      }),
+      updateModel: vi.fn(),
+    }) as unknown as IVisualizationNode;
+
+  const vizNodeWithValidator = createVizNodeWithValidator(
+    'xslt-saxon:kaoto-datamapper-1234.xsl',
+    'validator:ShipOrder.xsd',
+  );
+
+  const vizNodeWithoutValidator = createVizNodeWithValidator('xslt-saxon:kaoto-datamapper-1234.xsl');
+
+  const createTargetDefinition = (
+    definitionType: DocumentDefinitionType,
+    definitionFiles: Record<string, string> = {},
+  ) => new DocumentDefinition(DocumentType.TARGET_BODY, definitionType, 'Body', definitionFiles);
+
+  const primitiveDoc = new PrimitiveDocument(
+    new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, 'Body'),
+  );
+
+  let metadata: IDataMapperMetadata;
+  let fileContents: Record<string, string>;
+
+  const api: IMetadataApi = {
+    getMetadata: (_key: string) => Promise.resolve(metadata),
+    setMetadata: (_key: string, meta: IDataMapperMetadata) => {
+      Object.assign(metadata, meta);
+      return Promise.resolve();
+    },
+    getResourceContent: (path: string) => Promise.resolve(fileContents[path]),
+    isResourceExist: (path: string) => Promise.resolve(fileContents[path] !== undefined),
+    saveResourceContent: (path: string, content: string) => {
+      fileContents[path] = content;
+      return Promise.resolve();
+    },
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+
+    metadata = {
+      sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+      sourceParameters: {},
+      targetBody: { type: DocumentDefinitionType.XML_SCHEMA, filePath: ['ShipOrder.xsd'] },
+      xsltPath: 'kaoto-datamapper-1234.xsl',
+    };
+    fileContents = {
+      'kaoto-datamapper-1234.xsl': EMPTY_XSL,
+    };
+
+    // Simulate the in-place mutation that the real updateTargetBodyMetadata performs
+    vi.spyOn(DataMapperMetadataService, 'updateTargetBodyMetadata').mockImplementation(
+      async (_api, _metadataId, meta, definition) => {
+        meta.targetBody = {
+          type: definition.definitionType,
+          filePath: definition.definitionFiles ? Object.keys(definition.definitionFiles) : [],
+        };
+      },
+    );
+  });
+
+  const renderDataMapper = (vizNode: IVisualizationNode) => {
+    render(
+      <EntitiesContext.Provider value={mockEntitiesContext}>
+        <MetadataProvider api={api}>
+          <DataMapper vizNode={vizNode} />
+        </MetadataProvider>
+      </EntitiesContext.Provider>,
+    );
+  };
+
+  it('1. schema file changed, validation enabled → updateValidationStep called', async () => {
+    const updateSpy = vi.spyOn(DataMapperValidationStepService, 'updateValidationStep').mockImplementation(() => {});
+    const addSpy = vi.spyOn(DataMapperValidationStepService, 'addValidationStep').mockImplementation(() => {});
+    vi.spyOn(DataMapperValidationStepService, 'isValidationEnabled').mockReturnValue(true);
+
+    renderDataMapper(vizNodeWithValidator);
+    await screen.findByTestId('source-parameters-header');
+
+    const definition = createTargetDefinition(DocumentDefinitionType.XML_SCHEMA, { 'NewOrder.xsd': '<schema/>' });
+    await act(async () => {
+      capturedContext.updateDocument(primitiveDoc, definition, '');
+    });
+
+    await waitFor(() => {
+      expect(DataMapperMetadataService.updateTargetBodyMetadata).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith(
+        vizNodeWithValidator,
+        expect.objectContaining({ type: DocumentDefinitionType.XML_SCHEMA, filePath: ['NewOrder.xsd'] }),
+        mockEntitiesContext,
+      );
+    });
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it('2. schema changed, validation NOT enabled → auto-add via addValidationStep', async () => {
+    metadata.targetBody = { type: DocumentDefinitionType.Primitive, filePath: [] };
+
+    const addSpy = vi.spyOn(DataMapperValidationStepService, 'addValidationStep').mockImplementation(() => {});
+    const updateSpy = vi.spyOn(DataMapperValidationStepService, 'updateValidationStep').mockImplementation(() => {});
+    vi.spyOn(DataMapperValidationStepService, 'isValidationEnabled').mockReturnValue(false);
+
+    renderDataMapper(vizNodeWithoutValidator);
+    await screen.findByTestId('source-parameters-header');
+
+    const definition = createTargetDefinition(DocumentDefinitionType.XML_SCHEMA, { 'ShipOrder.xsd': '<schema/>' });
+    await act(async () => {
+      capturedContext.updateDocument(primitiveDoc, definition, '');
+    });
+
+    await waitFor(() => {
+      expect(DataMapperMetadataService.updateTargetBodyMetadata).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(addSpy).toHaveBeenCalledWith(
+        vizNodeWithoutValidator,
+        expect.objectContaining({ type: DocumentDefinitionType.XML_SCHEMA, filePath: ['ShipOrder.xsd'] }),
+        mockEntitiesContext,
+      );
+    });
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('3. type changed from XML to JSON, validation enabled → updateValidationStep with JSON metadata', async () => {
+    const updateSpy = vi.spyOn(DataMapperValidationStepService, 'updateValidationStep').mockImplementation(() => {});
+    vi.spyOn(DataMapperValidationStepService, 'isValidationEnabled').mockReturnValue(true);
+
+    renderDataMapper(vizNodeWithValidator);
+    await screen.findByTestId('source-parameters-header');
+
+    const definition = createTargetDefinition(DocumentDefinitionType.JSON_SCHEMA, { 'schema.json': '{}' });
+    await act(async () => {
+      capturedContext.updateDocument(primitiveDoc, definition, '');
+    });
+
+    await waitFor(() => {
+      expect(DataMapperMetadataService.updateTargetBodyMetadata).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith(
+        vizNodeWithValidator,
+        expect.objectContaining({ type: DocumentDefinitionType.JSON_SCHEMA, filePath: ['schema.json'] }),
+        mockEntitiesContext,
+      );
+    });
+  });
+
+  it('4. schema removed (→Primitive), validation enabled → updateValidationStep with Primitive metadata', async () => {
+    const updateSpy = vi.spyOn(DataMapperValidationStepService, 'updateValidationStep').mockImplementation(() => {});
+    vi.spyOn(DataMapperValidationStepService, 'isValidationEnabled').mockReturnValue(true);
+
+    renderDataMapper(vizNodeWithValidator);
+    await screen.findByTestId('source-parameters-header');
+
+    const definition = createTargetDefinition(DocumentDefinitionType.Primitive, {});
+    await act(async () => {
+      capturedContext.updateDocument(primitiveDoc, definition, '');
+    });
+
+    await waitFor(() => {
+      expect(DataMapperMetadataService.updateTargetBodyMetadata).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith(
+        vizNodeWithValidator,
+        expect.objectContaining({ type: DocumentDefinitionType.Primitive, filePath: [] }),
+        mockEntitiesContext,
+      );
+    });
+  });
+
+  it('5. schema removed (→Primitive), validation NOT enabled → no service calls', async () => {
+    metadata.targetBody = { type: DocumentDefinitionType.Primitive, filePath: [] };
+
+    const updateSpy = vi.spyOn(DataMapperValidationStepService, 'updateValidationStep').mockImplementation(() => {});
+    const addSpy = vi.spyOn(DataMapperValidationStepService, 'addValidationStep').mockImplementation(() => {});
+    const removeSpy = vi.spyOn(DataMapperValidationStepService, 'removeValidationStep').mockImplementation(() => {});
+    vi.spyOn(DataMapperValidationStepService, 'isValidationEnabled').mockReturnValue(false);
+
+    renderDataMapper(vizNodeWithoutValidator);
+    await screen.findByTestId('source-parameters-header');
+
+    const definition = createTargetDefinition(DocumentDefinitionType.Primitive, {});
+    await act(async () => {
+      capturedContext.updateDocument(primitiveDoc, definition, '');
+    });
+
+    await waitFor(() => {
+      expect(DataMapperMetadataService.updateTargetBodyMetadata).toHaveBeenCalled();
+    });
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(addSpy).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  it('6. type override adds additional schema files, validation enabled → updateValidationStep with multi-file metadata', async () => {
+    const updateSpy = vi.spyOn(DataMapperValidationStepService, 'updateValidationStep').mockImplementation(() => {});
+    vi.spyOn(DataMapperValidationStepService, 'isValidationEnabled').mockReturnValue(true);
+
+    renderDataMapper(vizNodeWithValidator);
+    await screen.findByTestId('source-parameters-header');
+
+    const definition = createTargetDefinition(DocumentDefinitionType.XML_SCHEMA, {
+      'ShipOrder.xsd': '<schema/>',
+      'CustomTypes.xsd': '<additional/>',
+    });
+    await act(async () => {
+      capturedContext.updateDocument(primitiveDoc, definition, '');
+    });
+
+    await waitFor(() => {
+      expect(DataMapperMetadataService.updateTargetBodyMetadata).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith(
+        vizNodeWithValidator,
+        expect.objectContaining({
+          type: DocumentDefinitionType.XML_SCHEMA,
+          filePath: expect.arrayContaining(['ShipOrder.xsd', 'CustomTypes.xsd']),
+        }),
+        mockEntitiesContext,
+      );
+    });
+  });
+
+  it('7. isOutputValidationEnabled state refreshed after sync', async () => {
+    const isValidationEnabledSpy = vi
+      .spyOn(DataMapperValidationStepService, 'isValidationEnabled')
+      .mockReturnValue(true);
+    vi.spyOn(DataMapperValidationStepService, 'updateValidationStep').mockImplementation(() => {});
+
+    renderDataMapper(vizNodeWithValidator);
+    await screen.findByTestId('source-parameters-header');
+
+    const callCountBefore = isValidationEnabledSpy.mock.calls.length;
+
+    const definition = createTargetDefinition(DocumentDefinitionType.XML_SCHEMA, { 'NewOrder.xsd': '<schema/>' });
+    await act(async () => {
+      capturedContext.updateDocument(primitiveDoc, definition, '');
+    });
+
+    await waitFor(() => {
+      expect(DataMapperMetadataService.updateTargetBodyMetadata).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      // isValidationEnabled should be called again after sync to refresh state
+      expect(isValidationEnabledSpy.mock.calls.length).toBeGreaterThan(callCountBefore);
+    });
+  });
+});

--- a/packages/ui/src/components/DataMapper/DataMapper.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.test.tsx
@@ -8,6 +8,7 @@ import { DocumentDefinitionType } from '../../models/datamapper/document';
 import { IDataMapperMetadata } from '../../models/datamapper/metadata';
 import { IMetadataApi, MetadataProvider } from '../../providers';
 import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
+import { DataMapperValidationStepService } from '../../services/datamapper-validation-step.service';
 import { EMPTY_XSL } from '../../services/mapping/mapping-serializer.service';
 import { getShipOrderToShipOrderXslt, getShipOrderXsd } from '../../stubs/datamapper/data-mapper';
 import { DataMapper } from './DataMapper';
@@ -237,5 +238,83 @@ describe('DataMapperPage', () => {
     });
 
     saveResourceContentSpy.mockRestore();
+  });
+
+  describe('Output Validation', () => {
+    const vizNodeWithSteps = {
+      getId: () => 'route-1234',
+      getNodeDefinition: () => ({
+        id: 'kaoto-datamapper-1234',
+        steps: [{ to: { id: 'xslt-1', uri: 'xslt-saxon:kaoto-datamapper-1234.xsl' } }],
+      }),
+      updateModel: vi.fn(),
+    } as unknown as IVisualizationNode;
+
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      metadata = defaultMetadata;
+      fileContents = {};
+    });
+
+    it('should read initial validation state via isValidationEnabled on mount', async () => {
+      const isValidationEnabledSpy = vi
+        .spyOn(DataMapperValidationStepService, 'isValidationEnabled')
+        .mockReturnValue(true);
+
+      fileContents[metadata.xsltPath] = EMPTY_XSL;
+
+      renderWithVirtuoso(
+        <MetadataProvider api={api}>
+          <DataMapper vizNode={vizNodeWithSteps} />
+        </MetadataProvider>,
+      );
+
+      await screen.findByTestId('source-parameters-header');
+
+      await waitFor(() => {
+        expect(isValidationEnabledSpy).toHaveBeenCalledWith(vizNodeWithSteps);
+      });
+    });
+
+    it('should not call isValidationEnabled when vizNode has no steps', async () => {
+      const emptyVizNode = {
+        getId: () => 'route-1234',
+        getNodeDefinition: () => ({ id: 'kaoto-datamapper-1234' }),
+      } as unknown as IVisualizationNode;
+
+      const isValidationEnabledSpy = vi
+        .spyOn(DataMapperValidationStepService, 'isValidationEnabled')
+        .mockReturnValue(false);
+
+      fileContents[metadata.xsltPath] = EMPTY_XSL;
+
+      renderWithVirtuoso(
+        <MetadataProvider api={api}>
+          <DataMapper vizNode={emptyVizNode} />
+        </MetadataProvider>,
+      );
+
+      await screen.findByTestId('source-parameters-header');
+
+      expect(isValidationEnabledSpy).toHaveBeenCalledWith(emptyVizNode);
+    });
+
+    it('should pass isOutputValidationEnabled and onSetOutputValidationEnabled to DataMapperProvider', async () => {
+      vi.spyOn(DataMapperValidationStepService, 'isValidationEnabled').mockReturnValue(false);
+      vi.spyOn(DataMapperValidationStepService, 'addValidationStep').mockImplementation(() => undefined);
+      vi.spyOn(DataMapperValidationStepService, 'removeValidationStep').mockImplementation(() => undefined);
+
+      fileContents[metadata.xsltPath] = EMPTY_XSL;
+
+      renderWithVirtuoso(
+        <MetadataProvider api={api}>
+          <DataMapper vizNode={vizNodeWithSteps} />
+        </MetadataProvider>,
+      );
+
+      await screen.findByTestId('source-parameters-header');
+
+      expect(DataMapperValidationStepService.isValidationEnabled).toHaveBeenCalledWith(vizNodeWithSteps);
+    });
   });
 });

--- a/packages/ui/src/components/DataMapper/DataMapper.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.tsx
@@ -18,7 +18,12 @@ import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useStat
 import { DataMapperControl } from '../../components/DataMapper/DataMapperControl';
 import { Loading } from '../../components/Loading';
 import { IVisualizationNode } from '../../models';
-import { DocumentDefinition, DocumentInitializationModel, DocumentType } from '../../models/datamapper/document';
+import {
+  DocumentDefinition,
+  DocumentDefinitionType,
+  DocumentInitializationModel,
+  DocumentType,
+} from '../../models/datamapper/document';
 import { IDataMapperMetadata } from '../../models/datamapper/metadata';
 import { EntitiesContext, MetadataContext } from '../../providers';
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
@@ -27,6 +32,7 @@ import { DataMapperDndProvider } from '../../providers/datamapper-dnd.provider';
 import { SourceTargetDnDHandler } from '../../providers/dnd/SourceTargetDnDHandler';
 import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
 import { DataMapperStepService } from '../../services/datamapper-step.service';
+import { DataMapperValidationStepService } from '../../services/datamapper-validation-step.service';
 import { EMPTY_XSL } from '../../services/mapping/mapping-serializer.service';
 
 export interface IDataMapperProps {
@@ -41,6 +47,7 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
   const [documentInitializationModel, setDocumentInitializationModel] = useState<DocumentInitializationModel>();
   const [initialXsltFile, setInitialXsltFile] = useState<string>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isOutputValidationEnabled, setIsOutputValidationEnabled] = useState<boolean>(false);
   const dndHandler = useMemo(() => new SourceTargetDnDHandler(), []);
 
   useEffect(() => {
@@ -63,6 +70,9 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
       setDocumentInitializationModel(initModel);
       const mappingFile = await DataMapperMetadataService.loadMappingFile(ctx, meta);
       setInitialXsltFile(mappingFile);
+      if (vizNode) {
+        setIsOutputValidationEnabled(DataMapperValidationStepService.isValidationEnabled(vizNode));
+      }
     };
     void initialize().then(() => {
       setIsLoading(false);
@@ -82,6 +92,14 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
           break;
         case DocumentType.TARGET_BODY:
           await DataMapperMetadataService.updateTargetBodyMetadata(ctx, metadataId, metadata, definition);
+          if (vizNode) {
+            if (DataMapperValidationStepService.isValidationEnabled(vizNode)) {
+              DataMapperValidationStepService.updateValidationStep(vizNode, metadata.targetBody, entitiesContext);
+            } else if (definition.definitionType !== DocumentDefinitionType.Primitive) {
+              DataMapperValidationStepService.addValidationStep(vizNode, metadata.targetBody, entitiesContext);
+            }
+            setIsOutputValidationEnabled(DataMapperValidationStepService.isValidationEnabled(vizNode));
+          }
           break;
         case DocumentType.PARAM:
           await DataMapperMetadataService.updateSourceParameterMetadata(
@@ -128,6 +146,19 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
     [ctx, metadata, metadataId],
   );
 
+  const onSetOutputValidationEnabled = useCallback(
+    (enabled: boolean) => {
+      if (!vizNode || !entitiesContext || !metadata) return;
+      if (enabled) {
+        DataMapperValidationStepService.addValidationStep(vizNode, metadata.targetBody, entitiesContext);
+      } else {
+        DataMapperValidationStepService.removeValidationStep(vizNode, entitiesContext);
+      }
+      setIsOutputValidationEnabled(DataMapperValidationStepService.isValidationEnabled(vizNode));
+    },
+    [vizNode, entitiesContext, metadata],
+  );
+
   if (!metadataId) {
     return <>No associated DataMapper step was provided.</>;
   }
@@ -145,6 +176,8 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
       initialXsltFile={initialXsltFile}
       onUpdateMappings={onUpdateMappings}
       onUpdateNamespaceMap={onUpdateNamespaceMap}
+      isOutputValidationEnabled={isOutputValidationEnabled}
+      onSetOutputValidationEnabled={onSetOutputValidationEnabled}
     >
       <DataMapperDndProvider handler={dndHandler}>
         <MappingLinksProvider>

--- a/packages/ui/src/components/DataMapper/DataMapper.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapper.tsx
@@ -92,7 +92,8 @@ export const DataMapper: FunctionComponent<IDataMapperProps> = ({ vizNode }) => 
           break;
         case DocumentType.TARGET_BODY:
           await DataMapperMetadataService.updateTargetBodyMetadata(ctx, metadataId, metadata, definition);
-          if (vizNode) {
+          // Output validation auto-sync: disabled until feature is complete — remove guard to enable
+          if (vizNode && (false as boolean)) {
             if (DataMapperValidationStepService.isValidationEnabled(vizNode)) {
               DataMapperValidationStepService.updateValidationStep(vizNode, metadata.targetBody, entitiesContext);
             } else if (definition.definitionType !== DocumentDefinitionType.Primitive) {

--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
@@ -12,7 +12,10 @@ import { IMetadataApi, MetadataContext } from '../../providers/metadata.provider
 import { Links } from '../../router/links.models';
 import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
 import { DataMapperStepService } from '../../services/datamapper-step.service';
+import { DataMapperValidationStepService } from '../../services/datamapper-validation-step.service';
 import { DataMapperLauncher } from './DataMapperLauncher';
+
+vi.mock('../../services/datamapper-validation-step.service');
 
 // Mock XsltDocumentRenameInput component
 vi.mock('./XsltDocumentRenameInput', async () => {
@@ -780,6 +783,119 @@ describe('DataMapperLauncher', () => {
         await waitFor(() => {
           expect(screen.getByTestId('xslt-document-name')).toBeInTheDocument();
           expect(screen.queryByTestId('xslt-document-name--text-input')).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('Validate Output toggle', () => {
+      beforeEach(() => {
+        // Default: file exists, XML target, validation disabled
+        mockMetadataContext.isResourceExist = vi.fn().mockResolvedValue(true);
+        const mockMeta: IDataMapperMetadata = {
+          sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+          sourceParameters: {},
+          targetBody: { type: DocumentDefinitionType.XML_SCHEMA, filePath: ['ShipOrder.xsd'] },
+          xsltPath: 'test-document.xsl',
+        };
+        mockMetadataContext.getMetadata = vi.fn().mockResolvedValue(mockMeta);
+        (DataMapperValidationStepService.isValidationEnabled as Mock).mockReturnValue(false);
+        (DataMapperStepService.getDataMapperMetadataId as Mock).mockReturnValue('test-node-id');
+      });
+
+      it('should show Validate Output checkbox when file exists and target is not Primitive', async () => {
+        const vizNode = createMockVizNode('test-document.xsl');
+        (DataMapperStepService.getXsltFileName as Mock).mockReturnValue('test-document.xsl');
+
+        render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
+
+        await waitFor(() => {
+          expect(screen.getByTestId('validate-output-checkbox')).toBeInTheDocument();
+        });
+        expect(screen.getByText('Output Validation')).toBeInTheDocument();
+      });
+
+      it('should hide Validate Output checkbox when target is Primitive', async () => {
+        const vizNode = createMockVizNode('test-document.xsl');
+        (DataMapperStepService.getXsltFileName as Mock).mockReturnValue('test-document.xsl');
+        const primitiveMeta: IDataMapperMetadata = {
+          sourceBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+          sourceParameters: {},
+          targetBody: { type: DocumentDefinitionType.Primitive, filePath: [] },
+          xsltPath: 'test-document.xsl',
+        };
+        mockMetadataContext.getMetadata = vi.fn().mockResolvedValue(primitiveMeta);
+
+        render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
+
+        await waitFor(() => {
+          expect(screen.queryByText('Document')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('validate-output-checkbox')).not.toBeInTheDocument();
+      });
+
+      it('should hide Validate Output checkbox when XSLT file does not exist', async () => {
+        const vizNode = createMockVizNode('test-document.xsl');
+        (DataMapperStepService.getXsltFileName as Mock).mockReturnValue('test-document.xsl');
+        mockMetadataContext.isResourceExist = vi.fn().mockResolvedValue(false);
+
+        render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('validate-output-checkbox')).not.toBeInTheDocument();
+        });
+      });
+
+      it('should render checkbox as unchecked when validation is disabled', async () => {
+        const vizNode = createMockVizNode('test-document.xsl');
+        (DataMapperStepService.getXsltFileName as Mock).mockReturnValue('test-document.xsl');
+        (DataMapperValidationStepService.isValidationEnabled as Mock).mockReturnValue(false);
+
+        render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
+
+        const checkbox = (await screen.findByTestId('validate-output-checkbox')) as HTMLInputElement;
+        expect(checkbox.checked).toBe(false);
+      });
+
+      it('should render checkbox as checked when validation is enabled', async () => {
+        const vizNode = createMockVizNode('test-document.xsl');
+        (DataMapperStepService.getXsltFileName as Mock).mockReturnValue('test-document.xsl');
+        (DataMapperValidationStepService.isValidationEnabled as Mock).mockReturnValue(true);
+
+        render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
+
+        const checkbox = (await screen.findByTestId('validate-output-checkbox')) as HTMLInputElement;
+        expect(checkbox.checked).toBe(true);
+      });
+
+      it('should call addValidationStep when checkbox is toggled ON', async () => {
+        const vizNode = createMockVizNode('test-document.xsl');
+        (DataMapperStepService.getXsltFileName as Mock).mockReturnValue('test-document.xsl');
+        (DataMapperValidationStepService.isValidationEnabled as Mock).mockReturnValue(false);
+        (DataMapperValidationStepService.addValidationStep as Mock).mockImplementation(() => undefined);
+
+        render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
+
+        const checkbox = await screen.findByTestId('validate-output-checkbox');
+        fireEvent.click(checkbox);
+
+        await waitFor(() => {
+          expect(DataMapperValidationStepService.addValidationStep).toHaveBeenCalled();
+        });
+      });
+
+      it('should call removeValidationStep when checkbox is toggled OFF', async () => {
+        const vizNode = createMockVizNode('test-document.xsl');
+        (DataMapperStepService.getXsltFileName as Mock).mockReturnValue('test-document.xsl');
+        (DataMapperValidationStepService.isValidationEnabled as Mock).mockReturnValue(true);
+        (DataMapperValidationStepService.removeValidationStep as Mock).mockImplementation(() => undefined);
+
+        render(<DataMapperLauncher vizNode={vizNode} />, { wrapper });
+
+        const checkbox = (await screen.findByTestId('validate-output-checkbox')) as HTMLInputElement;
+        fireEvent.click(checkbox);
+
+        await waitFor(() => {
+          expect(DataMapperValidationStepService.removeValidationStep).toHaveBeenCalled();
         });
       });
     });

--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.test.tsx
@@ -787,7 +787,8 @@ describe('DataMapperLauncher', () => {
       });
     });
 
-    describe('Validate Output toggle', () => {
+    // Output validation UI: skipped until feature is complete
+    describe.skip('Validate Output toggle', () => {
       beforeEach(() => {
         // Default: file exists, XML target, validation disabled
         mockMetadataContext.isResourceExist = vi.fn().mockResolvedValue(true);

--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
@@ -57,6 +57,8 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
   const [isValidationEnabled, setIsValidationEnabled] = useState<boolean>(false);
   const [isValidationTogglePending, setIsValidationTogglePending] = useState<boolean>(false);
   const [isTargetPrimitive, setIsTargetPrimitive] = useState<boolean>(true);
+  // Output validation UI: set to true when feature is complete
+  const showOutputValidation = false as boolean;
 
   const xsltDocumentName = useMemo(() => {
     const xsltComponent = vizNode?.getNodeDefinition()?.steps?.find(isXSLTComponent) as XsltComponentDef;
@@ -230,7 +232,8 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
           />
         </FormGroup>
       )}
-      {xsltFileExists && !isTargetPrimitive && (
+      {/* Output validation UI: set to true when feature is complete */}
+      {showOutputValidation && xsltFileExists && !isTargetPrimitive && (
         <FormGroup label="Output Validation">
           <Checkbox
             id="validate-output"

--- a/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
+++ b/packages/ui/src/components/DataMapper/DataMapperLauncher.tsx
@@ -16,18 +16,20 @@
 import './DataMapperLauncher.scss';
 
 import { isDefined } from '@kaoto/forms';
-import { Alert, Button, FormGroup, HelperText, HelperTextItem, Popover } from '@patternfly/react-core';
+import { Alert, Button, Checkbox, FormGroup, HelperText, HelperTextItem, Popover } from '@patternfly/react-core';
 import { HelpIcon, WrenchIcon } from '@patternfly/react-icons';
-import { FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { type FormEvent, FunctionComponent, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { IVisualizationNode, ValidationResult, ValidationStatus } from '../../models';
+import { DocumentDefinitionType } from '../../models/datamapper/document';
 import { IDataMapperMetadata } from '../../models/datamapper/metadata';
 import { EntitiesContext } from '../../providers';
 import { MetadataContext } from '../../providers/metadata.provider';
 import { Links } from '../../router/links.models';
 import { DataMapperMetadataService } from '../../services/datamapper-metadata.service';
 import { DataMapperStepService } from '../../services/datamapper-step.service';
+import { DataMapperValidationStepService } from '../../services/datamapper-validation-step.service';
 import { isXSLTComponent } from '../../utils';
 import type { XsltComponentDef } from '../../utils/is-xslt-component';
 import XsltDocumentRenameInput from './XsltDocumentRenameInput';
@@ -52,6 +54,9 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
   const [currentFileName, setCurrentFileName] = useState<string | undefined>(undefined);
   const [isEditingFilename, setIsEditingFilename] = useState<boolean>(false);
   const [isSavingFile, setIsSavingFile] = useState<boolean>(false);
+  const [isValidationEnabled, setIsValidationEnabled] = useState<boolean>(false);
+  const [isValidationTogglePending, setIsValidationTogglePending] = useState<boolean>(false);
+  const [isTargetPrimitive, setIsTargetPrimitive] = useState<boolean>(true);
 
   const xsltDocumentName = useMemo(() => {
     const xsltComponent = vizNode?.getNodeDefinition()?.steps?.find(isXSLTComponent) as XsltComponentDef;
@@ -65,17 +70,29 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
   }, [xsltDocumentName]);
 
   useEffect(() => {
+    let cancelled = false;
     const checkFile = async () => {
       if (!xsltDocumentName || !metadata) {
         setXsltFileExists(false);
         return;
       }
       const exists = await metadata.isResourceExist(xsltDocumentName);
+      if (cancelled) return;
       setXsltFileExists(exists);
+
+      if (vizNode) {
+        setIsValidationEnabled(DataMapperValidationStepService.isValidationEnabled(vizNode));
+        const metadataId = DataMapperStepService.getDataMapperMetadataId(vizNode);
+        const meta = await metadata.getMetadata<IDataMapperMetadata>(metadataId);
+        if (cancelled) return;
+        setIsTargetPrimitive(!meta?.targetBody || meta.targetBody.type === DocumentDefinitionType.Primitive);
+      }
     };
-    void checkFile();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    checkFile().catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [xsltDocumentName, metadata, vizNode]);
 
   const validateDocumentName = useCallback(
     async (value: string): Promise<ValidationResult> => {
@@ -143,6 +160,31 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
     [xsltDocumentName, metadata, entitiesContext, vizNode],
   );
 
+  const handleValidationToggle = useCallback(
+    (_event: FormEvent<HTMLInputElement>, checked: boolean) => {
+      if (!vizNode || !entitiesContext) return;
+      if (checked) {
+        setIsValidationTogglePending(true);
+        const metadataId = DataMapperStepService.getDataMapperMetadataId(vizNode);
+        void metadata
+          ?.getMetadata<IDataMapperMetadata>(metadataId)
+          .then((meta) => {
+            if (meta?.targetBody) {
+              DataMapperValidationStepService.addValidationStep(vizNode, meta.targetBody, entitiesContext);
+            }
+            setIsValidationEnabled(DataMapperValidationStepService.isValidationEnabled(vizNode));
+          })
+          .finally(() => {
+            setIsValidationTogglePending(false);
+          });
+      } else {
+        DataMapperValidationStepService.removeValidationStep(vizNode, entitiesContext);
+        setIsValidationEnabled(DataMapperValidationStepService.isValidationEnabled(vizNode));
+      }
+    },
+    [vizNode, entitiesContext, metadata],
+  );
+
   const onClick = useCallback(async () => {
     await navigate(`${Links.DataMapper}/${vizNode?.getNodeDefinition()?.id}`);
   }, [navigate, vizNode]);
@@ -185,6 +227,18 @@ export const DataMapperLauncher: FunctionComponent<{ vizNode?: IVisualizationNod
             textTitle="XSLT document name"
             editTitle="Edit document name"
             data-testid="xslt-document-name"
+          />
+        </FormGroup>
+      )}
+      {xsltFileExists && !isTargetPrimitive && (
+        <FormGroup label="Output Validation">
+          <Checkbox
+            id="validate-output"
+            label="Validate output"
+            isChecked={isValidationEnabled}
+            isDisabled={isValidationTogglePending}
+            onChange={handleValidationToggle}
+            data-testid="validate-output-checkbox"
           />
         </FormGroup>
       )}

--- a/packages/ui/src/components/Document/actions/Settings/DataMapperSettingsModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/Settings/DataMapperSettingsModal.test.tsx
@@ -1,35 +1,66 @@
 import { act, render, screen } from '@testing-library/react';
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren, useEffect } from 'react';
 
-import { DocumentDefinitionType, DocumentInitializationModel, DocumentType } from '../../../../models/datamapper';
+import { useDataMapper } from '../../../../hooks/useDataMapper';
+import { DocumentDefinitionType, DocumentType, IDocument } from '../../../../models/datamapper';
+import { IField } from '../../../../models/datamapper/document';
 import { DataMapperProvider } from '../../../../providers/datamapper.provider';
 import { DataMapperSettingsModal } from './DataMapperSettingsModal';
+
+/**
+ * Helper component that injects a mock target document with the given definitionType
+ * into the DataMapper context after the provider has finished loading.
+ * This is necessary because DocumentInitializationModel with XML_SCHEMA/JSON_SCHEMA
+ * but without real schema files does not produce a real document — so we bypass it
+ * and inject via setNewDocument directly.
+ */
+const TargetDocumentInjector: FunctionComponent<PropsWithChildren<{ targetDocType: DocumentDefinitionType }>> = ({
+  targetDocType,
+  children,
+}) => {
+  const { setNewDocument } = useDataMapper();
+
+  useEffect(() => {
+    if (targetDocType === DocumentDefinitionType.Primitive) return;
+
+    const mockDocument: IDocument = {
+      documentType: DocumentType.TARGET_BODY,
+      documentId: 'Body',
+      name: 'Body',
+      definitionType: targetDocType,
+      fields: [] as IField[],
+      path: { pathSegments: [] } as never,
+      namedTypeFragments: {},
+      definition: null as never,
+      totalFieldCount: 0,
+      isNamespaceAware: targetDocType === DocumentDefinitionType.XML_SCHEMA,
+      getReferenceId: () => '',
+      getExpression: () => '',
+    };
+
+    act(() => {
+      setNewDocument(DocumentType.TARGET_BODY, 'Body', mockDocument);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <>{children}</>;
+};
 
 describe('DataMapperSettingsModal', () => {
   const mockOnModalClose = vi.fn();
 
   const createWrapper = (
     targetDocType: DocumentDefinitionType = DocumentDefinitionType.XML_SCHEMA,
+    isOutputValidationEnabled = false,
+    onSetOutputValidationEnabled?: (enabled: boolean) => void,
   ): FunctionComponent<PropsWithChildren> => {
     return ({ children }) => (
       <DataMapperProvider
-        documentInitializationModel={
-          new DocumentInitializationModel(
-            {},
-            {
-              documentType: DocumentType.SOURCE_BODY,
-              definitionType: DocumentDefinitionType.XML_SCHEMA,
-              name: 'source',
-            },
-            {
-              documentType: DocumentType.TARGET_BODY,
-              definitionType: targetDocType,
-              name: 'target',
-            },
-          )
-        }
+        isOutputValidationEnabled={isOutputValidationEnabled}
+        onSetOutputValidationEnabled={onSetOutputValidationEnabled}
       >
-        {children}
+        <TargetDocumentInjector targetDocType={targetDocType}>{children}</TargetDocumentInjector>
       </DataMapperProvider>
     );
   };
@@ -217,6 +248,89 @@ describe('DataMapperSettingsModal', () => {
       // Verify checkbox is rendered for XML target
       expect(checkbox).toBeInTheDocument();
       expect(checkbox).toHaveAttribute('id', 'omit-xml-declaration');
+    });
+  });
+
+  describe('Output Validation', () => {
+    it('should show Validate output checkbox when target is XML', async () => {
+      const wrapper = createWrapper(DocumentDefinitionType.XML_SCHEMA);
+      render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });
+
+      await screen.findByTestId('validate-output-settings-checkbox');
+      expect(screen.getByText('Output Validation')).toBeInTheDocument();
+    });
+
+    it('should show Validate output checkbox when target is JSON', async () => {
+      const wrapper = createWrapper(DocumentDefinitionType.JSON_SCHEMA);
+      render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });
+
+      await screen.findByTestId('validate-output-settings-checkbox');
+      expect(screen.getByText('Output Validation')).toBeInTheDocument();
+    });
+
+    it('should hide Validate output checkbox when target is Primitive', async () => {
+      const wrapper = createWrapper(DocumentDefinitionType.Primitive);
+      render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });
+
+      await screen.findByTestId('datamapper-settings-modal');
+      expect(screen.queryByTestId('validate-output-settings-checkbox')).not.toBeInTheDocument();
+    });
+
+    it('should render checkbox as checked when isOutputValidationEnabled is true', async () => {
+      const wrapper = createWrapper(DocumentDefinitionType.XML_SCHEMA, true);
+      render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });
+
+      const checkbox = (await screen.findByTestId('validate-output-settings-checkbox')) as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it('should render checkbox as unchecked when isOutputValidationEnabled is false', async () => {
+      const wrapper = createWrapper(DocumentDefinitionType.XML_SCHEMA, false);
+      render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });
+
+      const checkbox = (await screen.findByTestId('validate-output-settings-checkbox')) as HTMLInputElement;
+      expect(checkbox.checked).toBe(false);
+    });
+
+    it('should call onSetOutputValidationEnabled(true) when checkbox is checked', async () => {
+      const mockOnSetOutputValidationEnabled = vi.fn();
+      const wrapper = createWrapper(DocumentDefinitionType.XML_SCHEMA, false, mockOnSetOutputValidationEnabled);
+      render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });
+
+      const checkbox = await screen.findByTestId('validate-output-settings-checkbox');
+      act(() => {
+        checkbox.click();
+      });
+
+      expect(mockOnSetOutputValidationEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('should call onSetOutputValidationEnabled(false) when checkbox is unchecked', async () => {
+      const mockOnSetOutputValidationEnabled = vi.fn();
+      const wrapper = createWrapper(DocumentDefinitionType.XML_SCHEMA, true, mockOnSetOutputValidationEnabled);
+      render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });
+
+      const checkbox = await screen.findByTestId('validate-output-settings-checkbox');
+      act(() => {
+        checkbox.click();
+      });
+
+      expect(mockOnSetOutputValidationEnabled).toHaveBeenCalledWith(false);
+    });
+
+    it('should take effect immediately (not buffered until Save)', async () => {
+      const mockOnSetOutputValidationEnabled = vi.fn();
+      const wrapper = createWrapper(DocumentDefinitionType.XML_SCHEMA, false, mockOnSetOutputValidationEnabled);
+      render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });
+
+      const checkbox = await screen.findByTestId('validate-output-settings-checkbox');
+      act(() => {
+        checkbox.click();
+      });
+
+      // onSetOutputValidationEnabled should be called immediately, before Save is clicked
+      expect(mockOnSetOutputValidationEnabled).toHaveBeenCalledWith(true);
+      expect(mockOnModalClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ui/src/components/Document/actions/Settings/DataMapperSettingsModal.test.tsx
+++ b/packages/ui/src/components/Document/actions/Settings/DataMapperSettingsModal.test.tsx
@@ -251,7 +251,8 @@ describe('DataMapperSettingsModal', () => {
     });
   });
 
-  describe('Output Validation', () => {
+  // Output validation UI: skipped until feature is complete
+  describe.skip('Output Validation', () => {
     it('should show Validate output checkbox when target is XML', async () => {
       const wrapper = createWrapper(DocumentDefinitionType.XML_SCHEMA);
       render(<DataMapperSettingsModal isModalOpen onModalClose={mockOnModalClose} />, { wrapper });

--- a/packages/ui/src/components/Document/actions/Settings/DataMapperSettingsModal.tsx
+++ b/packages/ui/src/components/Document/actions/Settings/DataMapperSettingsModal.tsx
@@ -9,7 +9,7 @@ import {
   ModalHeader,
   ModalVariant,
 } from '@patternfly/react-core';
-import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { FormEvent, FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useDataMapper } from '../../../../hooks/useDataMapper';
 import { DocumentDefinitionType, IDataMapperSettings } from '../../../../models/datamapper';
@@ -23,11 +23,22 @@ export const DataMapperSettingsModal: FunctionComponent<DataMapperSettingsModalP
   isModalOpen,
   onModalClose,
 }) => {
-  const { dataMapperSettings, updateDataMapperSettings, targetBodyDocument } = useDataMapper();
+  const {
+    dataMapperSettings,
+    updateDataMapperSettings,
+    targetBodyDocument,
+    isOutputValidationEnabled,
+    setOutputValidationEnabled,
+  } = useDataMapper();
   const [localOptions, setLocalOptions] = useState<IDataMapperSettings>(dataMapperSettings);
 
   const isTargetXml = useMemo(
     () => targetBodyDocument.definitionType === DocumentDefinitionType.XML_SCHEMA,
+    [targetBodyDocument.definitionType],
+  );
+
+  const isTargetPrimitive = useMemo(
+    () => targetBodyDocument.definitionType === DocumentDefinitionType.Primitive,
     [targetBodyDocument.definitionType],
   );
 
@@ -50,6 +61,13 @@ export const DataMapperSettingsModal: FunctionComponent<DataMapperSettingsModalP
     updateDataMapperSettings(localOptions);
     onModalClose();
   }, [localOptions, updateDataMapperSettings, onModalClose]);
+
+  const handleValidationToggle = useCallback(
+    (_event: FormEvent<HTMLInputElement>, checked: boolean) => {
+      setOutputValidationEnabled(checked);
+    },
+    [setOutputValidationEnabled],
+  );
 
   const handleCancel = useCallback(() => {
     setLocalOptions(dataMapperSettings);
@@ -79,6 +97,17 @@ export const DataMapperSettingsModal: FunctionComponent<DataMapperSettingsModalP
               description={!isTargetXml ? 'Only available when target document is XML' : undefined}
             />
           </FormGroup>
+          {!isTargetPrimitive && (
+            <FormGroup label="Output Validation">
+              <Checkbox
+                id="validate-output-settings"
+                label="Validate output"
+                isChecked={isOutputValidationEnabled}
+                onChange={handleValidationToggle}
+                data-testid="validate-output-settings-checkbox"
+              />
+            </FormGroup>
+          )}
         </Form>
       </ModalBody>
       <ModalFooter>

--- a/packages/ui/src/components/Document/actions/Settings/DataMapperSettingsModal.tsx
+++ b/packages/ui/src/components/Document/actions/Settings/DataMapperSettingsModal.tsx
@@ -41,6 +41,8 @@ export const DataMapperSettingsModal: FunctionComponent<DataMapperSettingsModalP
     () => targetBodyDocument.definitionType === DocumentDefinitionType.Primitive,
     [targetBodyDocument.definitionType],
   );
+  // Output validation UI: set to true when feature is complete
+  const showOutputValidation = false as boolean;
 
   // Sync local state with context when modal opens
   useEffect(() => {
@@ -97,7 +99,8 @@ export const DataMapperSettingsModal: FunctionComponent<DataMapperSettingsModalP
               description={!isTargetXml ? 'Only available when target document is XML' : undefined}
             />
           </FormGroup>
-          {!isTargetPrimitive && (
+          {/* Output validation UI: set to true when feature is complete */}
+          {showOutputValidation && !isTargetPrimitive && (
             <FormGroup label="Output Validation">
               <Checkbox
                 id="validate-output-settings"

--- a/packages/ui/src/providers/datamapper.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper.provider.test.tsx
@@ -1296,4 +1296,50 @@ describe('DataMapperProvider', () => {
       serializeSpy.mockRestore();
     });
   });
+
+  describe('Output Validation', () => {
+    it('should default isOutputValidationEnabled to false when prop is not provided', async () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DataMapperProvider>{children}</DataMapperProvider>
+      );
+
+      const { result } = renderHook(() => useDataMapper(), { wrapper });
+
+      expect(result.current.isOutputValidationEnabled).toBe(false);
+    });
+
+    it('should reflect isOutputValidationEnabled=true when prop is provided', async () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DataMapperProvider isOutputValidationEnabled>{children}</DataMapperProvider>
+      );
+
+      const { result } = renderHook(() => useDataMapper(), { wrapper });
+
+      expect(result.current.isOutputValidationEnabled).toBe(true);
+    });
+
+    it('should call onSetOutputValidationEnabled callback when setOutputValidationEnabled is invoked', async () => {
+      const mockOnSetOutputValidationEnabled = vi.fn();
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DataMapperProvider onSetOutputValidationEnabled={mockOnSetOutputValidationEnabled}>
+          {children}
+        </DataMapperProvider>
+      );
+
+      const { result } = renderHook(() => useDataMapper(), { wrapper });
+
+      act(() => {
+        result.current.setOutputValidationEnabled(true);
+      });
+
+      expect(mockOnSetOutputValidationEnabled).toHaveBeenCalledWith(true);
+
+      act(() => {
+        result.current.setOutputValidationEnabled(false);
+      });
+
+      expect(mockOnSetOutputValidationEnabled).toHaveBeenCalledWith(false);
+    });
+  });
 });

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -79,6 +79,9 @@ export interface IDataMapperContext {
 
   dataMapperSettings: IDataMapperSettings;
   updateDataMapperSettings(settings: Partial<IDataMapperSettings>): void;
+
+  isOutputValidationEnabled: boolean;
+  setOutputValidationEnabled: (enabled: boolean) => void;
 }
 
 export const DataMapperContext = createContext<IDataMapperContext | null>(null);
@@ -91,6 +94,8 @@ type DataMapperProviderProps = PropsWithChildren & {
   initialXsltFile?: string;
   onUpdateMappings?: (xsltFile: string) => void;
   onUpdateNamespaceMap?: (namespaceMap: Record<string, string>) => void;
+  isOutputValidationEnabled?: boolean;
+  onSetOutputValidationEnabled?: (enabled: boolean) => void;
 };
 
 export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
@@ -101,6 +106,8 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
   initialXsltFile,
   onUpdateMappings,
   onUpdateNamespaceMap,
+  isOutputValidationEnabled: isOutputValidationEnabledProp,
+  onSetOutputValidationEnabled,
   children,
 }) => {
   const [debug, setDebug] = useState<boolean>(false);
@@ -112,6 +119,13 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
   const updateDataMapperSettings = useCallback((settings: Partial<IDataMapperSettings>) => {
     setDataMapperSettings((prev) => ({ ...prev, ...settings }));
   }, []);
+
+  const setOutputValidationEnabled = useCallback(
+    (enabled: boolean) => {
+      onSetOutputValidationEnabled?.(enabled);
+    },
+    [onSetOutputValidationEnabled],
+  );
 
   const [sourceParameterMap, setSourceParameterMap] = useState<Map<string, IDocument>>(new Map<string, IDocument>());
   const [isSourceParametersExpanded, setSourceParametersExpanded] = useState<boolean>(true);
@@ -408,6 +422,8 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
       setDebug,
       dataMapperSettings,
       updateDataMapperSettings,
+      isOutputValidationEnabled: isOutputValidationEnabledProp ?? false,
+      setOutputValidationEnabled,
     };
   }, [
     isLoading,
@@ -430,6 +446,8 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     debug,
     dataMapperSettings,
     updateDataMapperSettings,
+    isOutputValidationEnabledProp,
+    setOutputValidationEnabled,
   ]);
 
   return (


### PR DESCRIPTION
## Summary

Implements **S6** (UI toggle) and **S7** (validation step synchronization) of the DataMapper output validation feature.

**S6 — UI toggle:** a checkbox to enable/disable output validation from two places:
- **Properties panel** (`DataMapperLauncher`) — visible when an XSLT file exists and the target is not Primitive
- **DataMapper Settings modal** (`DataMapperSettingsModal`) — visible below the XML Declaration group when the target is not Primitive

Validation toggles **immediately** (not buffered until Save). Delegates to the existing `DataMapperValidationStepService` (S4), which is **not modified**.

**S7 — step synchronization:** when the target schema changes during a session, the validator step is kept in sync automatically via the `onUpdateDocument` callback chain:
- Target schema file changed → validator `resourceUri` updated
- Target type changed (XML ↔ JSON) → component swapped between `validator:` and `json-validator:`
- Target removed (→ Primitive) → validator step removed
- Type override adds/removes schema files → validator updated accordingly

> ⚠️ **UI temporarily disabled for release.** The final commit (`chore(DataMapper): disable output validation UI until feature is complete`) hides the checkbox in both locations and disables auto-sync behind `showOutputValidation` flags (`false`), pending the remaining steps (e.g. S9 wrapper schema regeneration). All production code and tests remain in place — the feature is re-enabled by reverting that single commit. The synchronization tests are `describe.skip`-ped alongside it.

Closes #3608, closes #3609

## Changes

| File | What changed |
|------|-------------|
| `datamapper.provider.tsx` | `isOutputValidationEnabled` / `setOutputValidationEnabled` added to `IDataMapperContext` and props |
| `DataMapper.tsx` | Reads initial state from service; wires add/remove/updateValidationStep into provider callback (sync logic) |
| `DataMapperLauncher.tsx` | Renders `Validate output` checkbox when `xsltFileExists && !isTargetPrimitive` (behind `showOutputValidation`) |
| `DataMapperSettingsModal.tsx` | Renders `Validate output` checkbox below XML Declaration when `!isTargetPrimitive` (behind `showOutputValidation`); immediate effect |

## Test coverage

| Test file | New tests |
|-----------|-----------|
| `datamapper.provider.test.tsx` | 3 |
| `DataMapper.test.tsx` | 3 |
| `DataMapperLauncher.test.tsx` | 7 |
| `DataMapperSettingsModal.test.tsx` | 8 |
| `DataMapper.sync.test.tsx` (S7) | 7 |

✅ Full suite passing, lint clean. (S6/S7 UI + sync tests are skipped by the disable commit until the feature is re-enabled.)

## Visibility rules

- Target **Primitive** → checkbox hidden in both locations
- Target **XML Schema / JSON Schema** → checkbox visible
- Launcher additionally requires `xsltFileExists`
- `showOutputValidation` flag (currently `false`) hides the checkbox everywhere until the feature is complete

## No breaking changes

- `DataMapperValidationStepService` is not modified
- New props on `DataMapperProvider` are optional — existing consumers unaffected

## Preview
<img width="2667" height="1443" alt="Screen Recording 2026-08-25 at 13 52 33" src="https://github.com/user-attachments/assets/89db66c8-3253-4304-a6f7-3e15e868dead" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Output Validation** option for eligible XML and JSON target documents.
  * The option is hidden for primitive targets or when no XSLT file is available.
  * Validation settings are shared between the Data Mapper and settings modal.

* **Bug Fixes**
  * Improved handling of validation settings when target documents change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
