### PR TITLE
fx(sonar): javascript:S7785: Use top-level await instead of async mai…

### DIFF
--- a/packages/ui/scripts/write-version-file.mjs
+++ b/packages/ui/scripts/write-version-file.mjs
@@ -4,25 +4,21 @@ import { createRequire } from 'module';
 const packageJson = createRequire(import.meta.url)('../package.json');
 const versionJson = createRequire(import.meta.url)('../src/version.json');
 
-const main = async () => {
-  const { getLastCommitInfo } = await import('./get-last-commit-info.mjs');
-  const gitInfo = await getLastCommitInfo();
+const { getLastCommitInfo } = await import('./get-last-commit-info.mjs');
+const gitInfo = await getLastCommitInfo();
 
-  /**
-   * This object is used to write the version.json file
-   * It should be kept in sync with the version.json schema,
-   * hence the use of `typeof versionJson`.
-   * @type {typeof versionJson}
-   */
-  const VERSION_OBJECT = {
-    GIT_HASH: gitInfo.hash,
-    GIT_DATE: gitInfo.date,
-    KAOTO_VERSION: packageJson.version,
-  };
-
-  const VERSION_FILE_CONTENT = JSON.stringify(VERSION_OBJECT, null, 4);
-
-  await writeFile('lib/version.json', VERSION_FILE_CONTENT);
+/**
+ * This object is used to write the version.json file
+ * It should be kept in sync with the version.json schema,
+ * hence the use of `typeof versionJson`.
+ * @type {typeof versionJson}
+ */
+const VERSION_OBJECT = {
+  GIT_HASH: gitInfo.hash,
+  GIT_DATE: gitInfo.date,
+  KAOTO_VERSION: packageJson.version,
 };
 
-main();
+const VERSION_FILE_CONTENT = JSON.stringify(VERSION_OBJECT, null, 4);
+
+await writeFile('lib/version.json', VERSION_FILE_CONTENT);


### PR DESCRIPTION
…n() pattern

fixes https://github.com/KaotoIO/kaoto/issues/3715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal version-file generation while preserving existing behavior.
  * Version metadata continues to be generated from the package version and latest commit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->