### PR TITLE
fx(sonar): typescript:S6661: Replace Object.assign with object spread…

### DIFF
--- a/packages/ui/src/utils/pipe-custom-schema.ts
+++ b/packages/ui/src/utils/pipe-custom-schema.ts
@@ -32,8 +32,8 @@ export const updatePipeFromCustomSchema = (pipe: Pipe, value: Record<string, unk
   const previousAnnotations: Record<string, unknown> = getValue(pipe, 'metadata.annotations', {});
   const previousLabels: Record<string, unknown> = getValue(pipe, 'metadata.labels', {});
 
-  const newLabels = Object.assign({}, getValue(value, 'labels', previousLabels));
-  const newAnnotations = Object.assign({}, getValue(value, 'annotations', previousAnnotations));
+  const newLabels = { ...getValue(value, 'labels', previousLabels) };
+  const newAnnotations = { ...getValue(value, 'annotations', previousAnnotations) };
 
   setValue(pipe, 'metadata.labels', newLabels);
   setValue(pipe, 'metadata.annotations', newAnnotations);


### PR DESCRIPTION
… syntax

fixes https://github.com/KaotoIO/kaoto/issues/3711

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal cloning of labels and annotations without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->