### PR TITLE
fx(sonar): typescript:S1444: Add readonly modifier to public static p…

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/flow.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/flow.service.ts
@@ -6,8 +6,8 @@ import { CanvasDefaults } from './canvas.defaults';
 import { CanvasEdge, CanvasNode, CanvasNodeData, CanvasNodesAndEdges } from './canvas.models';
 
 export class FlowService {
-  static nodes: CanvasNode[] = [];
-  static edges: CanvasEdge[] = [];
+  static nodes: CanvasNode[] = []; // NOSONAR typescript:S1444 - intentionally reassigned on each diagram rebuild
+  static edges: CanvasEdge[] = []; // NOSONAR typescript:S1444 - intentionally reassigned on each diagram rebuild
   private static visitedNodes: string[] = [];
 
   static getFlowDiagram(

--- a/packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts
+++ b/packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts
@@ -143,7 +143,7 @@ allTokens.push(NCName, DecimalLiteral, DoubleLiteral);
  * - https://www.w3.org/TR/xpath20/#id-grammar
  */
 export class XPath2Parser extends CstParser implements XPathParser {
-  static lexer = new Lexer(allTokens);
+  static readonly lexer = new Lexer(allTokens);
 
   constructor() {
     super(allTokens, {


### PR DESCRIPTION
…roperties

fixes: github.com/KaotoIO/kaoto/issues/3718

xpath-2.0-parser.ts:146 — added readonly to static lexer: it is initialised once and never reassigned, so readonly is correct and safe.

flow.service.ts:9-10 — nodes and edges are explicitly reassigned on every diagram rebuild (lines 18–19 and 82–83), so readonly would be wrong. Added // NOSONAR typescript:S1444 suppressions with explanation instead.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality and static analysis compliance.
  * Prevented unintended reassignment of the XPath parser’s lexer.
* **Bug Fixes**
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->