### PR TITLE
fx(sonar): typescript:S9027: Use getBy* instead of queryBy* for prese…

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
@@ -226,7 +226,7 @@ describe('BeanField', () => {
       fireEvent.click(createButton);
 
       expect(onPropertyChangeSpy).not.toHaveBeenCalled();
-      expect(screen.queryByTestId('NewBeanModal-myNewBean')).toBeInTheDocument();
+      expect(screen.getByTestId('NewBeanModal-myNewBean')).toBeInTheDocument();
     });
 
     it('should appear in document export when bean is added', async () => {


### PR DESCRIPTION
…nce assertions

fixes: https://github.com/KaotoIO/kaoto/issues/3722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for bean creation by verifying that the new-bean modal appears when attempting to create a bean without a specified type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->