### PR TITLE
fix(sonar): remove redundant constructor return

### DIFF
--- a/packages/ui/src/models/camel/integration-resource.ts
+++ b/packages/ui/src/models/camel/integration-resource.ts
@@ -15,7 +15,6 @@ export class IntegrationResource extends CamelKResource {
     } else {
       this.integration = this.resource as IntegrationType;
       this.integration.kind = SourceSchemaType.Integration;
-      return;
     }
   }
 


### PR DESCRIPTION
### Description

Remove the redundant return at the natural end of the IntegrationResource constructor, addressing Sonar rule typescript:S3626 without changing behavior.

Closes #3739

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other

#### How Has This Been Tested?

- yarn workspace @kaoto/kaoto test src/models/kaoto-resource.test.ts src/components/Visualization/ContextToolbar/ContextToolbar.test.tsx — 28 tests passed, 1 skipped
- yarn workspace @kaoto/kaoto lint
- yarn workspace @kaoto/kaoto lint:style

#### Checklist
- [x] I have read the Contributing Guidelines.
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [ ] Documentation update — not applicable to this code-quality cleanup.
- [ ] New tests — existing focused tests cover the unchanged constructor behavior.

AI assistance was used. The change was reviewed and approved by the human operator before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal constructor logic without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->