### PR TITLE
fix(sonar): use Math.max for overflow index

### DIFF
--- a/packages/ui/src/components/Catalog/sort-tags.ts
+++ b/packages/ui/src/components/Catalog/sort-tags.ts
@@ -39,6 +39,6 @@ export const sortTags = (allTiles: ITile[], filterTags: string[]): { sortedTags:
       return 0;
     });
   const num = sortedTags.filter((tag) => filterTags.includes(tag) || priorityTags.includes(tag)).length;
-  const overflowIndex = num > overflowThreshold ? num : overflowThreshold;
+  const overflowIndex = Math.max(num, overflowThreshold);
   return { sortedTags, overflowIndex };
 };


### PR DESCRIPTION
## Summary

- replace the overflow-index ternary with `Math.max`
- preserve the existing behavior while addressing Sonar rule `typescript:S7766`

Fixes #3733

## Verification

- `yarn workspace @kaoto/kaoto test src/components/Catalog/sort-tags.test.ts` (3 tests passed)
- `yarn workspace @kaoto/kaoto lint`
- `yarn workspace @kaoto/kaoto lint:style`

The full UI test suite was also attempted locally with Node.js 25.2.1. It completed with 485 test files and 7,021 tests passing, while unrelated existing environment failures remained around jsdom `localStorage` and `requestSubmit`. A representative `localStorage` failure was reproduced on unchanged `main`.

AI assistance was used; the change was reviewed and approved by the human operator before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal sorting logic without changing catalog tag behavior or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->