### PR TITLE
Update documentation checklist link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -16,5 +16,5 @@ Provide information about the testing procedures, types of tests, and tools used
 - [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md).
 - [ ] I have followed the coding style and conventions of the project.
 - [ ] I have tested my changes and ensured that they work as expected.
-- [ ] I have updated any relevant documentation.
+- [ ] I have updated any relevant [documentation](https://github.com/KaotoIO/kaoto.io/tree/main/content/docs).
 - [ ] I have added tests that prove my fix or feature works.


### PR DESCRIPTION
Added a link to the docs repository location to make it clear where documentation updates should go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request checklist so its documentation item links directly to the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->