### PR TITLE
refactor(MultiValuePropertyEditor): migrate multi-value service to async DynamicCatalogRegistry

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/EndpointPropertiesField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/EndpointPropertiesField.test.tsx
@@ -1,8 +1,9 @@
 import { SchemaContext } from '@kaoto/forms';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { EndpointPropertiesField } from './EndpointPropertiesField';
+import { MultiValuePropertyService } from './MultiValueProperty.service';
 
 const mockOnChange = vi.fn();
 const mockUseFieldValue = vi.fn();
@@ -64,11 +65,29 @@ describe('EndpointPropertiesField', () => {
       value: { key1: 'value1', key2: 'value2' },
       onChange: mockOnChange,
     });
+    vi.spyOn(MultiValuePropertyService, 'getMultiValueProperties').mockReturnValue(Promise.resolve(new Map()));
   });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Renders the component inside `await act(async () => ...)` so that the
+   * microtask queue drains and the <Suspense> boundary resolves before the
+   * first assertion. Plain `render()` uses a synchronous act internally and
+   * exits before the already-settled promise microtask fires, causing
+   * `findByTestId` to time out waiting for the standard view.
+   * The eslint rule cannot detect Suspense inside the tree, so we suppress it.
+   */
+
+  const renderWithSuspense = async (ui: React.ReactElement) =>
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(async () => render(ui));
 
   describe('when schema has properties', () => {
     it('should render toggle buttons with standard view by default', async () => {
-      render(
+      await renderWithSuspense(
         <SchemaContext.Provider value={schemaWithProperties}>
           <EndpointPropertiesField {...defaultProps} />
         </SchemaContext.Provider>,
@@ -76,48 +95,53 @@ describe('EndpointPropertiesField', () => {
 
       expect(screen.getByText('Standard')).toBeInTheDocument();
       expect(screen.getByText('Custom')).toBeInTheDocument();
-      await waitFor(() => {
-        expect(screen.getByTestId('object-field-testProp')).toBeInTheDocument();
-        expect(screen.queryByTestId('array-field-wrapper')).not.toBeInTheDocument();
-        expect(screen.getByTestId('testProp-standard-toggle').querySelector('button')).toHaveClass('pf-m-selected');
-      });
+
+      expect(await screen.findByTestId('object-field-testProp')).toBeInTheDocument();
+      expect(screen.queryByTestId('array-field-wrapper')).not.toBeInTheDocument();
+
+      const standardToggle = screen.getByTestId('testProp-standard-toggle');
+      expect(within(standardToggle).getByRole('button')).toHaveClass('pf-m-selected');
     });
 
     it('should switch to custom view and back', async () => {
       const user = userEvent.setup();
 
-      render(
+      await renderWithSuspense(
         <SchemaContext.Provider value={schemaWithProperties}>
           <EndpointPropertiesField {...defaultProps} />
         </SchemaContext.Provider>,
       );
 
+      // Wait for Suspense to resolve before interacting
+      await screen.findByTestId('object-field-testProp');
+
       // Switch to custom view
       await user.click(screen.getByText('Custom'));
-      expect(screen.getByTestId('array-field-wrapper')).toBeInTheDocument();
+
+      expect(await screen.findByTestId('array-field-wrapper')).toBeInTheDocument();
       expect(screen.getByTestId('array-field-title')).toHaveTextContent('Endpoint Properties');
       expect(screen.getByTestId('properties-field-testProp')).toBeInTheDocument();
       expect(screen.queryByTestId('object-field-testProp')).not.toBeInTheDocument();
 
-      const customButton = screen.getByTestId('testProp-custom-toggle').querySelector('button');
-      expect(customButton).toHaveClass('pf-m-selected');
+      const customToggle = screen.getByTestId('testProp-custom-toggle');
+      expect(within(customToggle).getByRole('button')).toHaveClass('pf-m-selected');
 
       // Switch back to standard view
       await user.click(screen.getByText('Standard'));
-      expect(screen.getByTestId('object-field-testProp')).toBeInTheDocument();
+      expect(await screen.findByTestId('object-field-testProp')).toBeInTheDocument();
       expect(screen.queryByTestId('array-field-wrapper')).not.toBeInTheDocument();
     });
   });
 
   describe('when schema has no properties', () => {
-    it('should render PropertiesField without toggle buttons and with badge', () => {
+    it('should render PropertiesField without toggle buttons and with badge', async () => {
       render(
         <SchemaContext.Provider value={schemaWithoutProperties}>
           <EndpointPropertiesField {...defaultProps} />
         </SchemaContext.Provider>,
       );
 
-      expect(screen.getByTestId('properties-field-testProp')).toBeInTheDocument();
+      expect(await screen.findByTestId('properties-field-testProp')).toBeInTheDocument();
       expect(screen.queryByText('Standard')).not.toBeInTheDocument();
       expect(screen.queryByText('Custom')).not.toBeInTheDocument();
 
@@ -130,7 +154,7 @@ describe('EndpointPropertiesField', () => {
       expect(screen.getByTestId('testProp__remove')).toBeInTheDocument();
     });
 
-    it('should handle undefined properties object', () => {
+    it('should handle undefined properties object', async () => {
       const schemaWithUndefined = {
         schema: { properties: undefined },
         definitions: {},
@@ -143,7 +167,7 @@ describe('EndpointPropertiesField', () => {
         </SchemaContext.Provider>,
       );
 
-      expect(screen.getByTestId('properties-field-testProp')).toBeInTheDocument();
+      expect(await screen.findByTestId('properties-field-testProp')).toBeInTheDocument();
       expect(screen.queryByText('Standard')).not.toBeInTheDocument();
       expect(screen.getByText('2')).toBeInTheDocument();
     });
@@ -153,15 +177,18 @@ describe('EndpointPropertiesField', () => {
     it('should display badge with correct item count in custom view', async () => {
       const user = userEvent.setup();
 
-      render(
+      await renderWithSuspense(
         <SchemaContext.Provider value={schemaWithProperties}>
           <EndpointPropertiesField {...defaultProps} />
         </SchemaContext.Provider>,
       );
 
+      // Wait for Suspense in standard view before switching
+      await screen.findByTestId('object-field-testProp');
+
       await user.click(screen.getByText('Custom'));
 
-      const badge = screen.getByText('2');
+      const badge = await screen.findByText('2');
       expect(badge).toBeInTheDocument();
       expect(badge).toHaveAttribute('title', '2 properties');
     });
@@ -169,15 +196,18 @@ describe('EndpointPropertiesField', () => {
     it('should call onChange with undefined when remove button is clicked', async () => {
       const user = userEvent.setup();
 
-      render(
+      await renderWithSuspense(
         <SchemaContext.Provider value={schemaWithProperties}>
           <EndpointPropertiesField {...defaultProps} />
         </SchemaContext.Provider>,
       );
 
+      // Wait for Suspense in standard view before switching
+      await screen.findByTestId('object-field-testProp');
+
       await user.click(screen.getByText('Custom'));
 
-      const removeButton = screen.getByTestId('testProp__remove');
+      const removeButton = await screen.findByTestId('testProp__remove');
       await user.click(removeButton);
 
       expect(mockOnChange).toHaveBeenCalledWith(undefined);
@@ -191,14 +221,17 @@ describe('EndpointPropertiesField', () => {
         onChange: mockOnChange,
       });
 
-      render(
+      await renderWithSuspense(
         <SchemaContext.Provider value={schemaWithProperties}>
           <EndpointPropertiesField {...defaultProps} />
         </SchemaContext.Provider>,
       );
 
+      // Wait for Suspense in standard view before switching
+      await screen.findByTestId('object-field-testProp');
+
       await user.click(screen.getByText('Custom'));
-      expect(screen.getByText('0')).toBeInTheDocument();
+      expect(await screen.findByText('0')).toBeInTheDocument();
     });
 
     it('should display badge with 0 when value is empty object', async () => {
@@ -209,14 +242,17 @@ describe('EndpointPropertiesField', () => {
         onChange: mockOnChange,
       });
 
-      render(
+      await renderWithSuspense(
         <SchemaContext.Provider value={schemaWithProperties}>
           <EndpointPropertiesField {...defaultProps} />
         </SchemaContext.Provider>,
       );
 
+      // Wait for Suspense in standard view before switching
+      await screen.findByTestId('object-field-testProp');
+
       await user.click(screen.getByText('Custom'));
-      expect(screen.getByText('0')).toBeInTheDocument();
+      expect(await screen.findByText('0')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/EndpointPropertiesField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/EndpointPropertiesField.test.tsx
@@ -1,5 +1,5 @@
 import { SchemaContext } from '@kaoto/forms';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { EndpointPropertiesField } from './EndpointPropertiesField';
@@ -67,7 +67,7 @@ describe('EndpointPropertiesField', () => {
   });
 
   describe('when schema has properties', () => {
-    it('should render toggle buttons with standard view by default', () => {
+    it('should render toggle buttons with standard view by default', async () => {
       render(
         <SchemaContext.Provider value={schemaWithProperties}>
           <EndpointPropertiesField {...defaultProps} />
@@ -76,11 +76,11 @@ describe('EndpointPropertiesField', () => {
 
       expect(screen.getByText('Standard')).toBeInTheDocument();
       expect(screen.getByText('Custom')).toBeInTheDocument();
-      expect(screen.getByTestId('object-field-testProp')).toBeInTheDocument();
-      expect(screen.queryByTestId('array-field-wrapper')).not.toBeInTheDocument();
-
-      const standardButton = screen.getByTestId('testProp-standard-toggle').querySelector('button');
-      expect(standardButton).toHaveClass('pf-m-selected');
+      await waitFor(() => {
+        expect(screen.getByTestId('object-field-testProp')).toBeInTheDocument();
+        expect(screen.queryByTestId('array-field-wrapper')).not.toBeInTheDocument();
+        expect(screen.getByTestId('testProp-standard-toggle').querySelector('button')).toHaveClass('pf-m-selected');
+      });
     });
 
     it('should switch to custom view and back', async () => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.test.ts
@@ -146,5 +146,38 @@ describe('MultiValuePropertyService', () => {
         parameters: { 'job.test': 'test', 'trigger.test': 'test' },
       });
     });
+
+    it('should omit nested child entries whose value is undefined', async () => {
+      const multiValueMap = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'quartz');
+      const definition = {
+        uri: 'quartz',
+        parameters: {
+          jobParameters: { name: 'myJob', description: undefined },
+          triggerParameters: { cron: '0 0 * * *' },
+        },
+      };
+      const result = MultiValuePropertyService.getMultiValueSerializedDefinition(multiValueMap, definition);
+
+      // 'job.description' must NOT appear in the output — its value is undefined
+      expect(result).toEqual({
+        uri: 'quartz',
+        parameters: { 'job.name': 'myJob', 'trigger.cron': '0 0 * * *' },
+      });
+      expect(result!.parameters).not.toHaveProperty('job.description');
+    });
+
+    it('should not emit any flat key when the entire nested object has only undefined values (delete/clear flow)', async () => {
+      const multiValueMap = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'quartz');
+      const definition = {
+        uri: 'quartz',
+        parameters: {
+          jobParameters: { name: undefined },
+        },
+      };
+      const result = MultiValuePropertyService.getMultiValueSerializedDefinition(multiValueMap, definition);
+
+      // The key must be entirely absent — not present with value undefined
+      expect(Object.prototype.hasOwnProperty.call(result!.parameters, 'job.name')).toBe(false);
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.test.ts
@@ -1,36 +1,66 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
-import { CamelCatalogService, CatalogKind } from '../../../../../../models';
-import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../../../../../models';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../../../../stubs/test-load-catalog';
 import { MultiValuePropertyService } from './MultiValueProperty.service';
 
 describe('MultiValuePropertyService', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Component, catalogsMap.componentCatalogMap);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   afterAll(() => {
-    CamelCatalogService.clearCatalogs();
+    DynamicCatalogRegistry.get().clearRegistry();
+  });
+
+  describe('getMultiValueProperties', () => {
+    it('should query the dynamic catalog service', async () => {
+      const dynamicCatalogServiceSpy = vi.spyOn(DynamicCatalogRegistry.get(), 'getEntity');
+
+      await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'log');
+
+      expect(dynamicCatalogServiceSpy).toHaveBeenCalledWith(CatalogKind.Component, 'log');
+    });
+
+    it('should return an empty map for components without multi-value parameters', async () => {
+      const result = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'log');
+
+      expect(result.size).toBe(0);
+    });
+
+    it('should return multi-value prefixes for quartz', async () => {
+      const result = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'quartz');
+
+      expect(result.get('jobParameters')).toBe('job.');
+      expect(result.get('triggerParameters')).toBe('trigger.');
+    });
   });
 
   describe('readMultiValue', () => {
-    it('should return original properties if component has no multi-value parameters', () => {
+    it('should return original properties if component has no multi-value parameters', async () => {
+      const multiValueMap = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'log');
       const definition = { message: 'Hello World', level: 'INFO' };
-      const result = MultiValuePropertyService.readMultiValue('log', definition);
+      const result = MultiValuePropertyService.readMultiValue(multiValueMap, definition);
 
       expect(result).toEqual({ message: 'Hello World', level: 'INFO' });
     });
 
-    it('should return original properties if component is not found', () => {
+    it('should return original properties if component is not found', async () => {
+      const multiValueMap = await MultiValuePropertyService.getMultiValueProperties(
+        CatalogKind.Component,
+        'unknown-component',
+      );
       const definition = { param1: 'value1', param2: 'value2' };
-      const result = MultiValuePropertyService.readMultiValue('unknown-component', definition);
+      const result = MultiValuePropertyService.readMultiValue(multiValueMap, definition);
 
       expect(result).toEqual({ param1: 'value1', param2: 'value2' });
     });
 
-    it('should convert flat multi-value parameters to nested structure', () => {
+    it('should convert flat multi-value parameters to nested structure', async () => {
+      const multiValueMap = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'quartz');
       const definition = {
         'job.name': 'myJob',
         'job.description': 'My job description',
@@ -38,7 +68,7 @@ describe('MultiValuePropertyService', () => {
         'trigger.repeatInterval': '1000',
         normalParam: 'normalValue',
       };
-      const result = MultiValuePropertyService.readMultiValue('quartz', definition);
+      const result = MultiValuePropertyService.readMultiValue(multiValueMap, definition);
 
       expect(result).toEqual({
         normalParam: 'normalValue',
@@ -53,13 +83,14 @@ describe('MultiValuePropertyService', () => {
       });
     });
 
-    it('should handle mixed parameters correctly', () => {
+    it('should handle mixed parameters correctly', async () => {
+      const multiValueMap = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'quartz');
       const definition = {
         'job.name': 'testJob',
         regularParam: 'value',
         'trigger.cron': '0 0 * * *',
       };
-      const result = MultiValuePropertyService.readMultiValue('quartz', definition);
+      const result = MultiValuePropertyService.readMultiValue(multiValueMap, definition);
 
       expect(result).toEqual({
         regularParam: 'value',
@@ -72,9 +103,10 @@ describe('MultiValuePropertyService', () => {
       });
     });
 
-    it('should handle empty definition', () => {
+    it('should handle empty definition', async () => {
+      const multiValueMap = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'quartz');
       const definition = {};
-      const result = MultiValuePropertyService.readMultiValue('quartz', definition);
+      const result = MultiValuePropertyService.readMultiValue(multiValueMap, definition);
 
       expect(result).toEqual({
         jobParameters: {},
@@ -84,9 +116,9 @@ describe('MultiValuePropertyService', () => {
   });
 
   describe('getMultiValueSerializedDefinition', () => {
-    it('should return the same parameters if the definition is not a component', () => {
+    it('should return the definition with empty parameters when multi-value map is empty', () => {
       const definition = { log: { message: 'Hello World' } };
-      const result = MultiValuePropertyService.getMultiValueSerializedDefinition('from', definition);
+      const result = MultiValuePropertyService.getMultiValueSerializedDefinition(new Map(), definition);
 
       expect(result).toEqual({ log: { message: 'Hello World' }, parameters: {} });
     });
@@ -96,25 +128,18 @@ describe('MultiValuePropertyService', () => {
         uri: 'unknown-component',
         parameters: { jobParameters: { test: 'test' }, triggerParameters: { test: 'test' } },
       };
-      const result = MultiValuePropertyService.getMultiValueSerializedDefinition('from', definition);
+      const result = MultiValuePropertyService.getMultiValueSerializedDefinition(new Map(), definition);
 
       expect(result).toEqual(definition);
     });
 
-    it('should query the catalog service', () => {
-      const definition = { uri: 'log', parameters: { message: 'Hello World' } };
-      const catalogServiceSpy = vi.spyOn(CamelCatalogService, 'getCatalogLookup');
-
-      MultiValuePropertyService.getMultiValueSerializedDefinition('log', definition);
-      expect(catalogServiceSpy).toHaveBeenCalledWith('log');
-    });
-
-    it('should return the serialized definition', () => {
+    it('should return the serialized definition', async () => {
+      const multiValueMap = await MultiValuePropertyService.getMultiValueProperties(CatalogKind.Component, 'quartz');
       const definition = {
         uri: 'quartz',
         parameters: { jobParameters: { test: 'test' }, triggerParameters: { test: 'test' } },
       };
-      const result = MultiValuePropertyService.getMultiValueSerializedDefinition('quartz', definition);
+      const result = MultiValuePropertyService.getMultiValueSerializedDefinition(multiValueMap, definition);
 
       expect(result).toEqual({
         uri: 'quartz',

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.ts
@@ -78,7 +78,9 @@ export class MultiValuePropertyService {
             return;
           }
           Object.keys(definition.parameters[key]).forEach((subKey) => {
-            defaultMultiValues[multiValueParameters.get(key) + subKey] = definition.parameters[key][subKey];
+            if (definition.parameters[key][subKey] !== undefined) {
+              defaultMultiValues[multiValueParameters.get(key) + subKey] = definition.parameters[key][subKey];
+            }
           });
           delete filteredParameters[key];
         } else if (prefixes.some((prefix) => key.startsWith(prefix))) {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValueProperty.service.ts
@@ -1,20 +1,27 @@
 import { isDefined } from '@kaoto/forms';
 
-import { CamelCatalogService, CatalogKind } from '../../../../../../models';
+import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind, ICamelComponentDefinition } from '../../../../../../models';
 import { ParsedParameters } from '../../../../../../utils';
 
 export class MultiValuePropertyService {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static readMultiValue(componentName: string, definition: any) {
-    const catalogLookup = CamelCatalogService.getCatalogLookup(componentName);
+  static async getMultiValueProperties(catalogKind: CatalogKind, componentName: string) {
+    const catalogLookup = (await DynamicCatalogRegistry.get().getEntity(
+      catalogKind,
+      componentName,
+    )) as ICamelComponentDefinition;
 
     const multiValueParameters: Map<string, string> = new Map<string, string>();
-    if (catalogLookup?.definition?.properties !== undefined) {
-      Object.entries(catalogLookup.definition.properties).forEach(([key, value]) => {
+    if (catalogLookup?.properties !== undefined) {
+      Object.entries(catalogLookup.properties).forEach(([key, value]) => {
         if (value.multiValue) multiValueParameters.set(key, value.prefix!);
       });
     }
+    return multiValueParameters;
+  }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static readMultiValue(multiValueParameters: Map<string, string>, definition: any) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let parameters: any = {};
 
@@ -51,42 +58,35 @@ export class MultiValuePropertyService {
     return parameters;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static getMultiValueSerializedDefinition(componentName: string, definition: any): ParsedParameters | undefined {
-    if (!componentName || !isDefined(definition)) {
+  static getMultiValueSerializedDefinition(
+    multiValueParameters: Map<string, string>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    definition: any,
+  ): ParsedParameters | undefined {
+    if (!isDefined(definition)) {
       return definition;
     }
 
-    const catalogLookup = CamelCatalogService.getCatalogLookup(componentName);
-    if (catalogLookup.catalogKind === CatalogKind.Component) {
-      const multiValueParameters: Map<string, string> = new Map<string, string>();
-      if (catalogLookup.definition?.properties !== undefined) {
-        Object.entries(catalogLookup.definition.properties).forEach(([key, value]) => {
-          if (value.multiValue) multiValueParameters.set(key, value.prefix!);
-        });
-      }
-      const defaultMultiValues: ParsedParameters = {};
-      const filteredParameters = { ...definition.parameters };
-      const prefixes = Array.from(multiValueParameters.values());
+    const defaultMultiValues: ParsedParameters = {};
+    const filteredParameters = { ...definition.parameters };
+    const prefixes = Array.from(multiValueParameters.values());
 
-      if (definition.parameters !== undefined) {
-        Object.keys(definition.parameters).forEach((key) => {
-          if (multiValueParameters.has(key)) {
-            if (definition.parameters[key] === undefined) {
-              return;
-            }
-            Object.keys(definition.parameters[key]).forEach((subKey) => {
-              defaultMultiValues[multiValueParameters.get(key) + subKey] = definition.parameters[key][subKey];
-            });
-            delete filteredParameters[key];
-          } else if (prefixes.some((prefix) => key.startsWith(prefix))) {
-            // Remove stale flat keys that match a multi-value prefix
-            delete filteredParameters[key];
+    if (definition.parameters !== undefined) {
+      Object.keys(definition.parameters).forEach((key) => {
+        if (multiValueParameters.has(key)) {
+          if (definition.parameters[key] === undefined) {
+            return;
           }
-        });
-      }
-      return { ...definition, parameters: { ...filteredParameters, ...defaultMultiValues } };
+          Object.keys(definition.parameters[key]).forEach((subKey) => {
+            defaultMultiValues[multiValueParameters.get(key) + subKey] = definition.parameters[key][subKey];
+          });
+          delete filteredParameters[key];
+        } else if (prefixes.some((prefix) => key.startsWith(prefix))) {
+          // Remove stale flat keys that match a multi-value prefix
+          delete filteredParameters[key];
+        }
+      });
     }
-    return definition;
+    return { ...definition, parameters: { ...filteredParameters, ...defaultMultiValues } };
   }
 }

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
@@ -1,83 +1,71 @@
-import { FieldProps, ModelContextProvider, SchemaProvider, setValue, useFieldValue } from '@kaoto/forms';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Suspense } from 'react';
+import {
+  CanvasFormTabsProvider,
+  FormComponentFactoryProvider,
+  ModelContextProvider,
+  SchemaProvider,
+} from '@kaoto/forms';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { FunctionComponent, PropsWithChildren, useState } from 'react';
 import type { Mock } from 'vitest';
 
-import { CatalogKind } from '../../../../../../models/catalog-kind';
+import { CatalogKind, KaotoSchemaDefinition } from '../../../../../../models';
 import { MultiValuePropertyService } from './MultiValueProperty.service';
 import { MultiValuePropertyEditor } from './MultiValuePropertyEditor';
 
-vi.mock('@kaoto/forms', async () => ({
-  ...(await vi.importActual('@kaoto/forms')),
-  ObjectField: (props: FieldProps) => {
-    const { value, onChange, disabled } = useFieldValue(props.propName);
-    return (
-      <div>
-        <div data-testid={`object-field-${props.propName}`}>ObjectField: {props.propName}</div>
-        <div data-testid="model-context-provider-disabled">{String(disabled)}</div>
-        <div data-testid="model-context-provider-model">{JSON.stringify(value)}</div>
-        <button
-          onClick={() => {
-            onChange({ jobParameters: { name: 'updated' } });
-          }}
-        >
-          Trigger property change
-        </button>
-        <button
-          onClick={() => {
-            onChange({ jobParameters: { name: '' } });
-          }}
-        >
-          Delete property
-        </button>
-      </div>
-    );
-  },
-  setValue: vi.fn(),
-}));
+type OnPropertyChange = Mock<(path: string, value: unknown) => void>;
 
-const quartzMultiValueMap = new Map([
-  ['jobParameters', 'job.'],
-  ['triggerParameters', 'trigger.'],
-]);
+/**
+ * Stateful wrapper that mirrors what a real parent component does:
+ * feeds each `onPropertyChange` result back into `ModelContextProvider`
+ * as the new model, so sequential interactions see up-to-date state.
+ * The spy is still called so assertions on `mockOnPropertyChange` work normally.
+ */
+const StatefulWrapper: FunctionComponent<
+  PropsWithChildren<{
+    schema: Record<string, unknown>;
+    initialModel: Record<string, unknown>;
+    onPropertyChange: OnPropertyChange;
+  }>
+> = ({ schema, initialModel, onPropertyChange, children }) => {
+  const [model, setModel] = useState(initialModel);
+
+  const handleChange = (path: string, value: unknown) => {
+    setModel((prev) => ({ ...prev, [path]: value }));
+    onPropertyChange(path, value);
+  };
+
+  return (
+    <CanvasFormTabsProvider tab="All">
+      <FormComponentFactoryProvider>
+        <SchemaProvider schema={schema}>
+          <ModelContextProvider model={model} onPropertyChange={handleChange} disabled={false}>
+            {children}
+          </ModelContextProvider>
+        </SchemaProvider>
+      </FormComponentFactoryProvider>
+    </CanvasFormTabsProvider>
+  );
+};
 
 describe('MultiValuePropertyEditor', () => {
-  const mockOnPropertyChange = vi.fn();
-  const getMultiValuePropertiesSpy = vi.spyOn(MultiValuePropertyService, 'getMultiValueProperties');
-  const readMultiValueSpy = vi.spyOn(MultiValuePropertyService, 'readMultiValue');
-  const getMultiValueSerializedDefinitionSpy = vi.spyOn(MultiValuePropertyService, 'getMultiValueSerializedDefinition');
-
-  const defaultProps: FieldProps = {
-    propName: 'parameters',
-    required: false,
-  };
-
-  const defaultSchema = {
-    'x-component-name': 'quartz',
-    'x-endpoint-catalog-kind': CatalogKind.Component,
-  };
+  let mockOnPropertyChange: OnPropertyChange;
+  let getMultiValuePropertiesSpy: ReturnType<typeof vi.spyOn>;
 
   const renderComponent = async ({
-    schema = defaultSchema,
-    model = { parameters: { 'job.name': 'daily' } },
-    disabled = true,
+    schema = quartzLikeSchema,
+    model = { parameters: {} },
     onPropertyChange = mockOnPropertyChange,
   }: {
-    schema?: Record<string, unknown>;
+    schema?: KaotoSchemaDefinition['schema'];
     model?: Record<string, unknown>;
-    disabled?: boolean;
-    onPropertyChange?: Mock;
+    onPropertyChange?: OnPropertyChange;
   } = {}) => {
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(async () => {
       render(
-        <SchemaProvider schema={schema}>
-          <ModelContextProvider model={model} onPropertyChange={onPropertyChange} disabled={disabled}>
-            <Suspense fallback={<div>Loading...</div>}>
-              <MultiValuePropertyEditor {...defaultProps} />
-            </Suspense>
-          </ModelContextProvider>
-        </SchemaProvider>,
+        <StatefulWrapper schema={schema} initialModel={model} onPropertyChange={onPropertyChange}>
+          <MultiValuePropertyEditor propName="parameters" required={false} />
+        </StatefulWrapper>,
       );
     });
 
@@ -88,83 +76,231 @@ describe('MultiValuePropertyEditor', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    getMultiValuePropertiesSpy.mockResolvedValue(quartzMultiValueMap);
-    readMultiValueSpy.mockReturnValue({ jobParameters: { name: 'daily' } });
-    getMultiValueSerializedDefinitionSpy.mockReturnValue({
-      parameters: { 'job.name': 'updated' },
-    } as unknown as Record<string, string>);
+    mockOnPropertyChange = vi.fn();
+    getMultiValuePropertiesSpy = vi
+      .spyOn(MultiValuePropertyService, 'getMultiValueProperties')
+      .mockResolvedValue(quartzMultiValueMap);
   });
 
-  it('should render the transformed model and disabled state', async () => {
-    await renderComponent();
-
-    expect(getMultiValuePropertiesSpy).toHaveBeenCalledWith(CatalogKind.Component, 'quartz');
-    expect(readMultiValueSpy).toHaveBeenCalledWith(quartzMultiValueMap, { 'job.name': 'daily' });
-    expect(screen.getByTestId('model-context-provider-disabled')).toHaveTextContent('true');
-    expect(screen.getByTestId('model-context-provider-model')).toHaveTextContent(
-      JSON.stringify({ jobParameters: { name: 'daily' } }),
-    );
-    expect(screen.getByTestId('object-field-parameters')).toHaveTextContent('ObjectField: parameters');
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('should serialize property changes and forward flattened parameters', async () => {
-    await renderComponent();
+  it('should serialize two newly added multivalue groups with their correct prefixes', async () => {
+    await renderComponent({ model: { parameters: {} } });
 
-    const triggerPropertyChangeButton = await screen.findByRole('button', { name: 'Trigger property change' });
-    fireEvent.click(triggerPropertyChangeButton);
+    // Add a row to jobParameters and type key=name, value=daily
+    const jobAddButton = await screen.findByTestId('parameters.jobParameters__add');
+    fireEvent.click(jobAddButton);
 
-    expect(setValue).toHaveBeenCalledWith({ parameters: { jobParameters: { name: 'daily' } } }, 'parameters', {
-      jobParameters: { name: 'updated' },
-    });
-    expect(getMultiValueSerializedDefinitionSpy).toHaveBeenCalledWith(quartzMultiValueMap, {
-      parameters: { jobParameters: { name: 'daily' } },
-    });
+    const jobKeyInput = within(await screen.findByTestId('parameters.jobParameters__key')).getByRole('textbox');
+    const jobValueInput = within(await screen.findByTestId('parameters.jobParameters__value')).getByRole('textbox');
+
+    fireEvent.change(jobKeyInput, { target: { value: 'name' } });
+    fireEvent.change(jobValueInput, { target: { value: 'daily' } });
+
     await waitFor(() => {
-      expect(mockOnPropertyChange).toHaveBeenCalledWith('parameters', { 'job.name': 'updated' });
+      expect(mockOnPropertyChange).toHaveBeenCalledWith('parameters', {
+        'job.name': 'daily',
+      });
+    });
+
+    // Add a row to triggerParameters and type key=repeatCount, value=5
+    const triggerAddButton = await screen.findByTestId('parameters.triggerParameters__add');
+    fireEvent.click(triggerAddButton);
+
+    const triggerKeyInput = within(await screen.findByTestId('parameters.triggerParameters__key')).getByRole('textbox');
+    const triggerValueInput = within(await screen.findByTestId('parameters.triggerParameters__value')).getByRole(
+      'textbox',
+    );
+    fireEvent.change(triggerKeyInput, { target: { value: 'repeatCount' } });
+    fireEvent.change(triggerValueInput, { target: { value: '5' } });
+
+    await waitFor(() => {
+      expect(mockOnPropertyChange).toHaveBeenLastCalledWith('parameters', {
+        'job.name': 'daily',
+        'trigger.repeatCount': '5',
+      });
     });
   });
 
-  it('should use undefined catalog metadata when schema extensions are missing', async () => {
+  it('should remove a deleted multivalue entry and reflect an overridden value in the serialized output', async () => {
+    await renderComponent({
+      model: {
+        parameters: {
+          'job.name': 'daily',
+          'job.description': 'desc',
+          'trigger.repeatCount': '3',
+        },
+      },
+    });
+
+    // Remove the description row from jobParameters
+    const removeDescriptionButton = await screen.findByTestId('parameters.jobParameters__remove__description');
+    fireEvent.click(removeDescriptionButton);
+
+    await waitFor(() => {
+      // After removing description: job.description must be absent, trigger still has original '3'
+      expect(mockOnPropertyChange).toHaveBeenNthCalledWith(1, 'parameters', {
+        'job.name': 'daily',
+        'trigger.repeatCount': '3',
+      });
+    });
+
+    // Change triggerParameters.repeatCount from '3' to '10'
+    const triggerValueInput = within(await screen.findByTestId('parameters.triggerParameters__value')).getByRole(
+      'textbox',
+    );
+    fireEvent.change(triggerValueInput, { target: { value: '10' } });
+
+    await waitFor(() => {
+      // After updating repeatCount: job.description stays absent, trigger.repeatCount updated to '10'
+      expect(mockOnPropertyChange).toHaveBeenNthCalledWith(2, 'parameters', {
+        'job.name': 'daily',
+        'trigger.repeatCount': '10',
+      });
+    });
+  });
+
+  it('should correctly serialize both standard and multivalue properties after editing each', async () => {
+    await renderComponent({
+      model: {
+        parameters: {
+          cron: '0 0 * * *',
+          'job.name': 'daily',
+        },
+      },
+    });
+
+    // Change the plain cron field to '0 1 * * *'
+    const cronInput = await screen.findByRole('textbox', { name: 'Cron' });
+    fireEvent.change(cronInput, { target: { value: '0 1 * * *' } });
+
+    await waitFor(() => {
+      expect(mockOnPropertyChange).toHaveBeenLastCalledWith('parameters', {
+        cron: '0 1 * * *',
+        'job.name': 'daily',
+      });
+    });
+
+    // Update jobParameters.name from 'daily' to 'weekly'
+    const jobValueInput = within(await screen.findByTestId('parameters.jobParameters__value')).getByRole('textbox');
+    fireEvent.change(jobValueInput, { target: { value: 'weekly' } });
+
+    await waitFor(() => {
+      expect(mockOnPropertyChange).toHaveBeenLastCalledWith('parameters', {
+        cron: '0 1 * * *',
+        'job.name': 'weekly',
+      });
+    });
+  });
+
+  it('should render without errors when schema catalog extension fields are missing', async () => {
     getMultiValuePropertiesSpy.mockResolvedValue(new Map());
+
     await renderComponent({ schema: {} });
 
     expect(getMultiValuePropertiesSpy).toHaveBeenCalledWith(undefined, undefined);
-    expect(readMultiValueSpy).toHaveBeenCalledWith(expect.any(Map), { 'job.name': 'daily' });
-    expect(readMultiValueSpy.mock.calls[0]?.[0]).toBeInstanceOf(Map);
-    expect(readMultiValueSpy.mock.calls[0]?.[0].size).toBe(0);
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
   });
 
-  it('should not call onPropertyChange when serialized parameters are missing', async () => {
-    getMultiValueSerializedDefinitionSpy.mockReturnValue(undefined);
+  it('should pass standard properties through unmodified when the schema has no catalog extension fields', async () => {
+    await renderComponent({
+      schema: schemaWithoutCatalogExtensions,
+      model: { parameters: { cron: '0 0 * * *' } },
+    });
 
-    await renderComponent();
+    expect(getMultiValuePropertiesSpy).toHaveBeenCalledWith(undefined, undefined);
 
-    const triggerPropertyChangeButton = await screen.findByRole('button', { name: 'Trigger property change' });
-    fireEvent.click(triggerPropertyChangeButton);
+    const cronInput = await screen.findByRole('textbox', { name: 'Cron' });
+    fireEvent.change(cronInput, { target: { value: '0 1 * * *' } });
 
+    await waitFor(() => {
+      expect(mockOnPropertyChange).toHaveBeenLastCalledWith('parameters', { cron: '0 1 * * *' });
+    });
+  });
+
+  it('should not call onPropertyChange when the serialized result is undefined', async () => {
+    vi.spyOn(MultiValuePropertyService, 'getMultiValueSerializedDefinition').mockReturnValue(undefined);
+
+    await renderComponent({ model: { parameters: { cron: '0 0 * * *' } } });
+
+    const cronInput = await screen.findByRole('textbox', { name: 'Cron' });
+    fireEvent.change(cronInput, { target: { value: '0 1 * * *' } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: 'Cron' })).toBeInTheDocument();
+    });
     expect(mockOnPropertyChange).not.toHaveBeenCalled();
   });
 
-  it('should delete property key when value is empty string', async () => {
-    readMultiValueSpy.mockReturnValue({ jobParameters: { name: 'daily' } });
-    getMultiValueSerializedDefinitionSpy.mockReturnValue({
-      parameters: { 'job.description': 'test' },
-    } as unknown as Record<string, string>);
+  it('should treat an empty-string value on a string field as a deletion and omit the key from the serialized output', async () => {
+    await renderComponent({ model: { parameters: { cron: '0 0 * * *', 'job.name': 'daily' } } });
 
-    await renderComponent({
-      model: { parameters: { 'job.name': 'daily', 'job.description': 'test' } },
-    });
-
-    const triggerPropertyChangeButton = await screen.findByRole('button', { name: 'Trigger property change' });
-    fireEvent.click(triggerPropertyChangeButton);
-
-    expect(setValue).toHaveBeenCalledWith({ parameters: { jobParameters: { name: 'daily' } } }, 'parameters', {
-      jobParameters: { name: 'updated' },
-    });
+    const cronInput = await screen.findByRole('textbox', { name: 'Cron' });
+    fireEvent.change(cronInput, { target: { value: '' } });
 
     await waitFor(() => {
-      expect(mockOnPropertyChange).toHaveBeenCalledWith('parameters', { 'job.description': 'test' });
+      const [path, value] = mockOnPropertyChange.mock.lastCall! as [string, Record<string, unknown>];
+      expect(path).toBe('parameters');
+      expect(value['cron']).toBeUndefined();
+      expect(value['job.name']).toBe('daily');
     });
   });
 });
+
+/**
+ * Minimal schema that resembles the quartz component, keeping only the
+ * properties exercised by these tests:
+ *   - cron              → plain string parameter (no prefix)
+ *   - jobParameters     → multivalue object, prefix "job."
+ *                         sub-properties: name, description
+ *   - triggerParameters → multivalue object, prefix "trigger."
+ *                         sub-properties: repeatCount, repeatInterval
+ *
+ * Sub-properties are declared so that ObjectField renders real text inputs
+ * that KaotoFormPageObject can interact with.
+ */
+const quartzLikeSchema: KaotoSchemaDefinition['schema'] = {
+  type: 'object',
+  title: 'Endpoint Properties',
+  properties: {
+    cron: {
+      title: 'Cron',
+      description: 'Specifies a cron expression to define when to trigger.',
+      type: 'string',
+    },
+    jobParameters: {
+      title: 'Job Parameters',
+      description: 'To configure additional options on the job. This is a multi-value option with prefix: job.',
+      type: 'object',
+    },
+    triggerParameters: {
+      title: 'Trigger Parameters',
+      description:
+        'To configure additional options on the trigger. The parameter timeZone is supported if the cron option is present. Otherwise the parameters repeatInterval and repeatCount are supported. Note: When using repeatInterval values of 1000 or less, the first few events after starting the camel context may be fired more rapidly than expected. . This is a multi-value option with prefix: trigger.',
+      type: 'object',
+    },
+  },
+  'x-component-name': 'quartz',
+  'x-endpoint-catalog-kind': CatalogKind.Component,
+};
+
+/** The map that MultiValuePropertyService.getMultiValueProperties() returns for quartz. */
+const quartzMultiValueMap = new Map([
+  ['jobParameters', 'job.'],
+  ['triggerParameters', 'trigger.'],
+]);
+
+/** Same properties as quartzLikeSchema but without catalog extension fields, so getMultiValueProperties receives (undefined, undefined). */
+const schemaWithoutCatalogExtensions: KaotoSchemaDefinition['schema'] = {
+  type: 'object',
+  title: 'Endpoint Properties',
+  properties: {
+    cron: {
+      title: 'Cron',
+      description: 'Specifies a cron expression to define when to trigger.',
+      type: 'string',
+    },
+  },
+};

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
@@ -1,7 +1,9 @@
 import { FieldProps, ModelContextProvider, SchemaProvider, setValue, useFieldValue } from '@kaoto/forms';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Suspense } from 'react';
 import type { Mock } from 'vitest';
 
+import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { MultiValuePropertyService } from './MultiValueProperty.service';
 import { MultiValuePropertyEditor } from './MultiValuePropertyEditor';
 
@@ -34,8 +36,14 @@ vi.mock('@kaoto/forms', async () => ({
   setValue: vi.fn(),
 }));
 
+const quartzMultiValueMap = new Map([
+  ['jobParameters', 'job.'],
+  ['triggerParameters', 'trigger.'],
+]);
+
 describe('MultiValuePropertyEditor', () => {
   const mockOnPropertyChange = vi.fn();
+  const getMultiValuePropertiesSpy = vi.spyOn(MultiValuePropertyService, 'getMultiValueProperties');
   const readMultiValueSpy = vi.spyOn(MultiValuePropertyService, 'readMultiValue');
   const getMultiValueSerializedDefinitionSpy = vi.spyOn(MultiValuePropertyService, 'getMultiValueSerializedDefinition');
 
@@ -44,8 +52,13 @@ describe('MultiValuePropertyEditor', () => {
     required: false,
   };
 
-  const renderComponent = ({
-    schema = { 'x-component-name': 'quartz' },
+  const defaultSchema = {
+    'x-component-name': 'quartz',
+    'x-endpoint-catalog-kind': CatalogKind.Component,
+  };
+
+  const renderComponent = async ({
+    schema = defaultSchema,
     model = { parameters: { 'job.name': 'daily' } },
     disabled = true,
     onPropertyChange = mockOnPropertyChange,
@@ -54,28 +67,40 @@ describe('MultiValuePropertyEditor', () => {
     model?: Record<string, unknown>;
     disabled?: boolean;
     onPropertyChange?: Mock;
-  } = {}) =>
-    render(
-      <SchemaProvider schema={schema}>
-        <ModelContextProvider model={model} onPropertyChange={onPropertyChange} disabled={disabled}>
-          <MultiValuePropertyEditor {...defaultProps} />
-        </ModelContextProvider>
-      </SchemaProvider>,
-    );
+  } = {}) => {
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      render(
+        <SchemaProvider schema={schema}>
+          <ModelContextProvider model={model} onPropertyChange={onPropertyChange} disabled={disabled}>
+            <Suspense fallback={<div>Loading...</div>}>
+              <MultiValuePropertyEditor {...defaultProps} />
+            </Suspense>
+          </ModelContextProvider>
+        </SchemaProvider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
 
+    getMultiValuePropertiesSpy.mockResolvedValue(quartzMultiValueMap);
     readMultiValueSpy.mockReturnValue({ jobParameters: { name: 'daily' } });
     getMultiValueSerializedDefinitionSpy.mockReturnValue({
       parameters: { 'job.name': 'updated' },
     } as unknown as Record<string, string>);
   });
 
-  it('should render the transformed model and disabled state', () => {
-    renderComponent();
+  it('should render the transformed model and disabled state', async () => {
+    await renderComponent();
 
-    expect(readMultiValueSpy).toHaveBeenCalledWith('quartz', { 'job.name': 'daily' });
+    expect(getMultiValuePropertiesSpy).toHaveBeenCalledWith(CatalogKind.Component, 'quartz');
+    expect(readMultiValueSpy).toHaveBeenCalledWith(quartzMultiValueMap, { 'job.name': 'daily' });
     expect(screen.getByTestId('model-context-provider-disabled')).toHaveTextContent('true');
     expect(screen.getByTestId('model-context-provider-model')).toHaveTextContent(
       JSON.stringify({ jobParameters: { name: 'daily' } }),
@@ -83,55 +108,63 @@ describe('MultiValuePropertyEditor', () => {
     expect(screen.getByTestId('object-field-parameters')).toHaveTextContent('ObjectField: parameters');
   });
 
-  it('should serialize property changes and forward flattened parameters', () => {
-    renderComponent();
+  it('should serialize property changes and forward flattened parameters', async () => {
+    await renderComponent();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Trigger property change' }));
+    const triggerPropertyChangeButton = await screen.findByRole('button', { name: 'Trigger property change' });
+    fireEvent.click(triggerPropertyChangeButton);
 
     expect(setValue).toHaveBeenCalledWith({ parameters: { jobParameters: { name: 'daily' } } }, 'parameters', {
       jobParameters: { name: 'updated' },
     });
-    expect(getMultiValueSerializedDefinitionSpy).toHaveBeenCalledWith('quartz', {
+    expect(getMultiValueSerializedDefinitionSpy).toHaveBeenCalledWith(quartzMultiValueMap, {
       parameters: { jobParameters: { name: 'daily' } },
     });
-    expect(mockOnPropertyChange).toHaveBeenCalledWith('parameters', { 'job.name': 'updated' });
+    await waitFor(() => {
+      expect(mockOnPropertyChange).toHaveBeenCalledWith('parameters', { 'job.name': 'updated' });
+    });
   });
 
-  it('should use an empty component name when schema metadata is missing', () => {
-    renderComponent({ schema: {} });
+  it('should use undefined catalog metadata when schema extensions are missing', async () => {
+    getMultiValuePropertiesSpy.mockResolvedValue(new Map());
+    await renderComponent({ schema: {} });
 
-    expect(readMultiValueSpy).toHaveBeenCalledWith('', { 'job.name': 'daily' });
+    expect(getMultiValuePropertiesSpy).toHaveBeenCalledWith(undefined, undefined);
+    expect(readMultiValueSpy).toHaveBeenCalledWith(expect.any(Map), { 'job.name': 'daily' });
+    expect(readMultiValueSpy.mock.calls[0]?.[0]).toBeInstanceOf(Map);
+    expect(readMultiValueSpy.mock.calls[0]?.[0].size).toBe(0);
   });
 
-  it('should not call onPropertyChange when serialized parameters are missing', () => {
+  it('should not call onPropertyChange when serialized parameters are missing', async () => {
     getMultiValueSerializedDefinitionSpy.mockReturnValue(undefined);
 
-    renderComponent();
+    await renderComponent();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Trigger property change' }));
+    const triggerPropertyChangeButton = await screen.findByRole('button', { name: 'Trigger property change' });
+    fireEvent.click(triggerPropertyChangeButton);
 
     expect(mockOnPropertyChange).not.toHaveBeenCalled();
   });
 
-  it('should delete property key when value is empty string', () => {
+  it('should delete property key when value is empty string', async () => {
     readMultiValueSpy.mockReturnValue({ jobParameters: { name: 'daily' } });
     getMultiValueSerializedDefinitionSpy.mockReturnValue({
       parameters: { 'job.description': 'test' },
     } as unknown as Record<string, string>);
 
-    renderComponent({
+    await renderComponent({
       model: { parameters: { 'job.name': 'daily', 'job.description': 'test' } },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Trigger property change' }));
+    const triggerPropertyChangeButton = await screen.findByRole('button', { name: 'Trigger property change' });
+    fireEvent.click(triggerPropertyChangeButton);
 
-    // When jobParameters.name is set to empty string, it should be converted to undefined
-    // which causes setValue to delete the key
     expect(setValue).toHaveBeenCalledWith({ parameters: { jobParameters: { name: 'daily' } } }, 'parameters', {
       jobParameters: { name: 'updated' },
     });
 
-    // The final serialized result should not include the deleted property
-    expect(mockOnPropertyChange).toHaveBeenCalledWith('parameters', { 'job.description': 'test' });
+    await waitFor(() => {
+      expect(mockOnPropertyChange).toHaveBeenCalledWith('parameters', { 'job.description': 'test' });
+    });
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.tsx
@@ -1,20 +1,25 @@
 import { FieldProps, ModelContextProvider, ObjectField, SchemaContext, setValue, useFieldValue } from '@kaoto/forms';
 import { cloneDeep } from 'lodash';
-import { FunctionComponent, use, useContext, useMemo } from 'react';
+import { FunctionComponent, Suspense, use, useContext, useMemo } from 'react';
 
 import { ParsedParameters } from '../../../../../../utils';
+import { Loading } from '../../../../../Loading';
 import { MultiValuePropertyService } from './MultiValueProperty.service';
 
 export const MultiValuePropertyEditor: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema } = useContext(SchemaContext);
+  const catalogKind = schema['x-endpoint-catalog-kind'];
+  const componentName = schema['x-component-name'];
 
   const multiValuePromise = useMemo(() => {
-    const catalogKind = schema['x-endpoint-catalog-kind'];
-    const componentName = schema['x-component-name'];
     return MultiValuePropertyService.getMultiValueProperties(catalogKind, componentName);
-  }, [schema]);
+  }, [catalogKind, componentName]);
 
-  return <MultiValuePropertyEditorInner propName={propName} required={required} promise={multiValuePromise} />;
+  return (
+    <Suspense fallback={<Loading />}>
+      <MultiValuePropertyEditorInner propName={propName} required={required} promise={multiValuePromise} />
+    </Suspense>
+  );
 };
 
 const MultiValuePropertyEditorInner: FunctionComponent<FieldProps & { promise: Promise<Map<string, string>> }> = ({

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.tsx
@@ -1,23 +1,36 @@
 import { FieldProps, ModelContextProvider, ObjectField, SchemaContext, setValue, useFieldValue } from '@kaoto/forms';
 import { cloneDeep } from 'lodash';
-import { FunctionComponent, useContext, useMemo } from 'react';
+import { FunctionComponent, use, useContext, useMemo } from 'react';
 
 import { ParsedParameters } from '../../../../../../utils';
 import { MultiValuePropertyService } from './MultiValueProperty.service';
 
 export const MultiValuePropertyEditor: FunctionComponent<FieldProps> = ({ propName, required }) => {
   const { schema } = useContext(SchemaContext);
+
+  const multiValuePromise = useMemo(() => {
+    const catalogKind = schema['x-endpoint-catalog-kind'];
+    const componentName = schema['x-component-name'];
+    return MultiValuePropertyService.getMultiValueProperties(catalogKind, componentName);
+  }, [schema]);
+
+  return <MultiValuePropertyEditorInner propName={propName} required={required} promise={multiValuePromise} />;
+};
+
+const MultiValuePropertyEditorInner: FunctionComponent<FieldProps & { promise: Promise<Map<string, string>> }> = ({
+  propName,
+  required,
+  promise,
+}) => {
   const { value: flatParameters = {}, onChange, disabled } = useFieldValue<ParsedParameters | undefined>(propName);
 
-  const componentName = useMemo(() => {
-    const name = schema['x-component-name'] as string | undefined;
-    return name || '';
-  }, [schema]);
+  const multiValueProperties = use(promise);
+
   const parametersWithMultivalue = {
-    parameters: MultiValuePropertyService.readMultiValue(componentName, flatParameters),
+    parameters: MultiValuePropertyService.readMultiValue(multiValueProperties, flatParameters),
   };
 
-  const onPropertyChange = (path: string, value: unknown) => {
+  const onPropertyChange = async (path: string, value: unknown) => {
     const updatedDefinition = cloneDeep(parametersWithMultivalue);
 
     let updatedValue = value;
@@ -27,7 +40,7 @@ export const MultiValuePropertyEditor: FunctionComponent<FieldProps> = ({ propNa
     setValue(updatedDefinition, path, updatedValue);
 
     const multiValueParameters = MultiValuePropertyService.getMultiValueSerializedDefinition(
-      componentName,
+      multiValueProperties,
       updatedDefinition,
     );
 

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -109,6 +109,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     schema.properties.parameters.properties = actualComponentProperties;
     schema.properties.parameters.required = camelComponentDefinition.propertiesSchema.required;
     schema.properties.parameters['x-component-name'] = ids.secondaryNodeId.name;
+    schema.properties.parameters['x-endpoint-catalog-kind'] = ids.secondaryNodeId.catalogKind;
 
     /* This would be a Kamelet definition being used by the kamelet component, f.i. `uri: kamelet:weather-action`, in case it's not, we can return the schema so far */
     if (ids.tertiaryNodeId?.catalogKind !== CatalogKind.Kamelet) {


### PR DESCRIPTION
Replace `CamelCatalogService.getCatalogLookup` with `DynamicCatalogRegistry` lookups and pass endpoint catalog kind via `x-endpoint-catalog-kind` on the parameters schema. `MultiValuePropertyEditor` now resolves the nested model asynchronously before rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint property editing when component definitions load asynchronously.
  * Ensured standard endpoint fields render reliably while custom controls remain hidden when appropriate.
  * Improved nested parameter loading and serialization for catalog-specific endpoint definitions.
  * Preserved non-component definitions and correctly handled missing or empty multi-value parameters.
  * Prevented outdated asynchronous results from replacing the latest endpoint property values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->