### PR TITLE
fix(sonar): typescript:S8754: Rename duplicate test titles to be uniq…

### DIFF
--- a/packages/ui/src/pages/RestDslImport/RestDslImportPage.test.tsx
+++ b/packages/ui/src/pages/RestDslImport/RestDslImportPage.test.tsx
@@ -23,7 +23,7 @@ describe('RestDslImportPage', () => {
     expect(screen.getByLabelText('Upload file')).toBeInTheDocument();
   });
 
-  it('navigates back to the Home page when closing the wizard', async () => {
+  it('navigates to the Rest Editor page when clicking Go to Rest Editor', async () => {
     render(
       <MemoryRouter initialEntries={[Links.RestImport]}>
         <Routes>

--- a/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.test.ts
@@ -212,7 +212,7 @@ describe('parser basics', () => {
   });
 
   describe('special cases', () => {
-    it('should handle intercept elements', async () => {
+    it('should handle intercept elements with a mock document', async () => {
       const interceptElement = mockDocument.createElement('interceptFrom');
       const whenElement = mockDocument.createElement('onWhen');
       interceptElement.appendChild(whenElement);
@@ -221,7 +221,7 @@ describe('parser basics', () => {
       expect(result.onWhen).toBeDefined();
     });
 
-    it('should handle intercept elements', async () => {
+    it('should handle intercept elements with an XML document', async () => {
       const interceptElement = getDocument(
         '<intercept id="intercept1"><onWhen><simple>${in.body} contains \'Hello\'</simple></onWhen><to uri="mock:intercepted"/></intercept>',
       ).documentElement;


### PR DESCRIPTION
…ue within their suite

fixes https://github.com/KaotoIO/kaoto/issues/3709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that selecting “Go to Rest Editor” from the REST import wizard navigates to the Rest Editor.
  * Retained coverage for closing the wizard from the Home page.
  * Clarified XML parser test coverage for intercept elements across mock and XML documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->