### PR TITLE
refactor: move SPECIAL_CHILD_PROCESSORS to constants and remove getNodeDefinitionValue

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.tsx
+++ b/packages/ui/src/components/Visualization/Custom/ContextMenu/get-move-icons.util.tsx
@@ -10,8 +10,8 @@ import {
 } from '@patternfly/react-icons';
 import { ReactElement } from 'react';
 
+import { SPECIAL_CHILD_PROCESSORS } from '../../../../models/special-processors.constants';
 import { IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
-import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
 import { LayoutType } from '../../Canvas/canvas.models';
 
 export interface MoveIcons {
@@ -77,5 +77,5 @@ function isSpecialChildNode(vizNode?: IVisualizationNode): boolean {
 
   // Check if this processor is in the list of special child processors
   // These are processors that are part of array-clause properties and use inverted direction
-  return CamelComponentSchemaService.SPECIAL_CHILD_PROCESSORS.includes(processorName);
+  return (SPECIAL_CHILD_PROCESSORS as readonly string[]).includes(processorName);
 }

--- a/packages/ui/src/models/special-processors.constants.ts
+++ b/packages/ui/src/models/special-processors.constants.ts
@@ -39,3 +39,13 @@ export const SPECIAL_PROCESSORS_PARENTS_MAP = {
   routeConfiguration: ['intercept', 'interceptFrom', 'interceptSendToEndpoint', 'onException', 'onCompletion'],
   rest: REST_DSL_VERBS,
 } as const;
+
+/**
+ * Flat list of all special child processors (i.e. processors that are
+ * stored directly as the definition value rather than wrapped in
+ * `{ [name]: definition }`).
+ * Derived from SPECIAL_PROCESSORS_PARENTS_MAP, excluding routeConfiguration children.
+ */
+export const SPECIAL_CHILD_PROCESSORS = Object.entries(SPECIAL_PROCESSORS_PARENTS_MAP)
+  .filter(([key]) => key !== 'routeConfiguration')
+  .flatMap(([, values]) => values);

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -11,6 +11,7 @@ import { EntityType } from '../../entities';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
 import { PlaceholderType } from '../../placeholder.constants';
 import { NodeLabelType } from '../../settings/settings.model';
+import { SPECIAL_CHILD_PROCESSORS } from '../../special-processors.constants';
 import {
   AddStepMode,
   BaseVisualEntity,
@@ -224,7 +225,10 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     data: IVisualizationNodeData;
     insertAtStart?: boolean;
   }) {
-    const defaultValue = CamelComponentSchemaService.getNodeDefinitionValue(options.clipboardContent);
+    const { name, definition } = options.clipboardContent;
+    const defaultValue = (SPECIAL_CHILD_PROCESSORS as readonly string[]).includes(name)
+      ? (definition as ProcessorDefinition)
+      : ({ [name]: definition } as ProcessorDefinition);
     this.addNewStep(defaultValue, options.mode, options.data, options.clipboardContent.name, options.insertAtStart);
   }
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -4,7 +4,6 @@ import { CatalogLibrary, ProcessorDefinition } from '@kaoto/camel-catalog/types'
 import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
-import { IClipboardContent } from '../../clipboard';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { CamelComponentSchemaService } from './camel-component-schema.service';
 import { CamelProcessorStepsProperties } from './camel-component-types';
@@ -145,32 +144,6 @@ describe('CamelComponentSchemaService', () => {
         expect(stepsProperties).toEqual(result);
       },
     );
-  });
-
-  describe('getNodeDefinitionValue', () => {
-    it('should return Node definition for a simple processor', () => {
-      const clipboadContent: IClipboardContent = {
-        name: 'log',
-        definition: {
-          id: 'log-3245',
-          message: '${body}',
-        },
-      };
-      const expectedValue = CamelComponentSchemaService.getNodeDefinitionValue(clipboadContent);
-      expect(expectedValue).toEqual({ log: { id: 'log-3245', message: '${body}' } });
-    });
-
-    it('should return Node definition for a Special processor', () => {
-      const clipboadContent: IClipboardContent = {
-        name: 'when',
-        definition: {
-          id: 'when-2765',
-          steps: [{ log: { id: 'log-2202', message: '${body}' } }],
-        },
-      };
-      const expectedValue = CamelComponentSchemaService.getNodeDefinitionValue(clipboadContent);
-      expect(expectedValue).toEqual({ id: 'when-2765', steps: [{ log: { id: 'log-2202', message: '${body}' } }] });
-    });
   });
 
   describe('canBeDisabled', () => {

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -3,7 +3,6 @@ import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
 import { REST_DSL_VERBS } from '../../../special-processors.constants';
-import { IClipboardContent } from '../../clipboard';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { CamelProcessorStepsProperties } from './camel-component-types';
 
@@ -51,14 +50,6 @@ export class CamelComponentSchemaService {
     ...REST_DSL_VERBS,
   ];
   static readonly DISABLED_REMOVE_STEPS = ['from', 'route'] as unknown as (keyof ProcessorDefinition)[];
-  static readonly SPECIAL_CHILD_PROCESSORS = [
-    'onFallback',
-    'when',
-    'otherwise',
-    'doCatch',
-    'doFinally',
-    ...REST_DSL_VERBS,
-  ];
   static readonly PROCESSOR_STRING_DEFINITIONS: Record<string, string> = {
     to: 'uri',
     toD: 'uri',
@@ -136,19 +127,6 @@ export class CamelComponentSchemaService {
         return CAMEL_REST_VERB_STEP_PROPERTIES;
       default:
         return [];
-    }
-  }
-
-  /**
-   * Get the definition for a given component and property
-   */
-  static getNodeDefinitionValue(clipboardContent: IClipboardContent): ProcessorDefinition {
-    const { name, definition: defaultValue } = clipboardContent;
-
-    if (this.SPECIAL_CHILD_PROCESSORS.includes(name)) {
-      return defaultValue as ProcessorDefinition;
-    } else {
-      return { [name]: defaultValue } as ProcessorDefinition;
     }
   }
 


### PR DESCRIPTION
Closes #3808

## What changed

- Added `SPECIAL_CHILD_PROCESSORS` constant to `special-processors.constants.ts`, derived from `SPECIAL_PROCESSORS_PARENTS_MAP` (single source of truth).
- Removed `CamelComponentSchemaService.SPECIAL_CHILD_PROCESSORS` static array (was a hardcoded duplicate).
- Removed `CamelComponentSchemaService.getNodeDefinitionValue()`; its logic is now inlined in `AbstractCamelVisualEntity.pasteStep`.
- Updated `get-move-icons.util.tsx` to import from the new constants module.
- Removed tests for the deleted method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved paste behavior for special child processors so copied steps retain their correct structure.
  - Ensured standard processors continue to be wrapped correctly when pasted into visual flows.
  - Updated context-menu handling so move icons are shown consistently for special child processors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->