### PR TITLE
fx(sonar): javascript:S7772: Use node: prefix for built-in module import

### DIFF
--- a/packages/ui/scripts/write-version-file.mjs
+++ b/packages/ui/scripts/write-version-file.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import { writeFile } from 'node:fs/promises';
-import { createRequire } from 'module';
+import { createRequire } from 'node:module';
 const packageJson = createRequire(import.meta.url)('../package.json');
 const versionJson = createRequire(import.meta.url)('../src/version.json');
 


### PR DESCRIPTION
fixes: https://github.com/KaotoIO/kaoto/issues/3721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal module reference to use the modern Node.js format.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->