### PR TITLE
fix(sonar) - typescript:S4043: Replace in-place sort with toSorted() …

### DIFF
--- a/packages/ui/src/components/Catalog/filter-tiles.ts
+++ b/packages/ui/src/components/Catalog/filter-tiles.ts
@@ -56,7 +56,7 @@ export const filterTiles = (
   });
 
   // Step 3: Sort the filtered tiles by score in descending order
-  const tilesResult: ITile[] = filteredTiles.sort((a, b) => b.score - a.score).map(({ tile }) => tile);
+  const tilesResult: ITile[] = [...filteredTiles].sort((a, b) => b.score - a.score).map(({ tile }) => tile);
 
   return tilesResult;
 };

--- a/packages/ui/src/services/mapping/mapping-serializer.service.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.ts
@@ -136,7 +136,7 @@ export class MappingSerializerService {
     MappingSerializerService.populateStylesheetVariables(xslt, mappings);
     const root = MappingSerializerService.populateMappingRoot(xslt, mappings);
     MappingSerializerService.populateTemplateVariables(root, mappings);
-    mappings.children.sort(MappingSerializerService.sortMappingItem).forEach((mapping) => {
+    [...mappings.children].sort(MappingSerializerService.sortMappingItem).forEach((mapping) => {
       MappingSerializerService.populateMapping(root, mapping);
     });
     return xmlFormat(new XMLSerializer().serializeToString(xslt));
@@ -270,8 +270,7 @@ export class MappingSerializerService {
       return;
     }
 
-    mapping.children.sort(MappingSerializerService.sortMappingItem);
-    for (const childItem of mapping.children) {
+    for (const childItem of [...mapping.children].sort(MappingSerializerService.sortMappingItem)) {
       MappingSerializerService.populateMapping(child, childItem);
     }
   }


### PR DESCRIPTION
…or separate sort statement

fixes https://github.com/KaotoIO/kaoto/issues/3708

Note: Array.prototype.toSorted() (ES2023) would be cleaner, but the project targets ES2020 (tsconfig.base.json), so the spread-then-sort pattern [...array].sort(fn) is used instead — which is explicitly listed as a valid option in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting behavior for catalog tiles while preserving the original filtered results.
  * Prevented mapping data order from changing unexpectedly during serialization and population.
  * Ensured sorting operations no longer alter underlying application data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->