### PR TITLE
fix(sonar): use nullish coalescing assignment

### DIFF
--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
@@ -70,9 +70,7 @@ export class BeansEntityHandler {
     }
 
     let entity = this.getBeansEntity();
-    if (!entity) {
-      entity = this.createBeansEntity();
-    }
+    entity ??= this.createBeansEntity();
     if (entity) {
       entity.parent.beans = model;
     }

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
@@ -37,9 +37,7 @@ export const PipeErrorHandlerPage: FunctionComponent = () => {
     (model: Record<string, unknown>) => {
       if (Object.keys(model).length > 0) {
         let entity = pipeResource.getErrorHandlerEntity();
-        if (!entity) {
-          entity = pipeResource.createErrorHandlerEntity();
-        }
+        entity ??= pipeResource.createErrorHandlerEntity();
         entity.parent.errorHandler = model;
       } else {
         pipeResource!.deleteErrorHandlerEntity();

--- a/packages/ui/src/utils/event-notifier.ts
+++ b/packages/ui/src/utils/event-notifier.ts
@@ -7,9 +7,7 @@ export class EventNotifier extends EventTarget {
   private static instance: EventNotifier | undefined;
 
   static getInstance(): EventNotifier {
-    if (!this.instance) {
-      this.instance = new EventNotifier();
-    }
+    this.instance ??= new EventNotifier();
 
     return this.instance;
   }

--- a/packages/ui/src/xml-schema-ts/extensions/DefaultExtensionDeserializer.ts
+++ b/packages/ui/src/xml-schema-ts/extensions/DefaultExtensionDeserializer.ts
@@ -23,9 +23,7 @@ export class DefaultExtensionDeserializer implements ExtensionDeserializer {
     // elements or the attributes
 
     let metaInfoMap = schemaObject.getMetaInfoMap();
-    if (metaInfoMap == null) {
-      metaInfoMap = new Map<string, object>();
-    }
+    metaInfoMap ??= new Map<string, object>();
 
     if (node.nodeType == Node.ATTRIBUTE_NODE) {
       let attribMap: Map<QName, Node>;

--- a/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.ts
+++ b/packages/ui/src/xml-schema-ts/utils/NodeNamespaceContext.ts
@@ -16,9 +16,7 @@ export class NodeNamespaceContext implements NamespacePrefixList {
   }
 
   getDeclaredPrefixes(): string[] {
-    if (this.prefixes === undefined) {
-      this.prefixes = Object.keys(this.declarations);
-    }
+    this.prefixes ??= Object.keys(this.declarations);
     return this.prefixes;
   }
 


### PR DESCRIPTION
### Description

Replace five conditional nullish initialization patterns with the nullish coalescing assignment operator, addressing Sonar rule typescript:S6606 while preserving existing behavior.

Closes #3737

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?

- Focused tests for BeansEntityHandler, PipeErrorHandlerPage, EventNotifier, ExtensionRegistry, and NodeNamespaceContext — 45 tests passed
- yarn workspace @kaoto/kaoto lint
- yarn workspace @kaoto/kaoto lint:style

#### Checklist
- [x] I have read the Contributing Guidelines.
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [ ] Documentation update — not applicable to this code-quality cleanup.
- [ ] New tests — existing focused tests cover the unchanged initialization behavior.

AI assistance was used. The change was reviewed and approved by the human operator before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal initialization logic across visualization, error handling, event notification, XML deserialization, and namespace processing.
  * Preserved existing behavior while making lazy creation and caching more concise and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->