### PR TITLE
feat: introduce getParsedDefinition and remove legacy sync catalog chain

### DIFF
--- a/packages/ui-tests/cypress/support/next-commands/default.ts
+++ b/packages/ui-tests/cypress/support/next-commands/default.ts
@@ -342,9 +342,9 @@ Cypress.Commands.add('deleteRouteInCanvas', (routeName: string) => {
   cy.openGroupConfigurationTab(routeName);
   cy.get(`button[data-testid="${routeName}|step-toolbar-button-delete-group"]`).click();
   cy.get('body').then(($body) => {
-    if ($body.find('.pf-m-danger').length) {
+    if ($body.find('[data-testid="action-confirmation-modal-btn-confirm"]').length) {
       // Delete Confirmation Modal appeared, click on the confirm button
-      cy.get('.pf-m-danger').click({ force: true });
+      cy.get('[data-testid="action-confirmation-modal-btn-confirm"]').click();
     }
   });
 });

--- a/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { Mock, MockedFunction, vi } from 'vitest';
 
 import { useProcessorTooltips } from '../../hooks/use-processor-tooltips.hook';
@@ -41,6 +41,7 @@ describe('ComponentMode', () => {
     });
     vi.spyOn(node, 'getNodeDefinition').mockReturnValue({});
     vi.spyOn(node, 'updateModel').mockImplementation(vi.fn());
+    (node as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue({});
     return node;
   };
 
@@ -94,6 +95,11 @@ describe('ComponentMode', () => {
     const pollButton = wrapper.getByText('Poll');
     expect(pollButton).toBeInTheDocument();
 
+    // Wait for getParsedDefinition to be called, then flush the resolved promise into React state
+    await waitFor(() => {
+      expect(vizNode.getParsedDefinition as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+
     await act(async () => {
       pollButton.click();
     });
@@ -109,6 +115,11 @@ describe('ComponentMode', () => {
 
     const toDButton = wrapper.getByText('Dynamic');
     expect(toDButton).toBeInTheDocument();
+
+    // Wait for useParsedDefinition to resolve before clicking
+    await waitFor(() => {
+      expect(vizNode.getParsedDefinition as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
 
     await act(async () => {
       toDButton.click();
@@ -126,6 +137,14 @@ describe('ComponentMode', () => {
     const toButton = wrapper.getByText('Static');
     expect(toButton).toBeInTheDocument();
 
+    // Wait for useParsedDefinition to resolve and flush the state update into the closure
+    await waitFor(() => {
+      expect(vizNode.getParsedDefinition as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
     await act(async () => {
       toButton.click();
     });
@@ -141,6 +160,14 @@ describe('ComponentMode', () => {
 
     const toButton = wrapper.getByText('Static');
     expect(toButton).toBeInTheDocument();
+
+    // Wait for useParsedDefinition to resolve and flush the state update into the closure
+    await waitFor(() => {
+      expect(vizNode.getParsedDefinition as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     await act(async () => {
       toButton.click();

--- a/packages/ui/src/components/ComponentMode/ComponentMode.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.tsx
@@ -6,6 +6,7 @@ import { FunctionComponent, useCallback, useState } from 'react';
 
 import { useProcessorTooltips } from '../../hooks/use-processor-tooltips.hook';
 import { useEntityContext } from '../../hooks/useEntityContext/useEntityContext';
+import { useParsedDefinition } from '../../hooks/useParsedDefinition';
 import { IVisualizationNode } from '../../models';
 import { COMPONENT_MODE_PROCESSORS } from '../../models/special-processors.constants';
 import { getProcessorIcon } from '../../utils/processor-icon';
@@ -13,6 +14,7 @@ import { getProcessorIcon } from '../../utils/processor-icon';
 export const ComponentMode: FunctionComponent<{ vizNode?: IVisualizationNode }> = ({ vizNode }) => {
   const { updateSourceCodeFromEntities } = useEntityContext();
   const [processorName, setProcessorName] = useState(vizNode?.data.primaryNodeId?.name);
+  const parsedDefinition = useParsedDefinition(vizNode);
 
   const switchComponentMode = useCallback(
     (newProcessorName: keyof ProcessorDefinition) => {
@@ -20,8 +22,7 @@ export const ComponentMode: FunctionComponent<{ vizNode?: IVisualizationNode }> 
 
       const path = vizNode.data.path;
       const rootEipPath = path?.split('.').slice(0, -1).join('.');
-      const definition = vizNode.getNodeDefinition();
-      if (!definition || !rootEipPath) return;
+      if (!parsedDefinition || !rootEipPath) return;
 
       /**
        * Switch the used EIP for the component, it can go from 'to' to 'toD' or 'poll'
@@ -41,11 +42,11 @@ export const ComponentMode: FunctionComponent<{ vizNode?: IVisualizationNode }> 
           name: newProcessorName,
         },
       };
-      vizNode.updateModel(definition);
+      vizNode.updateModel(parsedDefinition);
       updateSourceCodeFromEntities();
       setProcessorName(newProcessorName);
     },
-    [vizNode, processorName, updateSourceCodeFromEntities],
+    [vizNode, processorName, parsedDefinition, updateSourceCodeFromEntities],
   );
 
   const ToIcon = getProcessorIcon('to');

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
@@ -27,6 +27,7 @@ describe('CanvasSideBar', () => {
     const visualEntity = camelResource.getVisualEntities()[0];
     const node = FlowService.getFlowDiagram('test', await visualEntity.toVizNode()).nodes[0];
     selectedVizNode = node.data!.vizNode!;
+    await selectedVizNode.fetchSchema();
     Provider = (await TestProvidersWrapper({ camelResource })).Provider;
   });
 
@@ -49,6 +50,7 @@ describe('CanvasSideBar', () => {
       </Provider>,
     );
 
+    await wrapper.findByRole('button', { name: 'All' });
     expect(wrapper.asFragment()).toMatchSnapshot();
   });
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasForm.test.tsx
@@ -70,6 +70,7 @@ describe('CanvasForm', () => {
       </Provider>,
     );
 
+    await screen.findAllByRole('button', { name: 'All' });
     expect(container).toMatchSnapshot();
   });
 
@@ -86,7 +87,7 @@ describe('CanvasForm', () => {
       isPlaceholder: false,
     });
 
-    vi.spyOn(noSchemaVizNode, 'getNodeDefinition').mockReturnValue(undefined);
+    (noSchemaVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue(undefined);
 
     const { Provider } = await TestProvidersWrapper();
     const { container } = render(
@@ -113,7 +114,7 @@ describe('CanvasForm', () => {
       isPlaceholder: false,
     });
 
-    vi.spyOn(noSchemaVizNode, 'getNodeDefinition').mockReturnValue(null);
+    (noSchemaVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue(null);
 
     const { Provider } = await TestProvidersWrapper();
     const { container } = render(
@@ -124,6 +125,7 @@ describe('CanvasForm', () => {
       </Provider>,
     );
 
+    await screen.findByText('null');
     expect(container).toMatchSnapshot();
   });
 
@@ -152,7 +154,7 @@ describe('CanvasForm', () => {
       </Provider>,
     );
 
-    const idField = screen.getAllByLabelText('Description', { selector: 'textarea' })[0];
+    const [idField] = await screen.findAllByLabelText('Description', { selector: 'textarea' });
     fireEvent.change(idField, { target: { value: '' } });
 
     const closeSideBarButton = screen.getByTestId('close-side-bar');
@@ -186,7 +188,7 @@ describe('CanvasForm', () => {
       </Provider>,
     );
 
-    const idField = screen.getAllByLabelText('Description', { selector: 'textarea' })[0];
+    const [idField] = await screen.findAllByLabelText('Description', { selector: 'textarea' });
     fireEvent.change(idField, { target: { value: ' ' } });
 
     const closeSideBarButton = screen.getByTestId('close-side-bar');
@@ -221,7 +223,7 @@ describe('CanvasForm', () => {
       </Provider>,
     );
 
-    const idField = screen.getByRole('textbox', { name: 'Id' });
+    const idField = await screen.findByRole('textbox', { name: 'Id' });
     fireEvent.change(idField, { target: { value: newName } });
 
     const closeSideBarButton = screen.getByTestId('close-side-bar');
@@ -253,7 +255,7 @@ describe('CanvasForm', () => {
       </Provider>,
     );
 
-    const NameField = screen.getByDisplayValue('user-source');
+    const NameField = await screen.findByDisplayValue('user-source');
     fireEvent.change(NameField, { target: { value: newName } });
 
     const closeSideBarButton = screen.getByTestId('close-side-bar');

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
@@ -85,6 +85,7 @@ describe('CanvasFormBody', () => {
         </EntitiesContext.Provider>,
       );
 
+      await screen.findByRole('button', { name: 'All' });
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.showAllFields();
       await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
@@ -138,6 +139,7 @@ describe('CanvasFormBody', () => {
         </EntitiesContext.Provider>,
       );
 
+      await screen.findByRole('button', { name: 'All' });
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.showAllFields();
       await formPageObject.inputText('Name', 'bar');
@@ -197,6 +199,7 @@ describe('CanvasFormBody', () => {
         </EntitiesContext.Provider>,
       );
 
+      await screen.findByRole('button', { name: 'All' });
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.showAllFields();
       await formPageObject.toggleOneOfFieldForProperty(ROOT_PATH);
@@ -249,6 +252,7 @@ describe('CanvasFormBody', () => {
         </EntitiesContext.Provider>,
       );
 
+      await screen.findByRole('button', { name: 'All' });
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.showAllFields();
       await formPageObject.inputText('Id', 'modified', { index: 0 });
@@ -306,6 +310,7 @@ describe('CanvasFormBody', () => {
         </EntitiesContext.Provider>,
       );
 
+      await screen.findByRole('button', { name: 'All' });
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.showAllFields();
       await formPageObject.toggleOneOfFieldForProperty(ROOT_PATH);
@@ -362,6 +367,7 @@ describe('CanvasFormBody', () => {
         </EntitiesContext.Provider>,
       );
 
+      await screen.findByRole('button', { name: 'All' });
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.showAllFields();
       await formPageObject.inputText('Id', 'modified', { index: 0 });
@@ -390,7 +396,7 @@ describe('CanvasFormBody', () => {
         },
       },
     };
-    vi.spyOn(vizNode, 'getNodeDefinition').mockReturnValue({ name: 'test-component' });
+    (vizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue({ name: 'test-component' });
 
     const wrapper = render(
       <Provider>
@@ -406,6 +412,7 @@ describe('CanvasFormBody', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
+    await waitFor(() => formPageObject.getFieldByDisplayName('Name'));
     const inputField = formPageObject.getFieldByDisplayName('Name')!;
 
     fireEvent.focus(inputField);

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.tsx
@@ -1,6 +1,7 @@
 import { isDefined, KaotoForm } from '@kaoto/forms';
 import { FunctionComponent, useCallback, useContext, useMemo, useRef } from 'react';
 
+import { useParsedDefinition } from '../../../../hooks/useParsedDefinition';
 import { IVisualizationNode } from '../../../../models';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { setValue } from '../../../../utils';
@@ -21,7 +22,28 @@ export const CanvasFormBody: FunctionComponent<CanvasFormTabsProps> = ({ vizNode
     return !isDefined(schema) || Object.keys(schema).length === 0;
   }, [schema]);
 
-  const model = vizNode.getNodeDefinition();
+  const parsedDefinition = useParsedDefinition(vizNode);
+
+  // Entities that don't implement getParsedDefinition (e.g. Pipe, Test, ErrorHandler,
+  // RestConfiguration) must use the synchronous getNodeDefinition() instead.
+  // Walk to the root node to find the entity, since data.entity is only set on the root node.
+  const rootEntity = useMemo(() => {
+    let node: IVisualizationNode = vizNode;
+    while (node.getPreviousNode() ?? node.getParentNode()) {
+      node = (node.getPreviousNode() ?? node.getParentNode())!;
+    }
+    return node.data.entity;
+  }, [vizNode]);
+  const supportsParsedDefinition =
+    typeof (rootEntity as { getParsedDefinition?: unknown })?.getParsedDefinition === 'function';
+  const model = supportsParsedDefinition ? parsedDefinition : vizNode.getNodeDefinition();
+
+  // Keep a ref to the current model so that handleOnChangeIndividualProp always writes
+  // back to the same (potentially parsed/expanded) object that the form is rendering,
+  // even when the parsedDefinition promise resolved without triggering a re-render
+  // (e.g. when the resolved value is falsy-equivalent to the initial undefined state).
+  const modelRef = useRef(model);
+  modelRef.current = model;
 
   const handleOnChangeIndividualProp = useCallback(
     (path: string, value: unknown) => {
@@ -30,7 +52,7 @@ export const CanvasFormBody: FunctionComponent<CanvasFormTabsProps> = ({ vizNode
         updatedValue = undefined;
       }
 
-      const newModel = vizNode.getNodeDefinition() ?? {};
+      const newModel = modelRef.current ?? vizNode.getNodeDefinition() ?? {};
       setValue(newModel, path, updatedValue);
       vizNode.updateModel(newModel);
       entitiesContext?.updateSourceCodeFromEntities();
@@ -40,6 +62,10 @@ export const CanvasFormBody: FunctionComponent<CanvasFormTabsProps> = ({ vizNode
 
   if (isUnknownComponent) {
     return <UnknownNode model={model} />;
+  }
+
+  if (!model) {
+    return null;
   }
 
   return (

--- a/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/StepToolbar/StepToolbar.tsx
@@ -142,9 +142,13 @@ export const StepToolbar: FunctionComponent<IStepToolbar> = ({
             data-testid={`${label}|step-toolbar-button-enable-all`}
             variant="control"
             title="Enable all"
-            onClick={(event) => {
+            onClick={async (event) => {
               event.stopPropagation();
-              onEnableAllSteps();
+              try {
+                await onEnableAllSteps();
+              } catch (err) {
+                console.error('Failed to enable all steps', err);
+              }
             }}
           />
         )}

--- a/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.test.tsx
@@ -1,5 +1,5 @@
 import { setValue } from '@kaoto/forms';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
@@ -31,7 +31,8 @@ describe('useDisableStep', () => {
       title: '',
       description: '',
     });
-    mockVizNode.getNodeDefinition = vi.fn();
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn();
+    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue({});
     mockVizNode.updateModel = vi.fn();
   });
 
@@ -43,55 +44,68 @@ describe('useDisableStep', () => {
     <EntitiesContext.Provider value={mockEntitiesContext}>{children}</EntitiesContext.Provider>
   );
 
-  it('should return onToggleDisableNode function and isDisabled status', () => {
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue({ disabled: false });
+  it('should return onToggleDisableNode function and isDisabled status', async () => {
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue({ disabled: false });
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
+    await waitFor(() => {
+      expect(result.current.isDisabled).toBe(false);
+    });
     expect(result.current.onToggleDisableNode).toBeDefined();
-    expect(result.current.isDisabled).toBeDefined();
     expect(typeof result.current.onToggleDisableNode).toBe('function');
     expect(typeof result.current.isDisabled).toBe('boolean');
   });
 
-  it('should return isDisabled as false when step is not disabled', () => {
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue({ disabled: false });
+  it('should return isDisabled as false when step is not disabled', async () => {
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue({ disabled: false });
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
-    expect(result.current.isDisabled).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isDisabled).toBe(false);
+    });
   });
 
-  it('should return isDisabled as true when step is disabled', () => {
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue({ disabled: true });
+  it('should return isDisabled as true when step is disabled', async () => {
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue({ disabled: true });
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
-    expect(result.current.isDisabled).toBe(true);
+    await waitFor(() => {
+      expect(result.current.isDisabled).toBe(true);
+    });
   });
 
-  it('should return isDisabled as false when disabled property is undefined', () => {
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue({});
+  it('should return isDisabled as false when disabled property is undefined', async () => {
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue({});
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
-    expect(result.current.isDisabled).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isDisabled).toBe(false);
+    });
   });
 
-  it('should return isDisabled as false when definition is undefined', () => {
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue(undefined);
+  it('should return isDisabled as false when definition is undefined', async () => {
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
-    expect(result.current.isDisabled).toBe(false);
+    await waitFor(() => {
+      expect(result.current.isDisabled).toBe(false);
+    });
   });
 
-  it('should enable step when currently disabled', () => {
+  it('should enable step when currently disabled', async () => {
     const mockDefinition = { disabled: true, id: 'test-step' };
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue(mockDefinition);
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue(mockDefinition);
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
+    await waitFor(() => {
+      expect(result.current.isDisabled).toBe(true);
+    });
     result.current.onToggleDisableNode();
 
     expect(setValue).toHaveBeenCalledWith(mockDefinition, 'disabled', false);
@@ -99,12 +113,15 @@ describe('useDisableStep', () => {
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });
 
-  it('should disable step when currently enabled', () => {
+  it('should disable step when currently enabled', async () => {
     const mockDefinition = { disabled: false, id: 'test-step' };
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue(mockDefinition);
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue(mockDefinition);
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
+    await waitFor(() => {
+      expect(mockVizNode.getParsedDefinition).toHaveBeenCalledTimes(1);
+    });
     result.current.onToggleDisableNode();
 
     expect(setValue).toHaveBeenCalledWith(mockDefinition, 'disabled', true);
@@ -112,12 +129,15 @@ describe('useDisableStep', () => {
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });
 
-  it('should work with empty definition object', () => {
+  it('should work with empty definition object', async () => {
     const mockDefinition = {};
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue(mockDefinition);
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue(mockDefinition);
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
+    await waitFor(() => {
+      expect(result.current.isDisabled).toBe(false);
+    });
     result.current.onToggleDisableNode();
 
     expect(setValue).toHaveBeenCalledWith(mockDefinition, 'disabled', true);
@@ -125,40 +145,39 @@ describe('useDisableStep', () => {
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });
 
-  it('should create new definition object when undefined', () => {
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue(undefined);
+  it('should use node definition as fallback when parsed definition is undefined', async () => {
+    const nodeDefinition = { id: 'test-step', uri: 'direct:start' };
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue(undefined);
+    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue(nodeDefinition);
 
     const { result } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
+    await waitFor(() => {
+      expect(result.current.isDisabled).toBe(false);
+    });
     result.current.onToggleDisableNode();
 
-    expect(setValue).toHaveBeenCalledWith({}, 'disabled', true);
-    expect(mockVizNode.updateModel).toHaveBeenCalledWith({});
+    expect(mockVizNode.getNodeDefinition).toHaveBeenCalled();
+    expect(setValue).toHaveBeenCalledWith(nodeDefinition, 'disabled', true);
+    expect(mockVizNode.updateModel).toHaveBeenCalledWith(nodeDefinition);
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });
 
-  it('should maintain stable reference when dependencies do not change', () => {
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue({ disabled: false });
+  it('should maintain stable reference when dependencies do not change', async () => {
+    (mockVizNode as IVisualizationNode).getParsedDefinition = vi.fn().mockResolvedValue({ disabled: false });
 
     const { result, rerender } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
 
-    const firstResult = result.current;
+    await waitFor(() => {
+      expect(mockVizNode.getParsedDefinition).toHaveBeenCalledTimes(1);
+    });
+    const firstCallback = result.current.onToggleDisableNode;
+    const firstIsDisabled = result.current.isDisabled;
     rerender();
 
-    expect(result.current).toBe(firstResult);
-  });
-
-  it('should update references when disabled status changes', () => {
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue({ disabled: false });
-
-    const { result, rerender } = renderHook(() => useDisableStep(mockVizNode), { wrapper });
-
-    const firstResult = result.current;
-    mockVizNode.getNodeDefinition = vi.fn().mockReturnValue({ disabled: true });
-
-    rerender();
-
-    expect(result.current).not.toBe(firstResult);
-    expect(result.current.isDisabled).toBe(true);
+    // useMemo does not guarantee object identity across renders; assert that
+    // the callback reference and primitive value are stable instead.
+    expect(result.current.onToggleDisableNode).toBe(firstCallback);
+    expect(result.current.isDisabled).toBe(firstIsDisabled);
   });
 });

--- a/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/disable-step.hook.tsx
@@ -1,20 +1,27 @@
 import { setValue } from '@kaoto/forms';
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 
+import { useParsedDefinition } from '../../../../hooks/useParsedDefinition';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 
 export const useDisableStep = (vizNode: IVisualizationNode) => {
   const entitiesContext = useContext(EntitiesContext);
-  const isDisabled = !!vizNode.getNodeDefinition()?.disabled;
+  const parsedDefinition = useParsedDefinition(vizNode);
+  const isDisabled = !!parsedDefinition?.disabled;
+
+  const parsedDefinitionRef = useRef(parsedDefinition);
+  parsedDefinitionRef.current = parsedDefinition;
+
+  const isDisabledRef = useRef(isDisabled);
+  isDisabledRef.current = isDisabled;
 
   const onToggleDisableNode = useCallback(() => {
-    const newModel = vizNode.getNodeDefinition() || {};
-    setValue(newModel, 'disabled', !isDisabled);
+    const newModel = parsedDefinitionRef.current ?? vizNode.getNodeDefinition();
+    setValue(newModel, 'disabled', !isDisabledRef.current);
     vizNode.updateModel(newModel);
-
     entitiesContext?.updateEntitiesFromCamelResource();
-  }, [entitiesContext, isDisabled, vizNode]);
+  }, [entitiesContext, vizNode]);
 
   const value = useMemo(
     () => ({

--- a/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.test.tsx
@@ -1,5 +1,5 @@
 import { ElementModel, Node } from '@patternfly/react-topology';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
@@ -177,7 +177,9 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    result.current.onEnableAllSteps();
+    await act(async () => {
+      await result.current.onEnableAllSteps();
+    });
 
     expect(mockSetValue).toHaveBeenCalledTimes(2);
     expect(mockSetValue).toHaveBeenCalledWith(mockDefinition1, 'disabled', false);
@@ -204,7 +206,9 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    result.current.onEnableAllSteps();
+    await act(async () => {
+      await result.current.onEnableAllSteps();
+    });
 
     expect(mockSetValue).toHaveBeenCalledWith(mockDefinition, 'disabled', false);
     expect(disabledNode.updateModel).toHaveBeenCalledWith(mockDefinition);
@@ -227,7 +231,9 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    result.current.onEnableAllSteps();
+    await act(async () => {
+      await result.current.onEnableAllSteps();
+    });
 
     expect(mockSetValue).toHaveBeenCalledWith({}, 'disabled', false);
     expect(disabledNode.updateModel).toHaveBeenCalledWith({});
@@ -239,7 +245,7 @@ describe('useEnableAllSteps', () => {
 
     const { result } = renderHook(() => useEnableAllSteps(), { wrapper });
 
-    result.current.onEnableAllSteps();
+    void result.current.onEnableAllSteps();
 
     expect(mockEntitiesContext.updateEntitiesFromCamelResource).toHaveBeenCalled();
   });

--- a/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/enable-all-steps.hook.tsx
@@ -15,13 +15,16 @@ export const useEnableAllSteps = () => {
   }, [controller]);
   const areMultipleStepsDisabled = disabledNodes.length > 1;
 
-  const onEnableAllSteps = useCallback(() => {
-    disabledNodes.forEach((node) => {
-      const newModel = node.getNodeDefinition() || {};
-      setValue(newModel, 'disabled', false);
-      node.updateModel(newModel);
-    });
-
+  const onEnableAllSteps = useCallback(async () => {
+    if (disabledNodes.length > 0) {
+      const models = await Promise.all(
+        disabledNodes.map(async (node) => (await node.getParsedDefinition()) ?? node.getNodeDefinition() ?? {}),
+      );
+      models.forEach((newModel, index) => {
+        setValue(newModel as Record<string, unknown>, 'disabled', false);
+        disabledNodes[index].updateModel(newModel);
+      });
+    }
     entitiesContext?.updateEntitiesFromCamelResource();
   }, [disabledNodes, entitiesContext]);
 

--- a/packages/ui/src/components/Visualization/Topology/topology-endpoints.ts
+++ b/packages/ui/src/components/Visualization/Topology/topology-endpoints.ts
@@ -39,7 +39,7 @@ const appendMapValue = (map: Map<string, string[]>, key: string, value: string):
 
 const recordTopologyStep = async (vizNode: IVisualizationNode, registry: TopologyEndpointRegistry): Promise<void> => {
   const processorName = vizNode.data.primaryNodeId?.name;
-  const nodeDefinition = vizNode.getNodeDefinition();
+  const nodeDefinition = await vizNode.getParsedDefinition?.();
   const uriString = CamelUriHelper.getUriString(nodeDefinition);
 
   if (!uriString) {

--- a/packages/ui/src/hooks/useParsedDefinition.test.ts
+++ b/packages/ui/src/hooks/useParsedDefinition.test.ts
@@ -1,0 +1,76 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { IVisualizationNode } from '../models/visualization/base-visual-entity';
+import { useParsedDefinition } from './useParsedDefinition';
+
+describe('useParsedDefinition', () => {
+  it('should return undefined initially before the promise resolves', () => {
+    const mockVizNode = {
+      data: { schema: undefined },
+      getParsedDefinition: vi.fn().mockReturnValue(new Promise(() => {})), // never resolves
+    } as unknown as IVisualizationNode;
+
+    const { result } = renderHook(() => useParsedDefinition(mockVizNode));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should call getParsedDefinition even when schema is not available', async () => {
+    const parsed = { uri: 'timer', parameters: {} };
+    const mockVizNode = {
+      data: { schema: undefined },
+      getParsedDefinition: vi.fn().mockResolvedValue(parsed),
+    } as unknown as IVisualizationNode;
+
+    const { result } = renderHook(() => useParsedDefinition(mockVizNode));
+    await waitFor(() => {
+      expect(result.current).toEqual(parsed);
+    });
+    expect(mockVizNode.getParsedDefinition).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return the parsed definition after resolution', async () => {
+    const parsed = { uri: 'timer', parameters: { timerName: 'tick' } };
+    const mockVizNode = {
+      data: { schema: {} },
+      getParsedDefinition: vi.fn().mockResolvedValue(parsed),
+    } as unknown as IVisualizationNode;
+
+    const { result } = renderHook(() => useParsedDefinition(mockVizNode));
+    await waitFor(() => {
+      expect(result.current).toEqual(parsed);
+    });
+  });
+
+  it('should return undefined when vizNode is undefined', () => {
+    const { result } = renderHook(() => useParsedDefinition(undefined));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should re-fetch when vizNode changes', async () => {
+    const firstParsed = { uri: 'timer', parameters: {} };
+    const secondParsed = { uri: 'log', parameters: {} };
+
+    const firstVizNode = {
+      data: { schema: {} },
+      getParsedDefinition: vi.fn().mockResolvedValue(firstParsed),
+    } as unknown as IVisualizationNode;
+
+    const secondVizNode = {
+      data: { schema: {} },
+      getParsedDefinition: vi.fn().mockResolvedValue(secondParsed),
+    } as unknown as IVisualizationNode;
+
+    const { result, rerender } = renderHook(({ vn }) => useParsedDefinition(vn), {
+      initialProps: { vn: firstVizNode },
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual(firstParsed);
+    });
+
+    rerender({ vn: secondVizNode });
+    await waitFor(() => {
+      expect(result.current).toEqual(secondParsed);
+    });
+  });
+});

--- a/packages/ui/src/hooks/useParsedDefinition.ts
+++ b/packages/ui/src/hooks/useParsedDefinition.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+import { IVisualizationNode } from '../models/visualization/base-visual-entity';
+
+export function useParsedDefinition(vizNode: IVisualizationNode): Record<string, unknown> | undefined;
+export function useParsedDefinition(vizNode: IVisualizationNode | undefined): unknown;
+export function useParsedDefinition(vizNode: IVisualizationNode | undefined): unknown {
+  const [parsedDefinition, setParsedDefinition] = useState<unknown>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    setParsedDefinition(undefined);
+
+    if (!vizNode) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void vizNode.getParsedDefinition().then((def) => {
+      if (!cancelled) setParsedDefinition(def);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [vizNode]);
+
+  return parsedDefinition;
+}

--- a/packages/ui/src/models/camel/parsers/uri-definition.parser.test.ts
+++ b/packages/ui/src/models/camel/parsers/uri-definition.parser.test.ts
@@ -1,0 +1,70 @@
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { DynamicCatalog } from '../../../dynamic-catalog/dynamic-catalog';
+import { CamelComponentsProvider } from '../../../dynamic-catalog/providers/camel-components.provider';
+import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { CatalogKind } from '../../catalog-kind';
+import { ICamelComponentDefinition } from '../camel-components-catalog';
+import { uriDefinitionParser } from './uri-definition.parser';
+
+describe('uriDefinitionParser', () => {
+  beforeEach(async () => {
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    const componentCatalog = new DynamicCatalog<ICamelComponentDefinition>(
+      new CamelComponentsProvider(catalogsMap.componentCatalogMap),
+    );
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Component, componentCatalog);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    DynamicCatalogRegistry.get().clearRegistry();
+  });
+
+  it('should split path and query params for a known component', async () => {
+    const result = await uriDefinitionParser('log', { uri: 'log:myLogger?level=INFO', parameters: {} });
+    expect(result).toMatchObject({ uri: 'log', parameters: { loggerName: 'myLogger', level: 'INFO' } });
+  });
+
+  it('should handle a kamelet URI', async () => {
+    const result = await uriDefinitionParser('kamelet:beer-source', {
+      uri: 'kamelet:beer-source?foo=bar',
+      parameters: {},
+    });
+    expect(result).toMatchObject({ uri: 'kamelet:beer-source', parameters: { foo: 'bar' } });
+  });
+
+  it('should return definition with empty parameters for an unknown component with no query string', async () => {
+    const result = await uriDefinitionParser('non-existing', { uri: 'non-existing:thing' });
+    expect(result).toEqual({ uri: 'non-existing:thing', parameters: {} });
+  });
+
+  it('should extract query parameters for an unknown component with a query string', async () => {
+    const result = await uriDefinitionParser('non-existing', { uri: 'non-existing:thing?foo=bar' });
+    expect(result).toEqual({ uri: 'non-existing:thing', parameters: { foo: 'bar' } });
+  });
+
+  it('should ensure parameters exists for a kamelet URI with no query string', async () => {
+    const result = await uriDefinitionParser('kamelet:log-sink', { uri: 'kamelet:log-sink' });
+    expect(result).toEqual({ uri: 'kamelet:log-sink', parameters: {} });
+  });
+
+  it('should return definition unchanged when uri is empty', async () => {
+    const definition = { uri: '', parameters: {} };
+    const result = await uriDefinitionParser('log', definition);
+    expect(result).toEqual(definition);
+  });
+
+  it('should preserve existing parameters and merge new ones', async () => {
+    const result = await uriDefinitionParser('log', {
+      uri: 'log:myLogger',
+      parameters: { level: 'DEBUG' },
+    });
+    expect(result).toMatchObject({
+      uri: 'log',
+      parameters: expect.objectContaining({ level: 'DEBUG', loggerName: 'myLogger' }),
+    });
+  });
+});

--- a/packages/ui/src/models/camel/parsers/uri-definition.parser.ts
+++ b/packages/ui/src/models/camel/parsers/uri-definition.parser.ts
@@ -1,0 +1,43 @@
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog';
+import { CamelUriHelper } from '../../../utils/camel-uri-helper';
+import { CatalogKind } from '../../catalog-kind';
+
+export const uriDefinitionParser = async (
+  componentName: string,
+  definition: Record<string, unknown>,
+): Promise<Record<string, unknown>> => {
+  const fullUri = definition.uri as string | undefined;
+  if (!fullUri) return definition;
+
+  const [pathPortion, queryStringPortion] = fullUri.split('?');
+
+  const componentDefinition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, componentName);
+  if (!componentDefinition) {
+    // For unknown components (e.g. kamelet:log-sink which isn't a plain Component catalog entry),
+    // still ensure parameters exists and extract any query parameters from the URI
+    const queryParameters = queryStringPortion ? CamelUriHelper.getParametersFromQueryString(queryStringPortion) : {};
+    return {
+      ...definition,
+      uri: pathPortion,
+      parameters: {
+        ...(definition.parameters as Record<string, unknown>),
+        ...queryParameters,
+      },
+    };
+  }
+
+  const pathParameters = CamelUriHelper.getParametersFromPathString(componentDefinition.component.syntax, pathPortion, {
+    requiredParameters: componentDefinition.propertiesSchema.required as string[],
+  });
+  const queryParameters = CamelUriHelper.getParametersFromQueryString(queryStringPortion);
+
+  return {
+    ...definition,
+    uri: componentName,
+    parameters: {
+      ...(definition.parameters as Record<string, unknown>),
+      ...pathParameters,
+      ...queryParameters,
+    },
+  };
+};

--- a/packages/ui/src/models/visualization/base-visual-entity.ts
+++ b/packages/ui/src/models/visualization/base-visual-entity.ts
@@ -139,6 +139,9 @@ export interface IVisualizationNode<T extends IVisualizationNodeData = IVisualiz
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getNodeDefinition(): any;
 
+  /** This method returns the node's parsed definition, with URI fields split into component properties */
+  getParsedDefinition(): Promise<unknown>;
+
   /** Return fields that should be omitted when configuring this entity */
   getOmitFormFields(): string[];
 

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.test.ts
@@ -13,7 +13,6 @@ import { NodeLabelType } from '../../settings';
 import { AddStepMode, IVisualizationNodeData } from '../base-visual-entity';
 import { CamelCatalogService } from './camel-catalog.service';
 import { CamelRouteVisualEntity } from './camel-route-visual-entity';
-import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
 describe('AbstractCamelVisualEntity', () => {
   let abstractVisualEntity: CamelRouteVisualEntity;
@@ -180,11 +179,12 @@ describe('AbstractCamelVisualEntity', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should return updated node definition when path is valid', () => {
+    it('should return raw node definition when path is valid', () => {
       const path = 'route.from.steps.2.to';
+      // getNodeDefinition returns raw — URI is not split
       const definition = {
-        uri: 'direct',
-        parameters: { name: 'my-route', bridgeErrorHandler: true },
+        uri: 'direct:my-route',
+        parameters: { bridgeErrorHandler: true },
       };
 
       const result = abstractVisualEntity.getNodeDefinition(path, toStepIds);
@@ -217,18 +217,68 @@ describe('AbstractCamelVisualEntity', () => {
       });
     });
 
-    it('should pass the kamelet component name to getUpdatedDefinition', () => {
+    it('should return raw definition for a kamelet from node (no URI split)', () => {
       const entity = new CamelRouteVisualEntity(cloneDeep(camelRouteWithKameletJson));
-      const getUpdatedDefinitionSpy = vi.spyOn(CamelComponentSchemaService, 'getUpdatedDefinition');
       const kameletFromIds = {
         primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
         secondaryNodeId: { name: 'kamelet', catalogKind: CatalogKind.Component },
         tertiaryNodeId: { name: 'avro-deserialize-action', catalogKind: CatalogKind.Kamelet },
       };
 
-      entity.getNodeDefinition('route.from', kameletFromIds);
+      const result = entity.getNodeDefinition('route.from', kameletFromIds);
 
-      expect(getUpdatedDefinitionSpy).toHaveBeenCalledWith(kameletFromIds, camelRouteWithKameletJson.route.from);
+      // getNodeDefinition returns raw form — no URI split here, that's getParsedDefinition's job
+      expect(result).toEqual(camelRouteWithKameletJson.route.from);
+    });
+
+    it('should apply string coercion for a string-valued processor', () => {
+      const entity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson));
+      const logIds = {
+        primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
+      };
+      // Temporarily set steps[0] to a string-valued log processor
+      (entity.entityDef.route.from.steps as unknown as Record<string, unknown>[])[0] = { log: '${body}' };
+
+      const result = entity.getNodeDefinition('route.from.steps.0.log', logIds);
+      expect(result).toEqual({ message: '${body}' });
+    });
+
+    it('should return the string value without throwing when the definition is a string primitive for an unknown processor', () => {
+      const entity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson));
+      const unknownIds = {
+        primaryNodeId: { name: 'id', catalogKind: CatalogKind.Pattern },
+      };
+      // Simulates the malformed step `- id: setBody-3518` in unknownNode.yaml
+      (entity.entityDef.route.from.steps as unknown as Record<string, unknown>[])[0] = { id: 'setBody-3518' };
+
+      expect(() => entity.getNodeDefinition('route.from.steps.0.id', unknownIds)).not.toThrow();
+      expect(entity.getNodeDefinition('route.from.steps.0.id', unknownIds)).toBe('setBody-3518');
+    });
+  });
+
+  describe('getParsedDefinition', () => {
+    it('should return raw definition for a processor node with no secondaryNodeId', async () => {
+      // Use a route entity with a setHeader step — setHeader is a processor, not a component
+      const entity = new CamelRouteVisualEntity(cloneDeep(camelRouteJson));
+      const ids = {
+        primaryNodeId: { name: 'setHeader', catalogKind: CatalogKind.Pattern },
+      };
+      const result = await entity.getParsedDefinition('route.from.steps.0.setHeader', ids);
+      // No secondaryNodeId => no componentName => returns raw form unchanged
+      expect(result).toEqual(entity.getNodeDefinition('route.from.steps.0.setHeader', ids));
+    });
+
+    it('should split URI for a component node with secondaryNodeId', async () => {
+      const routeWithUri = { route: { from: { uri: 'timer:tick?period=1000', steps: [] } } };
+      const entity = new CamelRouteVisualEntity(cloneDeep(routeWithUri));
+      const ids = {
+        primaryNodeId: { name: 'from', catalogKind: CatalogKind.Pattern },
+        secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
+      };
+      const result = (await entity.getParsedDefinition('route.from', ids)) as Record<string, unknown>;
+      expect(result.uri).toBe('timer');
+      expect((result.parameters as Record<string, unknown>).timerName).toBe('tick');
+      expect((result.parameters as Record<string, unknown>).period).toBe(1000);
     });
   });
 
@@ -254,9 +304,8 @@ describe('AbstractCamelVisualEntity', () => {
       abstractVisualEntity.updateModel('route.from.steps.2.to.parameters', parameters);
 
       expect(abstractVisualEntity.getNodeDefinition('route.from.steps.2.to', toStepIds)).toEqual({
-        uri: 'direct',
+        uri: 'direct:my-route',
         parameters: {
-          name: 'my-route',
           ...parameters,
         },
       });

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -5,6 +5,7 @@ import { cloneDeep } from 'lodash';
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { getArrayProperty, getValue, setValue } from '../../../utils';
 import { DefinedComponent } from '../../camel/camel-catalog-index';
+import { uriDefinitionParser } from '../../camel/parsers/uri-definition.parser';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
@@ -133,15 +134,43 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
   getNodeDefinition(path?: string, ids?: IVisualizationNodeIds): unknown {
     if (!path) return undefined;
 
-    const definition = getValue(this.entityDef, path);
-    const updatedDefinition = CamelComponentSchemaService.getUpdatedDefinition(ids, definition);
+    let definition = cloneDeep(getValue(this.entityDef, path));
 
-    /** Overriding parameters with an empty object When the parameters property is mistakenly set to null */
-    if (updatedDefinition?.parameters === null) {
-      updatedDefinition.parameters = {};
+    // String coercion: some processors store their value as a plain string
+    const processorName = ids?.primaryNodeId?.name;
+    if (processorName !== undefined) {
+      const prop = CamelComponentSchemaService.PROCESSOR_STRING_DEFINITIONS[processorName];
+      if (prop && typeof definition === 'string') {
+        definition = { [prop]: definition };
+      }
     }
 
-    return updatedDefinition;
+    // Overriding parameters with an empty object when mistakenly set to null or undefined.
+    // Guard with typeof check: the `in` operator throws a TypeError on string primitives.
+    if (
+      definition != null &&
+      typeof definition === 'object' &&
+      'parameters' in (definition as object) &&
+      (definition as Record<string, unknown>).parameters == null
+    ) {
+      (definition as Record<string, unknown>).parameters = {};
+    }
+
+    return definition;
+  }
+
+  async getParsedDefinition(path?: string, ids?: IVisualizationNodeIds): Promise<unknown> {
+    const definition = this.getNodeDefinition(path, ids);
+    if (definition == null) return definition;
+
+    const componentName =
+      ids?.secondaryNodeId?.name === 'kamelet' && ids?.tertiaryNodeId?.name !== undefined
+        ? `kamelet:${ids.tertiaryNodeId.name}`
+        : ids?.secondaryNodeId?.name;
+
+    if (!componentName) return definition;
+
+    return uriDefinitionParser(componentName, definition as Record<string, unknown>);
   }
 
   getOmitFormFields(): string[] {

--- a/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-route-visual-entity.test.ts
@@ -11,7 +11,6 @@ import { EntityType } from '../../entities/base-entity';
 import { NodeLabelType } from '../../settings/settings.model';
 import { IVisualizationNode } from '../base-visual-entity';
 import { CamelRouteVisualEntity } from './camel-route-visual-entity';
-import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 
 describe('Camel Route', () => {
   let camelEntity: CamelRouteVisualEntity;
@@ -108,14 +107,12 @@ describe('Camel Route', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should return the updated definition for a valid path', () => {
-      const getUpdatedDefinitionSpy = vi.spyOn(CamelComponentSchemaService, 'getUpdatedDefinition');
-
+    it('should return the raw definition for a valid path', () => {
       const result = camelEntity.getNodeDefinition('route.from.steps.2.to', toStepIds);
 
-      expect(getUpdatedDefinitionSpy).toHaveBeenCalledWith(toStepIds, camelRouteJson.route.from.steps[2].to);
+      // getNodeDefinition returns raw form — URI is not split here
       expect(result).toEqual({
-        uri: 'direct',
+        uri: 'direct:my-route',
         parameters: {
           bridgeErrorHandler: true,
         },
@@ -123,33 +120,26 @@ describe('Camel Route', () => {
     });
 
     it('should override null parameters with an empty object', () => {
-      const getUpdatedDefinitionSpy = vi.spyOn(CamelComponentSchemaService, 'getUpdatedDefinition');
-      const mockDefinition = { uri: 'timer', parameters: null };
-      getUpdatedDefinitionSpy.mockReturnValueOnce(mockDefinition);
+      const clonedRoute = cloneDeep(camelRouteJson);
+      (clonedRoute.route.from as unknown as Record<string, unknown>).parameters = null;
+      const entity = new CamelRouteVisualEntity(clonedRoute);
 
-      const result = camelEntity.getNodeDefinition('route.from', fromStepIds);
+      const result = entity.getNodeDefinition('route.from', fromStepIds);
 
-      expect(result).toEqual({ uri: 'timer', parameters: {} });
+      expect((result as Record<string, unknown>).parameters).toEqual({});
     });
 
     it('should handle nested step definitions', () => {
-      const getUpdatedDefinitionSpy = vi.spyOn(CamelComponentSchemaService, 'getUpdatedDefinition');
-      const mockDefinition = { message: 'We got a one.', id: 'log-1' };
-      getUpdatedDefinitionSpy.mockReturnValueOnce(mockDefinition);
+      const result = camelEntity.getNodeDefinition('route.from.steps.1.choice.when.0.steps.0.log', logStepIds);
 
-      camelEntity.getNodeDefinition('route.from.steps.1.choice.when.0.steps.0.log', logStepIds);
-
-      expect(getUpdatedDefinitionSpy).toHaveBeenCalledWith(logStepIds, { message: 'We got a one.', id: 'log-1' });
+      expect(result).toEqual({ message: 'We got a one.', id: 'log-1' });
     });
 
-    it('should preserve original definition when parameters is undefined', () => {
-      const spy = vi.spyOn(CamelComponentSchemaService, 'getUpdatedDefinition');
-      const mockDefinition = { uri: 'direct' };
-      spy.mockReturnValueOnce(mockDefinition);
-
+    it('should return raw definition when parameters is present', () => {
       const result = camelEntity.getNodeDefinition('route.from.steps.2.to', toStepIds);
 
-      expect(result).toEqual({ uri: 'direct' });
+      // getNodeDefinition returns raw — uri is 'direct:my-route' not split
+      expect(result).toMatchObject({ uri: 'direct:my-route' });
     });
   });
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -4,7 +4,6 @@ import { CatalogLibrary, ProcessorDefinition } from '@kaoto/camel-catalog/types'
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
-import { IVisualizationNodeIds } from '../../base-visual-entity';
 import { IClipboardContent } from '../../clipboard';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { CamelComponentSchemaService } from './camel-component-schema.service';
@@ -26,124 +25,6 @@ describe('CamelComponentSchemaService', () => {
 
   afterAll(() => {
     CamelCatalogService.clearCatalogs();
-  });
-
-  describe('getUpdatedDefinition', () => {
-    const textBasedProcessors: [IVisualizationNodeIds, string, object][] = [
-      [
-        {
-          primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
-          secondaryNodeId: { name: 'bean', catalogKind: CatalogKind.Component },
-        },
-        'bean:myBean?method=hello',
-        {
-          uri: 'bean',
-          parameters: {
-            beanName: 'myBean',
-            method: 'hello',
-          },
-        },
-      ],
-      [
-        {
-          primaryNodeId: { name: 'toD', catalogKind: CatalogKind.Pattern },
-          secondaryNodeId: { name: 'bean', catalogKind: CatalogKind.Component },
-        },
-        'bean:myBean?method=hello',
-        {
-          uri: 'bean',
-          parameters: {
-            beanName: 'myBean',
-            method: 'hello',
-          },
-        },
-      ],
-      [
-        {
-          primaryNodeId: { name: 'log', catalogKind: CatalogKind.Pattern },
-        },
-        '${body}',
-        {
-          message: '${body}',
-        },
-      ],
-    ];
-
-    it.each(textBasedProcessors)('should transform string-based processors', (ids, definition, expectedResult) => {
-      const result = CamelComponentSchemaService.getUpdatedDefinition(ids, definition);
-
-      expect(result).toMatchObject(expectedResult);
-    });
-
-    it(`should clone the component's definition`, () => {
-      const toLogDefinition = {
-        id: 'to-3044',
-        uri: 'log',
-        parameters: {
-          groupActiveOnly: true,
-          logMask: true,
-          level: 'ERROR',
-        },
-      };
-
-      const result = CamelComponentSchemaService.getUpdatedDefinition(
-        {
-          primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
-          secondaryNodeId: { name: 'log', catalogKind: CatalogKind.Component },
-        },
-        toLogDefinition,
-      );
-
-      expect(result).not.toBe(toLogDefinition);
-      expect(result).toEqual(toLogDefinition);
-    });
-
-    it(`should not apply missing syntax's path segments`, () => {
-      const toLogDefinition = {
-        uri: 'timer',
-      };
-
-      const result = CamelComponentSchemaService.getUpdatedDefinition(
-        {
-          primaryNodeId: { name: 'from', catalogKind: CatalogKind.Entity },
-          secondaryNodeId: { name: 'timer', catalogKind: CatalogKind.Component },
-        },
-        toLogDefinition,
-      );
-
-      expect(result.uri).toBe('timer');
-      expect(result.parameters).toEqual({});
-    });
-
-    it('should not build a schema for an unknown component', () => {
-      const camelCatalogServiceSpy = vi.spyOn(CamelCatalogService, 'getComponent');
-      const toNonExistingDefinition = {
-        id: 'to-3044',
-        uri: 'non-existing-component',
-        parameters: {
-          level: 'ERROR',
-        },
-      };
-
-      const result = CamelComponentSchemaService.getUpdatedDefinition(
-        {
-          primaryNodeId: { name: 'to', catalogKind: CatalogKind.Pattern },
-          secondaryNodeId: { name: 'non-existing-component', catalogKind: CatalogKind.Component },
-        },
-        toNonExistingDefinition,
-      );
-
-      expect(camelCatalogServiceSpy).toHaveBeenCalledTimes(1);
-      expect(camelCatalogServiceSpy).toHaveBeenNthCalledWith(1, CatalogKind.Component, 'non-existing-component');
-      expect(camelCatalogServiceSpy).toHaveBeenNthCalledWith(1, CatalogKind.Component, 'non-existing-component');
-      expect(result).toEqual({
-        id: 'to-3044',
-        parameters: {
-          level: 'ERROR',
-        },
-        uri: 'non-existing-component',
-      });
-    });
   });
 
   describe('canHavePreviousStep', () => {
@@ -264,19 +145,6 @@ describe('CamelComponentSchemaService', () => {
         expect(stepsProperties).toEqual(result);
       },
     );
-  });
-
-  describe('getComponentNameFromUri', () => {
-    it.each([
-      ['', undefined],
-      ['kamelet:beer-source', 'kamelet:beer-source'],
-      ['kamelet:beer-source?foo=bar', 'kamelet:beer-source'],
-      ['timer:foo?delay=1000&period=1000', 'timer'],
-      ['timer', 'timer'],
-    ] as [string, string | undefined][])(`should return the component name from '%s'`, (uri, expected) => {
-      const componentName = CamelComponentSchemaService.getComponentNameFromUri(uri);
-      expect(componentName).toBe(expected);
-    });
   });
 
   describe('getNodeDefinitionValue', () => {

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -1,10 +1,8 @@
 import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
-import { cloneDeep } from 'lodash';
 
-import { CamelUriHelper, DATAMAPPER_ID_PREFIX } from '../../../../utils';
+import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
 import { REST_DSL_VERBS } from '../../../special-processors.constants';
-import { IVisualizationNodeIds } from '../../base-visual-entity';
 import { IClipboardContent } from '../../clipboard';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { CamelProcessorStepsProperties } from './camel-component-types';
@@ -142,27 +140,6 @@ export class CamelComponentSchemaService {
   }
 
   /**
-   * Extract the component name from the endpoint uri
-   * An URI is composed by a component name and query parameters, separated by a colon
-   * For instance:
-   *    - `log:MyLogger`
-   *    - `timer:tick?period=1000`
-   *    - `file:inbox?fileName=orders.txt&noop=true`
-   *    - `kamelet:kafka-not-secured-sink?topic=foobar&bootstrapServers=localhost`
-   */
-  static getComponentNameFromUri(uri: string): string | undefined {
-    if (!uri) {
-      return undefined;
-    }
-    const uriParts = uri.split(':');
-    if (uriParts[0] === 'kamelet' && uriParts.length > 1) {
-      const kameletName = uriParts[1].split('?')[0];
-      return uriParts[0] + ':' + kameletName;
-    }
-    return uriParts[0];
-  }
-
-  /**
    * Get the definition for a given component and property
    */
   static getNodeDefinitionValue(clipboardContent: IClipboardContent): ProcessorDefinition {
@@ -175,35 +152,6 @@ export class CamelComponentSchemaService {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static getUpdatedDefinition(ids: IVisualizationNodeIds | undefined, definition: any) {
-    /** Clone the original definition since we want to preserve the original one, until the form is changed */
-    let updatedDefinition = cloneDeep(definition);
-
-    const processorName = ids?.primaryNodeId?.name;
-    const componentName =
-      ids?.secondaryNodeId?.name === 'kamelet' && ids?.tertiaryNodeId?.name !== undefined
-        ? `kamelet:${ids.tertiaryNodeId.name}`
-        : ids?.secondaryNodeId?.name;
-
-    if (processorName !== undefined) {
-      const prop = this.PROCESSOR_STRING_DEFINITIONS[processorName];
-      if (prop && typeof definition === 'string') {
-        updatedDefinition = { [prop]: definition };
-      }
-    }
-
-    if (componentName !== undefined) {
-      if (updatedDefinition == null) {
-        return updatedDefinition;
-      }
-      updatedDefinition.parameters = updatedDefinition.parameters ?? {};
-      this.applyParametersFromSyntax(componentName, updatedDefinition);
-    }
-
-    return updatedDefinition;
-  }
-
   static canBeDisabled(processorName: keyof ProcessorDefinition): boolean {
     if (processorName == DATAMAPPER_ID_PREFIX) {
       return true;
@@ -212,36 +160,5 @@ export class CamelComponentSchemaService {
     const processorDefinition = CamelCatalogService.getComponent(CatalogKind.Processor, processorName);
 
     return Object.keys(processorDefinition?.properties ?? {}).includes('disabled');
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private static applyParametersFromSyntax(componentName: string, definition: any) {
-    const catalogLookup = CamelCatalogService.getCatalogLookup(componentName);
-    if (catalogLookup === undefined) return;
-
-    const [pathUri, queryUri] = definition.uri?.split('?') ?? [undefined, undefined];
-    if (queryUri) {
-      definition.uri = pathUri;
-      Object.assign(definition.parameters, CamelUriHelper.getParametersFromQueryString(queryUri));
-    }
-
-    if (pathUri && catalogLookup.catalogKind === CatalogKind.Component) {
-      const requiredParameters: string[] = [];
-      if (catalogLookup.definition?.properties !== undefined) {
-        Object.entries(catalogLookup.definition.properties).forEach(([key, value]) => {
-          if (value.required) {
-            requiredParameters.push(key);
-          }
-        });
-      }
-
-      const parametersFromSyntax = CamelUriHelper.getParametersFromPathString(
-        catalogLookup.definition?.component.syntax,
-        definition?.uri,
-        { requiredParameters },
-      );
-      definition.uri = this.getComponentNameFromUri(definition.uri);
-      Object.assign(definition.parameters, parametersFromSyntax);
-    }
   }
 }

--- a/packages/ui/src/models/visualization/visualization-node.ts
+++ b/packages/ui/src/models/visualization/visualization-node.ts
@@ -119,6 +119,15 @@ class VisualizationNode<T extends IVisualizationNodeData = IVisualizationNodeDat
     return schema;
   }
 
+  async getParsedDefinition(): Promise<unknown> {
+    const { primaryNodeId, secondaryNodeId, tertiaryNodeId } = this.data;
+    type EntityWithParsed = {
+      getParsedDefinition?: (path?: string, ids?: IVisualizationNodeIds) => Promise<unknown>;
+    };
+    const entity = this.getBaseEntity() as EntityWithParsed | undefined;
+    return entity?.getParsedDefinition?.(this.data.path, { primaryNodeId, secondaryNodeId, tertiaryNodeId });
+  }
+
   getNodeDefinition(): unknown {
     const { primaryNodeId, secondaryNodeId, tertiaryNodeId } = this.data;
     return this.getBaseEntity()?.getNodeDefinition(this.data.path, {

--- a/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
+++ b/packages/ui/src/pages/RestDslEditor/RestDslEditorPage.tsx
@@ -12,6 +12,7 @@ import { useEntityContext } from '../../hooks/useEntityContext/useEntityContext'
 import { CatalogKind } from '../../models/catalog-kind';
 import { EntityType } from '../../models/entities';
 import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
+import { CamelRestConfigurationVisualEntity } from '../../models/visualization/flows/camel-rest-configuration-visual-entity';
 import { CamelRestVisualEntity } from '../../models/visualization/flows/camel-rest-visual-entity';
 import { AddMethodFormModel } from './components/add-method-schema';
 import { AddMethodModal } from './components/AddMethodModal';
@@ -36,15 +37,18 @@ export const RestDslEditorPage: FunctionComponent = () => {
   const [isSchemaLoading, setIsSchemaLoading] = useState(false);
   const restRelatedEntities = useMemo(() => getRestEntities(entities), [entities]);
 
-  const selectedEntity = restRelatedEntities.find((entity) => entity.id === selectedElement?.entityId);
+  const { entityId, modelPath, ids } = selectedElement ?? {};
+  const name = ids?.primaryNodeId?.name;
+
+  const selectedEntity = restRelatedEntities.find((entity) => entity.id === entityId);
 
   useEffect(() => {
     let cancelled = false;
     setSchema(undefined);
-    if (!selectedEntity || !selectedElement?.ids) return;
+    if (!selectedEntity || !ids) return;
     setIsSchemaLoading(true);
     selectedEntity
-      .fetchNodeSchema(selectedElement.ids)
+      .fetchNodeSchema(ids)
       .then((resolved) => {
         if (!cancelled) setSchema(resolved);
       })
@@ -58,14 +62,35 @@ export const RestDslEditorPage: FunctionComponent = () => {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    selectedEntity,
-    selectedElement?.entityId,
-    selectedElement?.modelPath,
-    selectedElement?.ids?.primaryNodeId?.name,
-  ]);
+  }, [selectedEntity, entityId, modelPath, name]);
 
-  const model = selectedEntity?.getNodeDefinition(selectedElement?.modelPath, selectedElement?.ids);
+  const [parsedModel, setParsedModel] = useState<unknown>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    setParsedModel(undefined);
+    if (!selectedEntity || !modelPath || !ids) return;
+
+    if (selectedEntity instanceof CamelRestConfigurationVisualEntity) {
+      setParsedModel(selectedEntity.getNodeDefinition());
+      return;
+    }
+
+    if (!(selectedEntity instanceof CamelRestVisualEntity)) return;
+
+    selectedEntity
+      .getParsedDefinition(modelPath, ids)
+      .then((resolved) => {
+        if (!cancelled) setParsedModel(resolved);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch parsed definition:', err);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedEntity, entityId, modelPath, name]);
 
   const [treeVersion, setTreeVersion] = useState(0);
 
@@ -94,12 +119,12 @@ export const RestDslEditorPage: FunctionComponent = () => {
         updatedValue = undefined;
       }
 
-      const fullPath = `${selectedElement.modelPath}.${path}`;
+      const fullPath = `${modelPath}.${path}`;
       selectedEntity.updateModel(fullPath, updatedValue);
       updateSourceCodeFromEntities();
       setTreeVersion((version) => version + 1);
     },
-    [selectedElement, selectedEntity, updateSourceCodeFromEntities],
+    [modelPath, selectedElement, selectedEntity, updateSourceCodeFromEntities],
   );
 
   /** Adds a new REST configuration entity to the resource */
@@ -199,17 +224,17 @@ export const RestDslEditorPage: FunctionComponent = () => {
         }
         rightPanel={
           <div className="rest-right-panel">
-            {!selectedElement?.entityId && <div>Select an entity from the list to edit its configuration</div>}
+            {!entityId && <div>Select an entity from the list to edit its configuration</div>}
             {selectedElement && (
               <>
                 <div className="form-rest-title">
                   <span>Edit </span>
-                  <span>{selectedElement.entityId} </span>
-                  {selectedElement.modelPath.startsWith('rest.') && (
+                  <span>{entityId} </span>
+                  {modelPath?.startsWith('rest.') && (
                     <>
-                      <span>/ {selectedElement.modelPath.split('.')[1]?.toUpperCase()} /</span>
+                      <span>/ {modelPath?.split('.')[1]?.toUpperCase()} /</span>
                       <CodeSnippet feedback="Copied to clipboard" type="inline">
-                        {(model as Rest)?.path}
+                        {(parsedModel as Rest)?.path}
                       </CodeSnippet>
                     </>
                   )}
@@ -219,14 +244,14 @@ export const RestDslEditorPage: FunctionComponent = () => {
                 ) : (
                   <Suspense fallback={<Loading>Loading form...</Loading>}>
                     <CanvasFormTabsProvider tab="All">
-                      <FilteredFieldProvider key={`${selectedElement.entityId}__${selectedElement.modelPath}`}>
+                      <FilteredFieldProvider key={`${entityId}__${modelPath}`}>
                         <RestDslFormHeader />
                         <SuggestionRegistrar>
                           <KaotoForm
-                            key={`${selectedElement.entityId}__${selectedElement.modelPath}`}
+                            key={`${entityId}__${modelPath}`}
                             schema={schema}
                             onChangeProp={handleOnChangeIndividualProp}
-                            model={model}
+                            model={parsedModel}
                             customFieldsFactory={restFormFieldFactory}
                           />
                         </SuggestionRegistrar>

--- a/packages/ui/src/serializers/xml/parsers/step-parser.ts
+++ b/packages/ui/src/serializers/xml/parsers/step-parser.ts
@@ -122,13 +122,12 @@ export class StepParser {
       const uriString = element.getAttribute('uri');
       if (!uriString) return {};
 
-      // Inline component name extraction (mirrors getComponentNameFromUri logic)
-      const uriParts = uriString.split(':');
-      const componentName =
-        uriParts[0] === 'kamelet' && uriParts.length > 1 ? `kamelet:${uriParts[1].split('?')[0]}` : uriParts[0];
-      if (!componentName) return { uri: uriString };
+      const componentName = CamelUriHelper.getComponentAndKameletName(uriString);
+      const resolvedComponentName =
+        'kameletName' in componentName ? `kamelet:${componentName.kameletName}` : componentName.componentName;
+      if (!resolvedComponentName) return { uri: uriString };
 
-      const component = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, componentName);
+      const component = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Component, resolvedComponentName);
       if (!component) return { uri: uriString };
 
       const qIdx = uriString.indexOf('?');
@@ -138,7 +137,7 @@ export class StepParser {
         requiredParameters: component.propertiesSchema.required as string[],
       });
       const queryParams = CamelUriHelper.getParametersFromQueryString(query);
-      return { uri: componentName, parameters: { ...pathParams, ...queryParams } };
+      return { uri: resolvedComponentName, parameters: { ...pathParams, ...queryParams } };
     }
     if (element.hasAttribute(name)) {
       return { [name]: element.getAttribute(name) };

--- a/packages/ui/src/stubs/index.ts
+++ b/packages/ui/src/stubs/index.ts
@@ -1,4 +1,5 @@
 export * from './camel-route';
+export * from './citrus-test';
 export * from './create-mock-entities-context';
 export * from './kamelet-binding-route';
 export * from './kamelet-route';


### PR DESCRIPTION
Closes #3791

## What

Removes the last synchronous `CamelCatalogService` call on the node-definition path by introducing an async `getParsedDefinition()` API and deleting the legacy method chain.

## Changes

- **New** `uri-definition.parser.ts` — async parser powered by `DynamicCatalogRegistry`, mirrors the `to.parser.ts` pattern
- **New** `useParsedDefinition` hook — wraps the async pre-fetch pattern for React component callers
- **`AbstractCamelVisualEntity`** — adds `getParsedDefinition()` (async, catalog-aware); strips catalog call from `getNodeDefinition()` so it returns the raw form
- **`VisualizationNode`** — adds thin async delegator for `getParsedDefinition()`
- **6 Group A callers** migrated to `getParsedDefinition()`: `CanvasFormBody`, `disable-step.hook`, `ComponentMode`, `RestDslEditorPage`, `topology-endpoints.ts`, `enable-all-steps.hook`
- **Deleted** `getUpdatedDefinition`, `applyParametersFromSyntax`, `getComponentNameFromUri` from `camel-component-schema.service.ts`
- **`step-parser.ts`** inline duplicate replaced with `CamelUriHelper.getComponentAndKameletName()`
- All 20 Group B callers are untouched — `getNodeDefinition()` still works, now returns the raw form

## Out of scope

Renaming `getNodeDefinition()` → `getRawDefinition()` is a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous parsing of component and route definitions, including URI, query parameter, and kamelet support.
  * Improved REST DSL and visualization editors to load parsed definitions reliably.

* **Bug Fixes**
  * Improved handling of missing, disabled, and asynchronously loaded node definitions.
  * Fixed form rendering, mode toggling, and enabling all steps to wait for definition data and handle failures safely.

* **Tests**
  * Expanded coverage for parsed definitions, URI parsing, async loading, and step state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->