### PR TITLE
refactor: move REST DSL entities out of canvas model

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -23,11 +23,7 @@ import { insertYamlComments } from '../../utils/yaml-comments';
 import { CatalogKind } from '../catalog-kind';
 import { BaseEntity, EntityType } from '../entities';
 import { BaseVisualEntityDefinition, BeansAwareResource, KaotoResource } from '../kaoto-resource';
-import {
-  AddStepMode,
-  BaseVisualCamelEntityConstructor,
-  IVisualizationNodeData,
-} from '../visualization/base-visual-entity';
+import { AddStepMode, BaseEntityConstructor, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { CamelCatalogService, CamelRouteVisualEntity } from '../visualization/flows';
 import { CamelErrorHandlerVisualEntity } from '../visualization/flows/camel-error-handler-visual-entity';
 import { CamelInterceptFromVisualEntity } from '../visualization/flows/camel-intercept-from-visual-entity';
@@ -49,7 +45,7 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
   static readonly SUPPORTED_ENTITIES: {
     type: EntityType;
     group: string;
-    Entity: BaseVisualCamelEntityConstructor;
+    Entity: BaseEntityConstructor;
     isVisualEntity: boolean;
     isYamlOnly?: boolean;
   }[] = [

--- a/packages/ui/src/models/camel/camel-xml-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-xml-route-resource.ts
@@ -23,7 +23,7 @@ import { EntityDefinition } from '../../serializers/xml/serializers/entitiy-defi
 import { KaotoXmlSerializer } from '../../serializers/xml/serializers/kaoto-xml-serializer';
 import { insertXmlComments, parseXmlComments } from '../../utils/xml-comments';
 import { EntityType } from '../entities';
-import { BaseVisualCamelEntityConstructor } from '../visualization/base-visual-entity';
+import { BaseEntityConstructor } from '../visualization/base-visual-entity';
 import { FlowTemplateService } from '../visualization/flows/support/flow-templates-service';
 import { CamelRouteResource } from './camel-route-resource';
 import { SourceSchemaType } from './source-schema-type';
@@ -31,7 +31,7 @@ import { SourceSchemaType } from './source-schema-type';
 type SupportedEntity = {
   type: EntityType;
   group: string;
-  Entity: BaseVisualCamelEntityConstructor;
+  Entity: BaseEntityConstructor;
   isVisualEntity: boolean;
   isYamlOnly?: boolean;
 };

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -9,11 +9,7 @@ import { CatalogKind } from '../catalog-kind';
 import { BaseEntity, EntityType } from '../entities';
 import { BaseVisualEntityDefinition, KaotoResource } from '../kaoto-resource';
 import { KaotoSchemaDefinition } from '../kaoto-schema';
-import {
-  AddStepMode,
-  BaseVisualCamelEntityConstructor,
-  IVisualizationNodeData,
-} from '../visualization/base-visual-entity';
+import { AddStepMode, BaseEntityConstructor, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { CamelCatalogService, CitrusTestVisualEntity } from '../visualization/flows';
 import { NonVisualEntity } from '../visualization/flows/non-visual-entity';
 import { FlowTemplateService } from '../visualization/flows/support/flow-templates-service';
@@ -38,7 +34,7 @@ export class CitrusTestResource implements KaotoResource {
   static readonly SUPPORTED_ENTITIES: {
     type: EntityType;
     group: string;
-    Entity: BaseVisualCamelEntityConstructor;
+    Entity: BaseEntityConstructor;
     isYamlOnly?: boolean;
   }[] = [{ type: EntityType.Test, group: '', Entity: CitrusTestVisualEntity }];
   private entities: BaseEntity[] = [];

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -87,9 +87,9 @@ export interface BaseVisualEntity extends BaseEntity {
   toVizNode: () => Promise<IVisualizationNode>;
 }
 
-export interface BaseVisualCamelEntityConstructor {
+export interface BaseEntityConstructor {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  new (...args: any[]): BaseVisualEntity;
+  new (...args: any[]): BaseEntity;
   isApplicable: (entity: unknown) => boolean;
 }
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts
@@ -65,16 +65,16 @@ describe('CamelRestConfigurationVisualEntity', () => {
     expect(entity.getId()).toEqual(newId);
   });
 
-  it('should return node label', () => {
-    const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
-
-    expect(entity.getNodeLabel()).toBe('restConfiguration');
-  });
-
   it('should return entity current definition', () => {
     const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
 
     expect(entity.getNodeDefinition()).toEqual(restConfigurationDef.restConfiguration);
+  });
+
+  it('should return the raw restConfiguration definition for parsed definition', async () => {
+    const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
+
+    await expect(entity.getParsedDefinition()).resolves.toEqual(restConfigurationDef.restConfiguration);
   });
 
   it('should return schema from catalog', async () => {
@@ -113,126 +113,6 @@ describe('CamelRestConfigurationVisualEntity', () => {
       entity.updateModel('restConfiguration', {});
 
       expect(restConfigurationDef.restConfiguration).toEqual({});
-    });
-  });
-
-  it('return no interactions', () => {
-    const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
-
-    expect(entity.getNodeInteraction()).toEqual({
-      canHavePreviousStep: false,
-      canHaveNextStep: false,
-      canHaveChildren: false,
-      canHaveSpecialChildren: false,
-      canRemoveStep: false,
-      canReplaceStep: false,
-      canRemoveFlow: true,
-      canBeDisabled: false,
-    });
-  });
-
-  describe('getNodeValidationText', () => {
-    it('should return undefined for valid definitions', async () => {
-      const entity = new CamelRestConfigurationVisualEntity({
-        restConfiguration: {
-          ...restConfigurationDef.restConfiguration,
-          useXForwardHeaders: true,
-          apiVendorExtension: true,
-          skipBindingOnErrorCode: true,
-          clientRequestValidation: true,
-          clientResponseValidation: true,
-          enableCORS: true,
-          enableNoContentResponse: true,
-          inlineRoutes: true,
-        },
-      });
-
-      const schema = await entity.fetchNodeSchema({
-        primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
-      });
-
-      expect(await entity.getNodeValidationText(undefined, schema)).toBeUndefined();
-    });
-
-    it('should not modify the original definition when validating', async () => {
-      const originalRestConfigurationDef: RestConfiguration = { ...restConfigurationDef.restConfiguration };
-      const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
-      const schema = await entity.fetchNodeSchema({
-        primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
-      });
-
-      await entity.getNodeValidationText(undefined, schema);
-
-      expect(restConfigurationDef.restConfiguration).toEqual(originalRestConfigurationDef);
-    });
-
-    it('should return errors when there is an invalid property', async () => {
-      const invalidRestConfigurationDef: RestConfiguration = {
-        ...restConfigurationDef.restConfiguration,
-        useXForwardHeaders: 'true' as unknown as RestConfiguration['useXForwardHeaders'],
-        apiVendorExtension: 'true' as unknown as RestConfiguration['apiVendorExtension'],
-        skipBindingOnErrorCode: 'true' as unknown as RestConfiguration['skipBindingOnErrorCode'],
-        clientRequestValidation: 'true' as unknown as RestConfiguration['clientRequestValidation'],
-        clientResponseValidation: 'true' as unknown as RestConfiguration['clientResponseValidation'],
-        enableCORS: 'true' as unknown as RestConfiguration['enableCORS'],
-        enableNoContentResponse: 'true' as unknown as RestConfiguration['enableNoContentResponse'],
-        inlineRoutes: 'true' as unknown as RestConfiguration['inlineRoutes'],
-      };
-      const entity = new CamelRestConfigurationVisualEntity({ restConfiguration: invalidRestConfigurationDef });
-      const schema = await entity.fetchNodeSchema({
-        primaryNodeId: { name: 'restConfiguration', catalogKind: CatalogKind.Entity },
-      });
-
-      expect(await entity.getNodeValidationText(undefined, schema)).toBe(`'/useXForwardHeaders' must be boolean,
-'/apiVendorExtension' must be boolean,
-'/skipBindingOnErrorCode' must be boolean,
-'/clientRequestValidation' must be boolean,
-'/clientResponseValidation' must be boolean,
-'/enableCORS' must be boolean,
-'/enableNoContentResponse' must be boolean,
-'/inlineRoutes' must be boolean`);
-    });
-  });
-
-  describe('toVizNode', () => {
-    it('toVizNode should return visualization node', async () => {
-      const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
-
-      const vizNode = await entity.toVizNode();
-      await vizNode.fetchSchema();
-
-      expect(vizNode.data).toEqual({
-        entity,
-        name: 'restConfiguration',
-        isGroup: true,
-        path: 'restConfiguration',
-        processorName: 'restConfiguration',
-        primaryNodeId: { name: entity.type, catalogKind: CatalogKind.Entity },
-        iconAlt: 'Entity icon',
-        iconUrl: '/src/assets/components/generic-component.png',
-        isPlaceholder: false,
-        title: 'Rest Configuration',
-        description:
-          'restConfiguration: Configures global settings for the REST DSL, such as host, port, context path, binding mode, and the underlying HTTP component to use',
-        processorIconTooltip: '',
-        schema: expect.any(Object),
-      });
-    });
-
-    it('should return schema title from enriched data', async () => {
-      const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
-      const vizNode = await entity.toVizNode();
-
-      expect(vizNode.getNodeTitle()).toBe('Rest Configuration');
-    });
-  });
-
-  it('getCopiedContent should return the content to be copied', () => {
-    const entity = new CamelRestConfigurationVisualEntity(restConfigurationDef);
-
-    expect(entity.getCopiedContent()).toEqual({
-      name: 'restConfiguration',
-      definition: restConfigurationDef.restConfiguration,
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-configuration-visual-entity.ts
@@ -1,29 +1,18 @@
-import { ProcessorDefinition, RestConfiguration } from '@kaoto/camel-catalog/types';
-import { getValidator, isDefined } from '@kaoto/forms';
+import { RestConfiguration } from '@kaoto/camel-catalog/types';
+import { isDefined } from '@kaoto/forms';
 
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { setValue } from '../../../utils';
-import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities/base-entity';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
-import {
-  BaseVisualEntity,
-  IVisualizationNode,
-  IVisualizationNodeData,
-  IVisualizationNodeIds,
-  NodeInteraction,
-} from '../base-visual-entity';
-import { IClipboardContent } from '../clipboard';
-import { NodeIdentity } from '../node-identity';
-import { createVisualizationNode } from '../visualization-node';
-import { NodeEnrichmentService } from './nodes/node-enrichment.service';
+import { IVisualizationNodeIds } from '../base-visual-entity';
+import { RestEntity } from './rest-entity';
 
-export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
+export class CamelRestConfigurationVisualEntity implements RestEntity {
   id: string;
   readonly type = EntityType.RestConfiguration;
   static readonly ROOT_PATH = 'restConfiguration';
-  private schemaValidator: ReturnType<typeof getValidator>;
 
   constructor(public restConfigurationDef: { restConfiguration: RestConfiguration } = { restConfiguration: {} }) {
     const id = getCamelRandomId('restConfiguration');
@@ -60,33 +49,6 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
     this.id = id;
   }
 
-  getNodeLabel(): string {
-    return 'restConfiguration';
-  }
-
-  addStep(): void {
-    return;
-  }
-
-  getCopiedContent(): IClipboardContent | undefined {
-    return {
-      name: CamelRestConfigurationVisualEntity.ROOT_PATH,
-      definition: this.restConfigurationDef.restConfiguration,
-    };
-  }
-
-  pasteStep(): void {
-    return;
-  }
-
-  canDragNode(_path?: string) {
-    return false;
-  }
-
-  canDropOnNode(_path?: string) {
-    return false;
-  }
-
   removeStep(): void {
     return;
   }
@@ -107,8 +69,8 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
     return { ...this.restConfigurationDef.restConfiguration };
   }
 
-  getOmitFormFields(): string[] {
-    return [];
+  async getParsedDefinition(): Promise<unknown> {
+    return this.getNodeDefinition();
   }
 
   updateModel(path: string | undefined, value: unknown): void {
@@ -119,49 +81,6 @@ export class CamelRestConfigurationVisualEntity implements BaseVisualEntity {
     if (!isDefined(this.restConfigurationDef.restConfiguration)) {
       this.restConfigurationDef.restConfiguration = {};
     }
-  }
-
-  getNodeInteraction(): NodeInteraction {
-    return {
-      canHavePreviousStep: false,
-      canHaveNextStep: false,
-      canHaveChildren: false,
-      canHaveSpecialChildren: false,
-      canRemoveStep: false,
-      canReplaceStep: false,
-      canRemoveFlow: true,
-      canBeDisabled: false,
-    };
-  }
-
-  async getNodeValidationText(_path?: string, schema?: KaotoSchemaDefinition['schema']): Promise<string | undefined> {
-    if (!schema) return undefined;
-
-    this.schemaValidator ??= getValidator<RestConfiguration>(schema, { useDefaults: 'empty' });
-
-    this.schemaValidator?.({ ...this.restConfigurationDef.restConfiguration });
-
-    return this.schemaValidator?.errors?.map((error) => `'${error.instancePath}' ${error.message}`).join(',\n');
-  }
-
-  async toVizNode(): Promise<IVisualizationNode<IVisualizationNodeData>> {
-    const restConfigurationGroupNode = createVisualizationNode(this.getRootPath(), {
-      name: this.type,
-      path: this.getRootPath(),
-      entity: this,
-      isPlaceholder: false,
-      isGroup: true,
-      iconUrl: '',
-      title: '',
-      description: '',
-      processorIconTooltip: '',
-      processorName: 'restConfiguration' as keyof ProcessorDefinition,
-      primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
-    });
-
-    await NodeEnrichmentService.enrichVisualizationTree(restConfigurationGroupNode);
-
-    return restConfigurationGroupNode;
   }
 
   toJSON(): { restConfiguration: RestConfiguration } {

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.test.ts
@@ -1,17 +1,12 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { CatalogLibrary, ProcessorDefinition, Rest, To2 } from '@kaoto/camel-catalog/types';
+import { CatalogLibrary, Rest } from '@kaoto/camel-catalog/types';
 
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { restStub } from '../../../stubs/rest';
 import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
-import { DefinedComponent } from '../../camel/camel-catalog-index';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
-import { PlaceholderType } from '../../placeholder.constants';
-import { REST_ELEMENT_NAME } from '../../special-processors.constants';
-import { AddStepMode } from '../base-visual-entity';
-import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { CamelCatalogService } from './camel-catalog.service';
 import { CamelRestVisualEntity } from './camel-rest-visual-entity';
 
@@ -80,21 +75,6 @@ describe('CamelRestVisualEntity', () => {
     expect(entity.getId()).toEqual(newId);
   });
 
-  it('should delegate to super return node label', () => {
-    const superGetNodeLabelSpy = vi
-      .spyOn(AbstractCamelVisualEntity.prototype, 'getNodeLabel')
-      .mockReturnValueOnce('label');
-    const entity = new CamelRestVisualEntity(restDef);
-
-    expect(entity.getNodeLabel()).toBe('label');
-    expect(superGetNodeLabelSpy).toHaveBeenCalled();
-  });
-
-  it('should return "verb" for placeholder path', () => {
-    const entity = new CamelRestVisualEntity(restDef);
-    expect(entity.getNodeLabel('rest.placeholder')).toBe('verb');
-  });
-
   it('should return entity current definition', () => {
     const entity = new CamelRestVisualEntity(restDef);
 
@@ -130,14 +110,28 @@ describe('CamelRestVisualEntity', () => {
       expect(definition).toEqual({ path: '/update', to: { uri: 'direct:update' } });
     });
 
-    it('should delegate to super for non-REST method paths', () => {
+    it('should return undefined for non-REST method paths', () => {
       const entity = new CamelRestVisualEntity(restDef);
-      const superGetNodeDefinitionSpy = vi.spyOn(AbstractCamelVisualEntity.prototype, 'getNodeDefinition');
 
-      // Use a path where method is NOT in REST_DSL_METHODS
-      entity.getNodeDefinition('rest.unknown.0');
+      expect(entity.getNodeDefinition('rest.unknown.0')).toBeUndefined();
+    });
+  });
 
-      expect(superGetNodeDefinitionSpy).toHaveBeenCalledWith('rest.unknown.0', undefined);
+  describe('getParsedDefinition', () => {
+    it('should parse REST endpoint URIs for component nodes', async () => {
+      const entity = new CamelRestVisualEntity({
+        rest: {
+          ...restDef.rest,
+          get: [{ path: '/logs', to: { uri: 'log:requests?level=INFO' } }],
+        },
+      });
+
+      const definition = await entity.getParsedDefinition('rest.get.0.to', {
+        primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
+        secondaryNodeId: { name: 'log', catalogKind: CatalogKind.Component },
+      });
+
+      expect(definition).toMatchObject({ uri: 'log', parameters: { loggerName: 'requests', level: 'INFO' } });
     });
   });
 
@@ -199,20 +193,6 @@ describe('CamelRestVisualEntity', () => {
     });
   });
 
-  it('should return omit form fields', () => {
-    const entity = new CamelRestVisualEntity(restDef);
-
-    expect(entity.getOmitFormFields()).toEqual([
-      'from',
-      'outputs',
-      'steps',
-      'when',
-      'otherwise',
-      'doCatch',
-      'doFinally',
-    ]);
-  });
-
   it('should return root path', () => {
     const entity = new CamelRestVisualEntity(restDef);
 
@@ -257,221 +237,6 @@ describe('CamelRestVisualEntity', () => {
       // The updateModel should reinitialize rest to an empty object
       expect(restDef.rest).toBeDefined();
       expect(restDef.rest).toEqual({});
-    });
-  });
-
-  describe('getNodeInteraction', () => {
-    it('should return interactions for root path', () => {
-      const entity = new CamelRestVisualEntity(restDef);
-
-      expect(
-        entity.getNodeInteraction({
-          name: REST_ELEMENT_NAME,
-          path: 'rest',
-          isPlaceholder: false,
-          isGroup: true,
-          iconUrl: '',
-          title: '',
-          description: '',
-        }),
-      ).toEqual({
-        canHavePreviousStep: false,
-        canHaveNextStep: false,
-        canHaveChildren: false,
-        canHaveSpecialChildren: true,
-        canRemoveStep: false,
-        canReplaceStep: false,
-        canRemoveFlow: true,
-        canBeDisabled: true,
-      });
-    });
-
-    it('should return interactions for to path', () => {
-      const restDefWithGet = {
-        rest: {
-          ...restDef.rest,
-          get: [{ path: '/hello', to: { uri: 'direct:hello' } }],
-        },
-      };
-      const entity = new CamelRestVisualEntity(restDefWithGet);
-
-      expect(
-        entity.getNodeInteraction({
-          name: 'direct',
-          path: 'rest.get.0.to',
-          processorName: 'to',
-          isPlaceholder: false,
-          isGroup: false,
-          iconUrl: '',
-          title: '',
-          description: '',
-        }),
-      ).toEqual({
-        canHavePreviousStep: false,
-        canHaveNextStep: false,
-        canHaveChildren: false,
-        canHaveSpecialChildren: false,
-        canRemoveStep: true,
-        canReplaceStep: false,
-        canRemoveFlow: false,
-        canBeDisabled: false,
-      });
-    });
-
-    it('should delegate to super for verb path', () => {
-      const restDefWithGet = {
-        rest: {
-          ...restDef.rest,
-          get: [{ path: '/hello', to: { uri: 'direct:hello' } }],
-        },
-      };
-      const entity = new CamelRestVisualEntity(restDefWithGet);
-      const superGetNodeInteractionSpy = vi.spyOn(AbstractCamelVisualEntity.prototype, 'getNodeInteraction');
-
-      entity.getNodeInteraction({
-        name: 'get',
-        path: 'rest.get.0',
-        processorName: 'get' as keyof ProcessorDefinition,
-        isPlaceholder: false,
-        isGroup: false,
-        iconUrl: '',
-        title: '',
-        description: '',
-      });
-
-      expect(superGetNodeInteractionSpy).toHaveBeenCalled();
-    });
-  });
-
-  describe('addStep', () => {
-    it('should delegate to super for root path', () => {
-      const entity = new CamelRestVisualEntity(restDef);
-      const superAddStepSpy = vi.spyOn(AbstractCamelVisualEntity.prototype, 'addStep');
-
-      entity.addStep({
-        definedComponent: { type: CatalogKind.Processor, name: 'get' } as DefinedComponent,
-        mode: AddStepMode.InsertSpecialChildStep,
-        data: {
-          name: REST_ELEMENT_NAME,
-          path: CamelRestVisualEntity.ROOT_PATH,
-          isPlaceholder: false,
-          isGroup: true,
-          iconUrl: '',
-          title: '',
-          description: '',
-        },
-        targetProperty: 'get',
-      });
-
-      expect(superAddStepSpy).toHaveBeenCalled();
-    });
-
-    it('should add to directive for verb placeholder path', () => {
-      const restDefWithGet: { rest: Rest } = {
-        rest: {
-          ...restDef.rest,
-          get: [{ id: 'get-1', path: '/hello', to: 'direct:example' }],
-        },
-      };
-
-      const entity = new CamelRestVisualEntity(restDefWithGet);
-
-      entity.addStep({
-        definedComponent: { type: CatalogKind.Component, name: 'direct' } as DefinedComponent,
-        mode: AddStepMode.ReplaceStep,
-        data: {
-          name: PlaceholderType.Placeholder,
-          path: 'rest.get.0.to.placeholder',
-          isPlaceholder: true,
-          isGroup: false,
-          iconUrl: '',
-          title: '',
-          description: '',
-        },
-      });
-
-      const toLocal = restDefWithGet.rest.get?.[0].to as Exclude<To2, string>;
-
-      expect(toLocal).toBeDefined();
-      expect(toLocal?.uri).toBe('direct');
-    });
-
-    it('should not add step when path is undefined', () => {
-      const entity = new CamelRestVisualEntity(restDef);
-
-      entity.addStep({
-        definedComponent: { type: CatalogKind.Component, name: 'direct' } as DefinedComponent,
-        mode: AddStepMode.ReplaceStep,
-        data: {
-          name: PlaceholderType.Placeholder,
-          path: undefined,
-          isPlaceholder: true,
-          isGroup: false,
-          iconUrl: '',
-          title: '',
-          description: '',
-        },
-      });
-
-      // Should not throw and rest should remain unchanged
-      expect(restDef.rest).toEqual(restStub.rest);
-    });
-  });
-
-  describe('getNodeValidationText', () => {
-    it('should return undefined for valid definitions', async () => {
-      const entity = new CamelRestVisualEntity({
-        rest: {
-          ...restDef.rest,
-          bindingMode: 'json',
-        },
-      });
-
-      expect(await entity.getNodeValidationText()).toBeUndefined();
-    });
-
-    it('should not modify the original definition when validating', async () => {
-      const originalRestDef: Rest = { ...restDef.rest };
-      const entity = new CamelRestVisualEntity(restDef);
-
-      await entity.getNodeValidationText();
-
-      expect(restDef.rest).toEqual(originalRestDef);
-    });
-
-    it('should NOT return errors when there is an invalid property', async () => {
-      const invalidRestDef: Rest = {
-        ...restDef.rest,
-        bindingMode: 'true' as unknown as Rest['bindingMode'],
-        openApi: 'true' as unknown as Rest['openApi'],
-      };
-      const entity = new CamelRestVisualEntity({ rest: invalidRestDef });
-
-      expect(await entity.getNodeValidationText()).toBeUndefined();
-    });
-  });
-
-  it('toVizNode should return visualization node', async () => {
-    const entity = new CamelRestVisualEntity(restDef);
-
-    const vizNode = await entity.toVizNode();
-    await vizNode.fetchSchema();
-
-    expect(vizNode.data).toEqual({
-      entity,
-      name: 'rest',
-      isGroup: true,
-      path: 'rest',
-      processorName: 'rest',
-      primaryNodeId: { name: entity.type, catalogKind: CatalogKind.Entity },
-      iconAlt: 'Entity icon',
-      iconUrl: '/src/assets/components/generic-component.png',
-      isPlaceholder: false,
-      title: 'Rest',
-      description:
-        'rest: Defines a REST service with HTTP operations (GET, POST, PUT, DELETE, etc.) using the Camel REST DSL',
-      processorIconTooltip: '',
-      schema: expect.any(Object),
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-rest-visual-entity.ts
@@ -4,37 +4,19 @@ import { isDefined } from '@kaoto/forms';
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { getValue, setValue } from '../../../utils';
-import { DefinedComponent } from '../../camel/camel-catalog-index';
-import { CatalogKind } from '../../catalog-kind';
+import { uriDefinitionParser } from '../../camel/parsers/uri-definition.parser';
 import { EntityType } from '../../entities/base-entity';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
-import { NodeLabelType } from '../../settings/settings.model';
-import {
-  REST_DSL_VERBS,
-  REST_ELEMENT_NAME,
-  RestMethods,
-  SPECIAL_PROCESSORS_PARENTS_MAP,
-} from '../../special-processors.constants';
-import {
-  AddStepMode,
-  BaseVisualEntity,
-  IVisualizationNode,
-  IVisualizationNodeData,
-  IVisualizationNodeIds,
-  NodeInteraction,
-} from '../base-visual-entity';
-import { NodeIdentity } from '../node-identity';
-import { createVisualizationNode } from '../visualization-node';
-import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
-import { NodeEnrichmentService } from './nodes/node-enrichment.service';
+import { REST_DSL_VERBS, RestMethods, SPECIAL_PROCESSORS_PARENTS_MAP } from '../../special-processors.constants';
+import { IVisualizationNodeIds } from '../base-visual-entity';
+import { RestEntity } from './rest-entity';
 
-export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Rest }> implements BaseVisualEntity {
+export class CamelRestVisualEntity implements RestEntity {
   id: string;
   readonly type = EntityType.Rest;
   static readonly ROOT_PATH = 'rest';
 
   constructor(public restDef: { rest: Rest } = { rest: {} }) {
-    super(restDef);
     const id = restDef.rest.id ?? getCamelRandomId(CamelRestVisualEntity.ROOT_PATH);
     this.id = id;
     this.restDef.rest.id = id;
@@ -48,16 +30,23 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
     return Object.keys(restDef).length === 1 && this.ROOT_PATH in restDef && typeof restDef.rest === 'object';
   }
 
-  getNodeLabel(path?: string, labelType?: NodeLabelType, ids?: IVisualizationNodeIds): string {
-    if (path === 'rest.placeholder') {
-      return 'verb';
-    }
-
-    return super.getNodeLabel(path, labelType, ids);
-  }
-
   removeStep(path?: string): void {
-    super.removeStep(path);
+    if (!path) return;
+
+    const pathArray = path.split('.');
+    const last = pathArray[pathArray.length - 1];
+    const penultimate = pathArray[pathArray.length - 2];
+
+    if (Number.isInteger(Number(last))) {
+      const array = getValue(this.restDef, pathArray.slice(0, -1), []);
+      if (Array.isArray(array)) array.splice(Number(last), 1);
+    } else if (Number.isInteger(Number(penultimate))) {
+      const array = getValue(this.restDef, pathArray.slice(0, -2), []);
+      if (Array.isArray(array)) array.splice(Number(penultimate), 1);
+    } else {
+      const object = getValue(this.restDef, pathArray.slice(0, -1), {});
+      if (object && typeof object === 'object') delete object[last];
+    }
 
     const restVerbs = SPECIAL_PROCESSORS_PARENTS_MAP['rest'];
     for (const verb of restVerbs) {
@@ -70,6 +59,10 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
 
   getRootPath() {
     return CamelRestVisualEntity.ROOT_PATH;
+  }
+
+  getId(): string {
+    return this.id;
   }
 
   setId(id: string): void {
@@ -88,7 +81,9 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
     return definition?.propertiesSchema;
   }
 
-  getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): unknown {
+  getNodeDefinition(path?: string, _ids?: IVisualizationNodeIds): unknown {
+    if (!path) return undefined;
+
     if (path === CamelRestVisualEntity.ROOT_PATH) {
       return { ...this.restDef.rest };
     }
@@ -100,7 +95,21 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
       return { ...getValue(this.restDef, path) };
     }
 
-    return super.getNodeDefinition(path, ids);
+    return getValue(this.restDef, path);
+  }
+
+  async getParsedDefinition(path?: string, ids?: IVisualizationNodeIds): Promise<unknown> {
+    const definition = this.getNodeDefinition(path, ids);
+    if (definition == null) return definition;
+
+    const componentName =
+      ids?.secondaryNodeId?.name === 'kamelet' && ids?.tertiaryNodeId?.name !== undefined
+        ? `kamelet:${ids.tertiaryNodeId.name}`
+        : ids?.secondaryNodeId?.name;
+
+    if (!componentName) return definition;
+
+    return uriDefinitionParser(componentName, definition as Record<string, unknown>);
   }
 
   updateModel(path: string | undefined, value: unknown): void {
@@ -113,61 +122,7 @@ export class CamelRestVisualEntity extends AbstractCamelVisualEntity<{ rest: Res
     }
   }
 
-  addStep(options: {
-    definedComponent: DefinedComponent;
-    mode: AddStepMode;
-    data: IVisualizationNodeData;
-    targetProperty?: string;
-  }): void {
-    const path = options.data.path?.replace('.placeholder', '');
-    const updatedOptions = { ...options, data: { ...options.data, path } };
-
-    super.addStep(updatedOptions);
-  }
-
-  getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
-    const isRootPath = data.path === CamelRestVisualEntity.ROOT_PATH;
-    if (isRootPath || data.path?.endsWith('to')) {
-      return {
-        canHavePreviousStep: false,
-        canHaveNextStep: false,
-        canHaveChildren: false,
-        canHaveSpecialChildren: isRootPath,
-        canRemoveStep: !isRootPath,
-        canReplaceStep: false,
-        canRemoveFlow: isRootPath,
-        canBeDisabled: isRootPath,
-      };
-    }
-
-    return super.getNodeInteraction(data);
-  }
-
-  async toVizNode(): Promise<IVisualizationNode<IVisualizationNodeData>> {
-    const restGroupNode = createVisualizationNode(this.getRootPath(), {
-      name: this.type,
-      path: this.getRootPath(),
-      entity: this,
-      isPlaceholder: false,
-      isGroup: true,
-      iconUrl: '',
-      title: '',
-      description: '',
-      processorIconTooltip: '',
-      processorName: REST_ELEMENT_NAME,
-      primaryNodeId: { name: this.type, catalogKind: CatalogKind.Entity } satisfies NodeIdentity,
-    });
-
-    await NodeEnrichmentService.enrichVisualizationTree(restGroupNode);
-
-    return restGroupNode;
-  }
-
   toJSON(): { rest: Rest } {
     return { rest: this.restDef.rest };
-  }
-
-  protected getRootUri(): string | undefined {
-    return undefined;
   }
 }

--- a/packages/ui/src/models/visualization/flows/index.ts
+++ b/packages/ui/src/models/visualization/flows/index.ts
@@ -4,3 +4,4 @@ export * from './citrus-test-visual-entity';
 export * from './kamelet-binding-visual-entity';
 export * from './kamelet-visual-entity';
 export * from './pipe-visual-entity';
+export * from './rest-entity';

--- a/packages/ui/src/models/visualization/flows/rest-entity.ts
+++ b/packages/ui/src/models/visualization/flows/rest-entity.ts
@@ -1,0 +1,15 @@
+import { BaseEntity } from '../../entities';
+import { KaotoSchemaDefinition } from '../../kaoto-schema';
+import { IVisualizationNodeIds } from '../base-visual-entity';
+
+/** The model operations used by the REST DSL editor. */
+export interface RestEntity extends BaseEntity {
+  getRootPath(): string;
+  getId(): string;
+  setId(id: string): void;
+  fetchNodeSchema(ids?: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined>;
+  getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): unknown;
+  getParsedDefinition(path?: string, ids?: IVisualizationNodeIds): Promise<unknown>;
+  updateModel(path: string | undefined, value: unknown): void;
+  removeStep(path?: string): void;
+}

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
@@ -76,8 +76,6 @@ export const RestDslEditorPage: FunctionComponent = () => {
       return;
     }
 
-    if (!(selectedEntity instanceof CamelRestVisualEntity)) return;
-
     selectedEntity
       .getParsedDefinition(modelPath, ids)
       .then((resolved) => {

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { CamelResourceFactory } from '../../../models/camel/camel-resource-factory';
 import { CatalogKind } from '../../../models/catalog-kind';
-import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';
+import { RestEntity } from '../../../models/visualization/flows/rest-entity';
 import { getRestEntities } from './get-rest-entities';
 import { RestTree } from './RestTree';
 
@@ -299,7 +299,7 @@ describe('RestTree', () => {
   });
 
   it('should handle empty entities array gracefully', async () => {
-    const entities: BaseVisualEntity[] = [];
+    const entities: RestEntity[] = [];
 
     render(<RestTree entities={entities} onSelect={mockOnSelect} onDelete={mockOnDelete} />);
 

--- a/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTree.tsx
@@ -4,7 +4,8 @@ import { TrashCan } from '@carbon/icons-react';
 import { Menu, MenuItem, TreeNode, TreeView, useContextMenu } from '@carbon/react';
 import { FunctionComponent, PropsWithChildren, useEffect, useRef, useState } from 'react';
 
-import { BaseVisualEntity, IVisualizationNodeIds } from '../../../models/visualization/base-visual-entity';
+import { IVisualizationNodeIds } from '../../../models/visualization/base-visual-entity';
+import { RestEntity } from '../../../models/visualization/flows/rest-entity';
 import { restToTree } from '../rest-to-tree';
 import { MethodBadge } from './MethodBadge';
 
@@ -15,7 +16,7 @@ export type IRestTreeSelection = { entityId: string; modelPath: string; ids: IVi
  * Props for the RestTree component.
  */
 export interface IRestTree extends PropsWithChildren {
-  entities: BaseVisualEntity[];
+  entities: RestEntity[];
   selected?: IRestTreeSelection;
   onSelect: (selection: IRestTreeSelection) => void;
   onDelete: () => void;
@@ -119,9 +120,11 @@ export const RestTree: FunctionComponent<IRestTree> = ({ entities, selected, onS
               >
                 {node.children?.map((child) => {
                   const currentEntity = entities.find((entity) => entity.id === node.entityId);
-                  const pathLabel = currentEntity?.getNodeDefinition(child?.modelPath, {
-                    primaryNodeId: child.primaryNodeId,
-                  }).path;
+                  const pathLabel = (
+                    currentEntity?.getNodeDefinition(child.modelPath, {
+                      primaryNodeId: child.primaryNodeId,
+                    }) as { path?: string } | undefined
+                  )?.path;
                   const label = pathLabel?.trim() ? (
                     pathLabel
                   ) : (

--- a/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { CamelResourceFactory } from '../../../models/camel/camel-resource-factory';
 import { CatalogKind } from '../../../models/catalog-kind';
-import { BaseVisualEntity } from '../../../models/visualization/base-visual-entity';
 import { CamelRestConfigurationVisualEntity } from '../../../models/visualization/flows/camel-rest-configuration-visual-entity';
+import { RestEntity } from '../../../models/visualization/flows/rest-entity';
 import { clickToolbarActionUtil } from '../test-utils';
 import { getRestEntities } from './get-rest-entities';
 import { RestTreeToolbar } from './RestTreeToolbar';
@@ -75,7 +75,7 @@ describe('RestTreeToolbar', () => {
     });
 
     it('should fire callback when clicked', async () => {
-      const entities: BaseVisualEntity[] = [];
+      const entities: RestEntity[] = [];
 
       render(
         <RestTreeToolbar
@@ -94,7 +94,7 @@ describe('RestTreeToolbar', () => {
 
   describe('Add Rest button', () => {
     it('should always be enabled', async () => {
-      const entities: BaseVisualEntity[] = [];
+      const entities: RestEntity[] = [];
 
       render(
         <RestTreeToolbar
@@ -142,7 +142,7 @@ describe('RestTreeToolbar', () => {
     });
 
     it('should fire callback when clicked', async () => {
-      const entities: BaseVisualEntity[] = [];
+      const entities: RestEntity[] = [];
 
       render(
         <RestTreeToolbar
@@ -161,7 +161,7 @@ describe('RestTreeToolbar', () => {
 
   describe('Add Method button', () => {
     it('should be disabled when nothing is selected', async () => {
-      const entities: BaseVisualEntity[] = [];
+      const entities: RestEntity[] = [];
 
       render(
         <RestTreeToolbar
@@ -356,7 +356,7 @@ describe('RestTreeToolbar', () => {
 
   describe('Delete button', () => {
     it('should be disabled when nothing is selected', async () => {
-      const entities: BaseVisualEntity[] = [];
+      const entities: RestEntity[] = [];
 
       render(
         <RestTreeToolbar

--- a/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.tsx
+++ b/packages/ui/src/pages/RestDslEditor/components/RestTreeToolbar.tsx
@@ -2,16 +2,16 @@ import { Add, TrashCan } from '@carbon/icons-react';
 import { MenuButton, MenuItem, MenuItemDivider } from '@carbon/react';
 import { FunctionComponent, RefObject, useLayoutEffect, useMemo, useRef } from 'react';
 
-import { BaseVisualEntity } from '../../../models';
 import { CamelRestConfigurationVisualEntity } from '../../../models/visualization/flows/camel-rest-configuration-visual-entity';
 import { CamelRestVisualEntity } from '../../../models/visualization/flows/camel-rest-visual-entity';
+import { RestEntity } from '../../../models/visualization/flows/rest-entity';
 import { IRestTreeSelection } from './RestTree';
 
 /**
  * Props for the RestTreeToolbar component.
  */
 export interface RestTreeToolbarProps {
-  entities: BaseVisualEntity[];
+  entities: RestEntity[];
   selectedElement?: IRestTreeSelection;
   launcherButtonRef?: RefObject<HTMLButtonElement | null>;
   onAddRestConfiguration: () => void;

--- a/packages/ui/src/pages/RestDslEditor/components/get-rest-entities.ts
+++ b/packages/ui/src/pages/RestDslEditor/components/get-rest-entities.ts
@@ -1,9 +1,8 @@
 import { BaseEntity } from '../../../models/entities';
 import { CamelRestConfigurationVisualEntity } from '../../../models/visualization/flows/camel-rest-configuration-visual-entity';
 import { CamelRestVisualEntity } from '../../../models/visualization/flows/camel-rest-visual-entity';
+import { RestEntity } from '../../../models/visualization/flows/rest-entity';
 
 /** Helper to get REST-related entities (non-visual after refactor) */
-export const getRestEntities = (
-  entities: BaseEntity[],
-): (CamelRestVisualEntity | CamelRestConfigurationVisualEntity)[] =>
+export const getRestEntities = (entities: BaseEntity[]): RestEntity[] =>
   entities.filter((e) => e instanceof CamelRestVisualEntity || e instanceof CamelRestConfigurationVisualEntity);

--- a/packages/ui/src/pages/RestDslEditor/rest-to-tree.test.ts
+++ b/packages/ui/src/pages/RestDslEditor/rest-to-tree.test.ts
@@ -1,18 +1,18 @@
 import { CamelResourceFactory } from '../../models/camel/camel-resource-factory';
 import { CatalogKind } from '../../models/catalog-kind';
 import { KaotoResource } from '../../models/kaoto-resource';
-import { BaseVisualEntity } from '../../models/visualization/base-visual-entity';
 import { CamelRestConfigurationVisualEntity } from '../../models/visualization/flows/camel-rest-configuration-visual-entity';
 import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
+import { RestEntity } from '../../models/visualization/flows/rest-entity';
 import { restToTree, RestTreeNode } from './rest-to-tree';
 
 /** Helper to get REST-related entities (non-visual after refactor) */
-const getRestEntities = (camelResource: KaotoResource): BaseVisualEntity[] =>
+const getRestEntities = (camelResource: KaotoResource): RestEntity[] =>
   camelResource
     .getEntities()
     .filter(
       (e) => e instanceof CamelRestVisualEntity || e instanceof CamelRestConfigurationVisualEntity,
-    ) as BaseVisualEntity[];
+    ) as RestEntity[];
 
 describe('restToTree', () => {
   let camelResource: KaotoResource;

--- a/packages/ui/src/pages/RestDslEditor/rest-to-tree.ts
+++ b/packages/ui/src/pages/RestDslEditor/rest-to-tree.ts
@@ -1,9 +1,10 @@
 import { Rest } from '@kaoto/camel-catalog/types';
 
-import { BaseVisualEntity, CatalogKind, IVisualizationNodeIds } from '../../models';
+import { CatalogKind, IVisualizationNodeIds } from '../../models';
 import { REST_DSL_VERBS } from '../../models/special-processors.constants';
 import { CamelRestConfigurationVisualEntity } from '../../models/visualization/flows/camel-rest-configuration-visual-entity';
 import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
+import { RestEntity } from '../../models/visualization/flows/rest-entity';
 
 /**
  * Represents a node in the REST DSL tree structure.
@@ -19,17 +20,17 @@ export interface RestTreeNode extends IVisualizationNodeIds {
 }
 
 /**
- * Converts visual entities into a tree structure for REST DSL display.
+ * Converts REST entities into a tree structure for REST DSL display.
  * Processes RestConfiguration and Rest entities, organizing REST methods as child nodes.
  *
- * @param visualEntities - Array of visual entities to convert
+ * @param restEntities - Array of REST entities to convert
  * @returns Array of tree nodes representing the REST DSL hierarchy
  */
-export const restToTree = (visualEntities: BaseVisualEntity[]): RestTreeNode[] => {
-  const restConfigEntities: CamelRestConfigurationVisualEntity[] = visualEntities.filter(
+export const restToTree = (restEntities: RestEntity[]): RestTreeNode[] => {
+  const restConfigEntities: CamelRestConfigurationVisualEntity[] = restEntities.filter(
     (entity) => entity instanceof CamelRestConfigurationVisualEntity,
   );
-  const restEntities = visualEntities.filter((entity) => entity instanceof CamelRestVisualEntity);
+  const restVisualEntities = restEntities.filter((entity) => entity instanceof CamelRestVisualEntity);
 
   const restConfigNodes: RestTreeNode[] = restConfigEntities.map((entity) => {
     const entityId = entity.getId();
@@ -47,7 +48,7 @@ export const restToTree = (visualEntities: BaseVisualEntity[]): RestTreeNode[] =
     };
   });
 
-  const restNodes: RestTreeNode[] = restEntities.map((entity) => {
+  const restNodes: RestTreeNode[] = restVisualEntities.map((entity) => {
     const entityId = entity.getId();
     const methodsTreeNodes: RestTreeNode[] = [];
     const restDef = entity.getNodeDefinition(entity.getRootPath()) as Rest;


### PR DESCRIPTION
## Description

I moved the REST DSL entities out of the canvas `BaseVisualEntity` contract. The REST editor now uses a focused `RestEntity` interface, while canvas-only methods and their obsolete tests are removed. REST parsing, importing, editing, serialization, and the existing non-visual registration remain intact.

Fixes https://github.com/KaotoIO/kaoto/issues/3643
Fixes https://github.com/KaotoIO/kaoto/issues/3196

## Verification

- `yarn workspace @kaoto/kaoto lint`
- `yarn workspace @kaoto/kaoto test --run src/models/visualization/flows/camel-rest-visual-entity.test.ts src/models/visualization/flows/camel-rest-configuration-visual-entity.test.ts src/pages/RestDslEditor` (126 passed)
- `yarn workspace @kaoto/kaoto build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved REST DSL editor handling for REST resources and configurations.
  * Enhanced REST tree navigation and labeling when node details are unavailable or incomplete.
  * Improved REST model operations, including identifying resources, updating values, retrieving parsed definitions, and removing steps.
  * Added broader support for REST entities across route resources and editor components.
* **Tests**
  * Updated coverage to reflect streamlined REST entity behavior, parsed definitions, and editor workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->