### PR TITLE
fix(sonar): merge duplicate Chevrotain imports

### DIFF
--- a/packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts
+++ b/packages/ui/src/services/xpath/2.0/xpath-2.0-parser.ts
@@ -1,5 +1,12 @@
-import { defaultParserErrorProvider, IParserConfig, ITokenConfig, TokenType } from 'chevrotain';
-import { createToken as orgCreateToken, CstParser, Lexer } from 'chevrotain';
+import {
+  createToken as orgCreateToken,
+  CstParser,
+  defaultParserErrorProvider,
+  IParserConfig,
+  ITokenConfig,
+  Lexer,
+  TokenType,
+} from 'chevrotain';
 
 import { XPathParser, XPathParserResult } from '../xpath-model';
 


### PR DESCRIPTION
### Description

Merge the two imports from chevrotain in the XPath 2.0 parser into one import declaration, addressing Sonar rule typescript:S3863 without changing behavior.

Closes #3729

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?

- yarn workspace @kaoto/kaoto test src/services/xpath/2.0/xpath-2.0-parser.test.ts — 2 tests passed
- yarn workspace @kaoto/kaoto lint
- yarn workspace @kaoto/kaoto lint:style

#### Checklist
- [x] I have read the Contributing Guidelines.
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [ ] Documentation update — not applicable to this code-quality cleanup.
- [ ] New tests — existing focused tests cover the unchanged parser behavior.

AI assistance was used. The change was reviewed and approved by the human operator before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted an internal import statement for improved code consistency.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->