### PR TITLE
fix(Datamapper): allow selecting an xs:sequence branch inside an xs:choice

### DIFF
--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.test.ts
@@ -192,6 +192,30 @@ describe('field-details-utils', () => {
 
       expect(getEffectiveMaxOccurs(wrapperField, choiceNode)).toBe('unbounded');
     });
+
+    it('should inherit maxOccurs from a repeating choice for a source child of a sequence branch', () => {
+      // choice(unbounded) > sequence(1) > key(1): on the source side the child is a plain
+      // FieldNodeData with no wrapperField/choiceField back-reference, so the effective maxOccurs
+      // must be resolved by walking up the transparent sequence compositor to the repeating choice —
+      // keeping the popover's Max Occurs in agreement with the collection indicator icon.
+      const shipOrderDoc = TestUtil.createSourceOrderDoc();
+      const documentNodeData = new DocumentNodeData(shipOrderDoc);
+      const choiceWrapper = {
+        ...shipOrderDoc.fields[0],
+        maxOccurs: 'unbounded',
+        wrapperKind: 'choice',
+      } as unknown as IField;
+      const sequenceField = {
+        ...shipOrderDoc.fields[0],
+        maxOccurs: 1,
+        wrapperKind: 'sequence',
+        parent: choiceWrapper,
+      } as unknown as IField;
+      const keyField = { ...shipOrderDoc.fields[0], maxOccurs: 1, parent: sequenceField } as unknown as IField;
+      const keyNode = new FieldNodeData(documentNodeData, keyField);
+
+      expect(getEffectiveMaxOccurs(keyField, keyNode)).toBe('unbounded');
+    });
   });
 
   describe('prepareFieldDetails', () => {

--- a/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.ts
+++ b/packages/ui/src/components/Document/FieldNodePopover/field-details-utils.ts
@@ -7,6 +7,7 @@ import {
   TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
 } from '../../../models/datamapper/visualization';
+import { DocumentService } from '../../../services/document/document.service';
 import { VisualizationUtilService } from '../../../services/visualization/visualization-util.service';
 import { QName } from '../../../xml-schema-ts/QName';
 import { getOverrideDisplayInfo } from '../actions/FieldOverride/override-util';
@@ -89,6 +90,16 @@ export const getEffectiveMaxOccurs = (field: IField, nodeData?: NodeData): IFiel
 
   if (VisualizationUtilService.isAbstractField(nodeData) && nodeData.abstractField) {
     return nodeData.abstractField.maxOccurs;
+  }
+
+  // A field nested under a repeating choice/sequence compositor (e.g. the children of an xs:sequence
+  // branch selected inside a `choice(unbounded)`) inherits the compositor's cardinality even though
+  // its own maxOccurs is 1. This mirrors DocumentService.isCollectionField so the popover's Max Occurs
+  // agrees with the collection indicator icon. Covers the source-side plain FieldNodeData, where no
+  // wrapperField/choiceField back-reference is available.
+  const enclosingCollectionCompositor = DocumentService.getEnclosingCollectionCompositor(field);
+  if (enclosingCollectionCompositor) {
+    return enclosingCollectionCompositor.maxOccurs;
   }
 
   return field.maxOccurs;

--- a/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
@@ -21,7 +21,7 @@ export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({ classNa
   const isChoiceWrapper = VisualizationUtilService.isUnselectedChoiceField(nodeData);
   const isSelectedChoiceWrapper = VisualizationUtilService.isSelectedNestedChoice(nodeData);
   const isAbstractWrapper = VisualizationUtilService.isUnselectedAbstractField(nodeData);
-  const isSequenceWrapper = VisualizationUtilService.isSequenceField(nodeData);
+  const isSequenceWrapper = VisualizationUtilService.isSequenceNode(nodeData);
   const hasNoCandidates = isAbstractWrapper && (nodeData.field.fields ?? []).length === 0;
   const optionalField = nodeData.field.minOccurs === 0;
   const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
@@ -23,6 +23,7 @@ import {
   FieldItemNodeData,
   FieldNodeData,
   MappingNodeData,
+  SequenceFieldNodeData,
   TargetDocumentNodeData,
   UnknownMappingNodeData,
 } from '../../../models/datamapper/visualization';
@@ -239,7 +240,7 @@ describe('NodeTitle', () => {
     render(<NodeTitle nodeData={choiceNodeData} isDocument={false} rank={0} />);
 
     expect(screen.getByText('choice')).toBeInTheDocument();
-    const memberText = screen.getByText('(email | phone)');
+    const memberText = screen.getByText('email | phone');
     expect(memberText).toBeInTheDocument();
     expect(memberText).toHaveClass('node-title__text__choice');
   });
@@ -264,9 +265,59 @@ describe('NodeTitle', () => {
     render(<NodeTitle nodeData={abstractNodeData} isDocument={false} rank={0} />);
 
     expect(screen.getByText('abstract')).toBeInTheDocument();
-    const memberText = screen.getByText('(Cat | Dog)');
+    const memberText = screen.getByText('Cat | Dog');
     expect(memberText).toBeInTheDocument();
     expect(memberText).toHaveClass('node-title__text__abstract');
+  });
+
+  it('should render a selected sequence branch as a bare "sequence" badge without its member label', () => {
+    const shipOrderDoc = TestUtil.createSourceOrderDoc();
+    const documentNodeData = new DocumentNodeData(shipOrderDoc);
+    const baseField = shipOrderDoc.fields[0];
+    const sequenceField = {
+      ...baseField,
+      name: '__sequence__',
+      displayName: 'sequence',
+      wrapperKind: 'sequence' as const,
+      fields: [
+        { ...baseField, name: 'key', displayName: 'key', fields: [] },
+        { ...baseField, name: 'value', displayName: 'value', fields: [] },
+      ],
+    } as unknown as typeof baseField;
+    const sequenceNodeData = new SequenceFieldNodeData(documentNodeData, sequenceField);
+
+    render(<NodeTitle nodeData={sequenceNodeData} isDocument={false} rank={0} />);
+
+    expect(screen.getByText('sequence')).toBeInTheDocument();
+    // The member label must not be rendered as the node title — the children are shown as sub-nodes.
+    expect(screen.queryByText('key, value')).not.toBeInTheDocument();
+  });
+
+  it('should render a per-instance collection FieldItemNodeData whose field is a sequence as a "sequence" badge', () => {
+    // Regression for #3802: a repeating (maxOccurs>1) choice renders its selected sequence branch
+    // as a FieldItemNodeData, which must show the same bare "sequence" badge as the maxOccurs=1
+    // case — not the raw synthetic literal "sequence" nor the composed "key, value" member label.
+    const targetDoc = TestUtil.createTargetOrderDoc();
+    const tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+    const targetDocNodeData = new TargetDocumentNodeData(targetDoc, tree);
+    const baseField = targetDoc.fields[0];
+    const sequenceField = {
+      ...baseField,
+      name: '__sequence__',
+      displayName: 'sequence',
+      wrapperKind: 'sequence' as const,
+      fields: [
+        { ...baseField, name: 'key', displayName: 'key', fields: [] },
+        { ...baseField, name: 'value', displayName: 'value', fields: [] },
+      ],
+    } as unknown as typeof baseField;
+    const fieldItem = new FieldItem(tree, sequenceField);
+    const fieldItemNodeData = new FieldItemNodeData(targetDocNodeData, fieldItem);
+
+    render(<NodeTitle nodeData={fieldItemNodeData} isDocument={false} rank={0} />);
+
+    expect(screen.getByText('sequence')).toBeInTheDocument();
+    expect(screen.queryByText('key, value')).not.toBeInTheDocument();
   });
 
   it('should not display popover for MappingNodeData', async () => {

--- a/packages/ui/src/components/Document/Nodes/BaseNode.tsx
+++ b/packages/ui/src/components/Document/Nodes/BaseNode.tsx
@@ -138,7 +138,7 @@ export const BaseNode: FunctionComponent<PropsWithChildren<BaseNodeProps>> = ({
           <Choices />
         </Icon>
       )}
-      {isChoiceField && isSelectedChoice && (
+      {isSelectedChoice && (
         <Label className="node__spacer" color="green" icon={<Choices />} isCompact data-testid="choice-field-icon">
           {choiceDepth >= 2 ? <>&times;{choiceDepth}</> : ''}
         </Label>

--- a/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
+++ b/packages/ui/src/components/Document/actions/FieldContextMenu/useChoiceContextMenu.test.tsx
@@ -314,7 +314,7 @@ describe('useChoiceContextMenu', () => {
 
     fireEvent.contextMenu(screen.getByTestId(`node-source-${memberNode.nodeData.id}`));
 
-    expect(screen.getByText("Select 'Email' in '(Email | Phone | Fax)'")).toBeInTheDocument();
+    expect(screen.getByText("Select 'Email' in 'Email | Phone | Fax'")).toBeInTheDocument();
     expect(screen.getByText('Override Field...')).toBeInTheDocument();
   });
 

--- a/packages/ui/src/models/datamapper/visualization.ts
+++ b/packages/ui/src/models/datamapper/visualization.ts
@@ -229,14 +229,25 @@ export class TargetAbstractFieldNodeData extends TargetFieldNodeData {
 
 /**
  * Visualization node for a source xs:sequence wrapper field inside an xs:choice.
- * Sequence wrappers have no selection mechanism — they always render all children.
+ * Sequence wrappers have no selection mechanism of their own — they always render all children.
+ *
+ * When this sequence is the selected member of an enclosing xs:choice, `choiceField` holds that
+ * choice wrapper (mirroring {@link ChoiceFieldNodeData.choiceField}). It lets the choice context
+ * menu treat the node as a selected branch so the selection can be changed or cleared. It is
+ * `undefined` for a sequence not rendered as a selected choice branch.
  */
-export class SequenceFieldNodeData extends FieldNodeData {}
+export class SequenceFieldNodeData extends FieldNodeData {
+  /** The enclosing choice wrapper when this sequence is the selected choice member; otherwise `undefined`. */
+  choiceField?: IField;
+}
 
 /**
  * Target-side counterpart of {@link SequenceFieldNodeData}.
  */
-export class TargetSequenceFieldNodeData extends TargetFieldNodeData {}
+export class TargetSequenceFieldNodeData extends TargetFieldNodeData {
+  /** The enclosing choice wrapper when this sequence is the selected choice member; otherwise `undefined`. */
+  choiceField?: IField;
+}
 
 /**
  * Visualization node for a mapping item (e.g. `if`, `choose`, `forEach`, `valueSelector`).

--- a/packages/ui/src/services/document/document.service.test.ts
+++ b/packages/ui/src/services/document/document.service.test.ts
@@ -707,6 +707,90 @@ describe('DocumentService', () => {
       const regularField = sourceDoc.fields[0].fields[0];
       expect(DocumentService.isFieldInsideCollectionChoiceWrapper(regularField)).toBeFalsy();
     });
+
+    it('should return true for children of an xs:sequence branch inside a collection choice', async () => {
+      const mockApi = {
+        getResourceContent: vi.fn().mockResolvedValue(getTestDocumentXsd()),
+      };
+
+      const result = await DocumentService.createDocument(
+        mockApi as unknown as IMetadataApi,
+        DocumentType.SOURCE_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        'TestDocument',
+        ['TestDocument.xsd'],
+      );
+
+      const doc = result.document!;
+      const testDocument = doc.fields[0];
+      const element = testDocument.fields.find((f) => f.name === 'CollectionSequenceInChoiceElement')!;
+      const choiceWrapper = element.fields[0];
+      expect(choiceWrapper.wrapperKind).toBe('choice');
+      expect(choiceWrapper.maxOccurs).toBe('unbounded');
+
+      const sequenceBranch = choiceWrapper.fields.find((f) => f.wrapperKind === 'sequence')!;
+      const seqKey = sequenceBranch.fields.find((f) => f.name === 'seqKey')!;
+      const seqValue = sequenceBranch.fields.find((f) => f.name === 'seqValue')!;
+
+      // The sequence's own maxOccurs is 1, but the enclosing choice repeats — so its children,
+      // reached through the transparent sequence compositor, must inherit collection semantics.
+      expect(seqKey.maxOccurs).toBe(1);
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(seqKey)).toBeTruthy();
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(seqValue)).toBeTruthy();
+      expect(DocumentService.isCollectionField(seqKey)).toBeTruthy();
+      expect(DocumentService.isCollectionField(seqValue)).toBeTruthy();
+      // The plain sibling branch (direct choice member) still inherits, as before.
+      const plainValue = choiceWrapper.fields.find((f) => f.name === 'plainValue')!;
+      expect(DocumentService.isCollectionField(plainValue)).toBeTruthy();
+    });
+
+    it('should return true for a child of a repeating xs:sequence (no choice involved)', () => {
+      const seq = { wrapperKind: 'sequence', maxOccurs: 'unbounded', parent: {} as IParentType } as IField;
+      const child = { maxOccurs: 1, parent: seq } as IField;
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(child)).toBeTruthy();
+    });
+
+    it('should return false for a child of a real repeating element (opaque, not a compositor)', () => {
+      // element(unbounded) > child: the child is a scalar inside a repeating element, not itself a
+      // collection — that repeat is handled at the element's own mapping level.
+      const element = { maxOccurs: 'unbounded', parent: {} as IParentType } as IField;
+      const child = { maxOccurs: 1, parent: element } as IField;
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(child)).toBeFalsy();
+    });
+
+    it('should return false for a child of a non-repeating sequence not inside a repeating compositor', () => {
+      const seq = { wrapperKind: 'sequence', maxOccurs: 1, parent: {} as IParentType } as IField;
+      const child = { maxOccurs: 1, parent: seq } as IField;
+      expect(DocumentService.isFieldInsideCollectionChoiceWrapper(child)).toBeFalsy();
+    });
+  });
+
+  describe('getEnclosingCollectionCompositor()', () => {
+    it('should return the repeating choice reached through a transparent sequence', () => {
+      const choice = { wrapperKind: 'choice', maxOccurs: 'unbounded', parent: {} as IParentType } as IField;
+      const seq = { wrapperKind: 'sequence', maxOccurs: 1, parent: choice } as IField;
+      const child = { maxOccurs: 1, parent: seq } as IField;
+      expect(DocumentService.getEnclosingCollectionCompositor(child)).toBe(choice);
+    });
+
+    it('should return the nearest repeating compositor (the sequence) when it repeats itself', () => {
+      const choice = { wrapperKind: 'choice', maxOccurs: 1, parent: {} as IParentType } as IField;
+      const seq = { wrapperKind: 'sequence', maxOccurs: 'unbounded', parent: choice } as IField;
+      const child = { maxOccurs: 1, parent: seq } as IField;
+      expect(DocumentService.getEnclosingCollectionCompositor(child)).toBe(seq);
+    });
+
+    it('should return undefined when no enclosing compositor repeats', () => {
+      const seq = { wrapperKind: 'sequence', maxOccurs: 1, parent: {} as IParentType } as IField;
+      const child = { maxOccurs: 1, parent: seq } as IField;
+      expect(DocumentService.getEnclosingCollectionCompositor(child)).toBeUndefined();
+    });
+
+    it('should return undefined when the parent is a real (opaque) element', () => {
+      const element = { maxOccurs: 'unbounded', parent: {} as IParentType } as IField;
+      const child = { maxOccurs: 1, parent: element } as IField;
+      expect(DocumentService.getEnclosingCollectionCompositor(child)).toBeUndefined();
+    });
   });
 
   describe('createDocument() error handling', () => {

--- a/packages/ui/src/services/document/document.service.ts
+++ b/packages/ui/src/services/document/document.service.ts
@@ -485,19 +485,38 @@ export class DocumentService {
     return field.fields.length > 0 || field.namedTypeFragmentRefs.length > 0;
   }
 
+  private static isRepeating(field: IField): boolean {
+    return field.maxOccurs === 'unbounded' || Number(field.maxOccurs) > 1;
+  }
+
   /**
-   * Returns true if the field's parent is a collection choice wrapper.
-   * A collection choice wrapper is an xs:choice with maxOccurs > 1, meaning its members
-   * can repeat across choice instances and should be treated as collection fields.
+   * Walks up through the chain of enclosing transparent compositors (xs:choice / xs:sequence) and
+   * returns the nearest one that repeats, or `undefined` when none does. xs:choice and xs:sequence
+   * are transparent compositors (not XML elements): when one repeats, the fields nested inside it
+   * repeat with it across instances. A real element is opaque and stops the walk — a scalar under a
+   * repeating element is not itself a collection (that repeat is handled at the element's own mapping
+   * level). This is the single source of truth for both {@link isFieldInsideCollectionChoiceWrapper}
+   * (does it repeat at all?) and the popover's effective-maxOccurs display (what is the repeat count?).
+   * @param field - The field whose ancestor compositors to inspect
+   * @returns the nearest repeating enclosing choice/sequence compositor, or `undefined`
+   */
+  static getEnclosingCollectionCompositor(field: IField): IField | undefined {
+    const parent = field.parent;
+    if (!('wrapperKind' in parent) || (parent.wrapperKind !== 'choice' && parent.wrapperKind !== 'sequence')) {
+      return undefined;
+    }
+    return DocumentService.isRepeating(parent) ? parent : DocumentService.getEnclosingCollectionCompositor(parent);
+  }
+
+  /**
+   * Returns true if the field inherits collection (repeating) semantics from an enclosing repeating
+   * xs:choice / xs:sequence compositor. See {@link getEnclosingCollectionCompositor} for how the
+   * ancestor chain is walked and why real elements stop the walk.
    * @param field - The field to inspect
-   * @returns true if the field is a direct child of a collection choice wrapper, false otherwise
+   * @returns true if the field is inside a repeating choice/sequence compositor, false otherwise
    */
   static isFieldInsideCollectionChoiceWrapper(field: IField): boolean {
-    if (!('wrapperKind' in field.parent)) return false;
-    return (
-      field.parent.wrapperKind === 'choice' &&
-      (field.parent.maxOccurs === 'unbounded' || Number(field.parent.maxOccurs) > 1)
-    );
+    return DocumentService.getEnclosingCollectionCompositor(field) !== undefined;
   }
 
   /**
@@ -508,11 +527,7 @@ export class DocumentService {
    * @returns true if the field is a collection, false otherwise
    */
   static isCollectionField(field: IField) {
-    return (
-      field.maxOccurs === 'unbounded' ||
-      Number(field.maxOccurs) > 1 ||
-      DocumentService.isFieldInsideCollectionChoiceWrapper(field)
-    );
+    return DocumentService.isRepeating(field) || DocumentService.isFieldInsideCollectionChoiceWrapper(field);
   }
 
   /**

--- a/packages/ui/src/services/document/wrapper-selection.service.test.ts
+++ b/packages/ui/src/services/document/wrapper-selection.service.test.ts
@@ -3,6 +3,7 @@ import { NS_XML_SCHEMA } from '../../models/datamapper/standard-namespaces';
 import { FieldOverrideVariant } from '../../models/datamapper/types';
 import { getChoiceWithAbstractXsd } from '../../stubs/datamapper/data-mapper';
 import { XmlSchemaCollection } from '../../xml-schema-ts';
+import { QName } from '../../xml-schema-ts/QName';
 import { SchemaPathService } from '../schema-path.service';
 import { DocumentUtilService } from './document-util.service';
 import { FieldOverrideService } from './field-override.service';
@@ -721,6 +722,67 @@ describe('WrapperSelectionService', () => {
 
       expect(doc.definition.choiceSelections ?? []).toHaveLength(0);
       expect(doc.definition.fieldSubstitutions ?? []).toHaveLength(0);
+    });
+  });
+
+  // Regression for #3802: clearing an outer choice must also clear choice/abstract selections
+  // nested inside a selected xs:sequence branch (a sequence is a transparent compositor; XSD
+  // allows choice/abstract/sequence inside a sequence). Behaviour must match choice>choice on clear.
+  describe('clearDescendantWrapperSelections through a selected xs:sequence branch (#3802)', () => {
+    function makeSequenceField(parent: XmlSchemaField): XmlSchemaField {
+      const seq = new XmlSchemaField(parent, 'sequence', false);
+      seq.wrapperKind = 'sequence';
+      return seq;
+    }
+
+    it('clears a choice nested inside the selected sequence branch', () => {
+      // Root/{choice:0} -> [plain, sequence[ k, innerChoice[a, b] ] ]
+      const root = new XmlSchemaField(document, 'Root', false);
+      const outerChoice = makeChoiceField(root, ['plain']);
+      const seq = makeSequenceField(outerChoice);
+      const k = new XmlSchemaField(seq, 'k', false);
+      const innerChoice = makeChoiceField(seq, ['a', 'b']);
+      seq.fields = [k, innerChoice];
+      outerChoice.fields.push(seq); // sequence is member index 1
+
+      outerChoice.selectedMemberIndex = 1; // select the sequence branch
+      innerChoice.selectedMemberIndex = 0; // select a member of the choice inside the sequence
+
+      WrapperSelectionService.clearDescendantWrapperSelections(outerChoice, namespaceMap);
+
+      expect(innerChoice.selectedMemberIndex).toBeUndefined();
+    });
+
+    it('reverts an abstract substitution nested inside the selected sequence branch', () => {
+      const revertSpy = vi.spyOn(FieldOverrideService, 'revertFieldSubstitution').mockImplementation(() => {});
+      const root = new XmlSchemaField(document, 'Root', false);
+      const outerChoice = makeChoiceField(root, ['plain']);
+      const seq = makeSequenceField(outerChoice);
+      const abstractField = new XmlSchemaField(seq, 'payload', false);
+      abstractField.wrapperKind = 'abstract';
+      abstractField.selectedMemberQName = new QName('io.kaoto.test', 'Concrete');
+      seq.fields = [abstractField];
+      outerChoice.fields.push(seq);
+
+      outerChoice.selectedMemberIndex = 1;
+
+      WrapperSelectionService.clearDescendantWrapperSelections(outerChoice, namespaceMap);
+
+      expect(revertSpy).toHaveBeenCalledWith(abstractField, namespaceMap);
+      revertSpy.mockRestore();
+    });
+
+    it('is a no-op when the selected sequence has only plain elements', () => {
+      const root = new XmlSchemaField(document, 'Root', false);
+      const outerChoice = makeChoiceField(root, ['plain']);
+      const seq = makeSequenceField(outerChoice);
+      seq.fields = [new XmlSchemaField(seq, 'k', false), new XmlSchemaField(seq, 'v', false)];
+      outerChoice.fields.push(seq);
+      outerChoice.selectedMemberIndex = 1;
+
+      expect(() => {
+        WrapperSelectionService.clearDescendantWrapperSelections(outerChoice, namespaceMap);
+      }).not.toThrow();
     });
   });
 });

--- a/packages/ui/src/services/document/wrapper-selection.service.ts
+++ b/packages/ui/src/services/document/wrapper-selection.service.ts
@@ -104,10 +104,9 @@ export class WrapperSelectionService {
   }
 
   /**
-   * Recursively clears nested wrapper selections (both choice and abstract) beneath
-   * the given field's currently selected member. Walks the member chain depth-first:
-   * clears `selectedMemberIndex` for choice wrappers, reverts `selectedMemberQName`
-   * for abstract wrappers.
+   * Recursively clears nested wrapper selections (choice and abstract) beneath the given
+   * field's currently selected member. Clears `selectedMemberIndex` for choice wrappers and
+   * reverts `selectedMemberQName` for abstract wrappers.
    *
    * This operates on the live field tree only — it does not update the document
    * definition. Callers should follow up with {@link DocumentUtilService.invalidateDescendants}
@@ -116,12 +115,20 @@ export class WrapperSelectionService {
   static clearDescendantWrapperSelections(field: IField, namespaceMap: Record<string, string>): void {
     const member = DocumentUtilService.getSelectedMember(field);
     if (!member) return;
-    if (member.wrapperKind === 'choice' && member.selectedMemberIndex !== undefined) {
-      WrapperSelectionService.clearDescendantWrapperSelections(member, namespaceMap);
-      member.selectedMemberIndex = undefined;
-    }
-    if (member.wrapperKind === 'abstract' && member.selectedMemberQName) {
-      FieldOverrideService.revertFieldSubstitution(member, namespaceMap);
+    WrapperSelectionService.clearWrapperSelection(member, namespaceMap);
+  }
+
+  /** Clears the selection on a single wrapper field, descending through a transparent xs:sequence branch. */
+  private static clearWrapperSelection(field: IField, namespaceMap: Record<string, string>): void {
+    if (field.wrapperKind === 'choice' && field.selectedMemberIndex !== undefined) {
+      WrapperSelectionService.clearDescendantWrapperSelections(field, namespaceMap);
+      field.selectedMemberIndex = undefined;
+    } else if (field.wrapperKind === 'abstract' && field.selectedMemberQName) {
+      FieldOverrideService.revertFieldSubstitution(field, namespaceMap);
+    } else if (field.wrapperKind === 'sequence') {
+      for (const child of field.fields) {
+        WrapperSelectionService.clearWrapperSelection(child, namespaceMap);
+      }
     }
   }
 

--- a/packages/ui/src/services/visualization/choice-field.service.test.ts
+++ b/packages/ui/src/services/visualization/choice-field.service.test.ts
@@ -176,6 +176,22 @@ describe('ChoiceFieldService', () => {
 
       expect(result.childrenPreview).toBeUndefined();
     });
+
+    it('should use getChoiceMemberLabel for sequence wrapper fields', () => {
+      const field = mockField({
+        wrapperKind: 'sequence',
+        type: Types.Container,
+        fields: [mockField({ name: 'key', displayName: 'key' }), mockField({ name: 'value', displayName: 'value' })],
+      });
+      vi.mocked(VisualizationService.getChoiceMemberLabel).mockReturnValue('(key | value)');
+
+      const result = ChoiceFieldService.fieldToCandidate(field, '2', 2);
+
+      expect(result.label).toBe('(key | value)');
+      expect(result.typeBadge).toBe(Types.Container);
+      expect(result.selection).toEqual({ memberIndex: 2 });
+      expect(VisualizationService.getChoiceMemberLabel).toHaveBeenCalledWith(field);
+    });
   });
 
   describe('dissolveChoiceMembers', () => {
@@ -205,12 +221,26 @@ describe('ChoiceFieldService', () => {
       );
     });
 
-    it('should skip sequence members', () => {
-      const sequenceMember = mockField({ wrapperKind: 'sequence' });
+    it('should produce one candidate for a sequence member with dissolved label', () => {
+      const sequenceMember = mockField({
+        wrapperKind: 'sequence',
+        type: Types.Container,
+        fields: [mockField({ name: 'key', displayName: 'key' }), mockField({ name: 'value', displayName: 'value' })],
+      });
+      vi.mocked(VisualizationService.getChoiceMemberLabel).mockReturnValue('(key | value)');
 
       const result = ChoiceFieldService.dissolveChoiceMembers([sequenceMember], namespaceMap);
 
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          key: '0',
+          label: '(key | value)',
+          typeBadge: Types.Container,
+          selection: { memberIndex: 0 },
+        }),
+      );
+      expect(result[0].childrenPreview).toEqual(['key', 'value']);
     });
 
     it('should pass through normal members via fieldToCandidate', () => {
@@ -232,18 +262,24 @@ describe('ChoiceFieldService', () => {
     it('should handle mixed members in correct order', () => {
       const normal = mockField({ name: 'email', displayName: 'Email', type: Types.String });
       const abstract = mockField({ wrapperKind: 'abstract' });
-      const sequence = mockField({ wrapperKind: 'sequence' });
+      const sequence = mockField({
+        wrapperKind: 'sequence',
+        fields: [mockField({ name: 'key', displayName: 'key' }), mockField({ name: 'value', displayName: 'value' })],
+      });
       vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
         'ns:Cat': mockSubstituteInfo('Cat'),
       });
+      vi.mocked(VisualizationService.getChoiceMemberLabel).mockReturnValue('(key | value)');
 
       const result = ChoiceFieldService.dissolveChoiceMembers([normal, abstract, sequence], namespaceMap);
 
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
       expect(result[0].key).toBe('0');
       expect(result[0].selection.memberIndex).toBe(0);
       expect(result[1].key).toBe('1:ns:Cat');
       expect(result[1].selection.memberIndex).toBe(1);
+      expect(result[2].key).toBe('2');
+      expect(result[2].selection.memberIndex).toBe(2);
     });
   });
 
@@ -273,6 +309,16 @@ describe('ChoiceFieldService', () => {
       const result = ChoiceFieldService.getChoiceFieldDisplayName(field);
 
       expect(result).toBe('(A | B)');
+      expect(VisualizationService.getChoiceMemberLabel).toHaveBeenCalledWith(field);
+    });
+
+    it('should use getChoiceMemberLabel for sequence wrapper', () => {
+      const field = mockField({ wrapperKind: 'sequence' });
+      vi.mocked(VisualizationService.getChoiceMemberLabel).mockReturnValue('key, value');
+
+      const result = ChoiceFieldService.getChoiceFieldDisplayName(field);
+
+      expect(result).toBe('key, value');
       expect(VisualizationService.getChoiceMemberLabel).toHaveBeenCalledWith(field);
     });
 

--- a/packages/ui/src/services/visualization/choice-field.service.ts
+++ b/packages/ui/src/services/visualization/choice-field.service.ts
@@ -45,10 +45,13 @@ export class ChoiceFieldService extends WrapperBaseService {
   static resolveInfo(nodeData: NodeData): IChoiceNodeInfo {
     const field = VisualizationUtilService.getField(nodeData);
     const isChoiceWrapper = field?.wrapperKind === 'choice';
-    const isSelectedChoice = VisualizationUtilService.isSelectedChoiceField(nodeData);
+    // The enclosing choice wrapper when this node is a selected branch — a directly selected
+    // choice member (ChoiceFieldNodeData) or an xs:sequence selected as one branch
+    // (SequenceFieldNodeData). Both expose it via getSelectedChoiceWrapper.
+    const selectedChoiceWrapper = VisualizationUtilService.getSelectedChoiceWrapper(nodeData);
+    const isSelectedChoice = !!selectedChoiceWrapper;
 
-    const choiceMemberField =
-      VisualizationUtilService.isChoiceField(nodeData) && nodeData.choiceField ? nodeData.choiceField : field;
+    const choiceMemberField = selectedChoiceWrapper ?? field;
     const choiceMemberParent =
       choiceMemberField?.parent && 'wrapperKind' in choiceMemberField.parent ? choiceMemberField.parent : undefined;
     const isChoiceMember = choiceMemberParent?.wrapperKind === 'choice';
@@ -60,7 +63,7 @@ export class ChoiceFieldService extends WrapperBaseService {
 
     let choiceWrapperField: IField | undefined;
     if (isSelectedChoice) {
-      choiceWrapperField = WrapperSelectionService.resolveOutermostSelectedWrapper(nodeData.choiceField).outermost;
+      choiceWrapperField = WrapperSelectionService.resolveOutermostSelectedWrapper(selectedChoiceWrapper).outermost;
     } else if (isChoiceWrapper) {
       choiceWrapperField = field;
     }
@@ -88,18 +91,22 @@ export class ChoiceFieldService extends WrapperBaseService {
     };
   }
 
+  /**
+   * Resolves the display label for a choice/sequence member field. Choice and sequence wrappers
+   * have no meaningful `displayName`/`name` of their own (an anonymous `xs:sequence` synthesizes
+   * the literal `"sequence"`), so they're described via {@link VisualizationService.getChoiceMemberLabel}
+   * instead. Abstract wrappers are excluded — their own name (the substitution head element) is
+   * already meaningful, unlike the dissolved candidate list `getChoiceMemberLabel` would produce.
+   */
   static getChoiceFieldDisplayName(field: IField): string {
-    return field.wrapperKind === 'choice'
+    return field.wrapperKind === 'choice' || field.wrapperKind === 'sequence'
       ? VisualizationService.getChoiceMemberLabel(field)
       : field.displayName || field.name;
   }
 
   /** Converts a schema field into an {@link IWrapperCandidate} for inline menus and the selection modal. */
   static fieldToCandidate(field: IField, key: string, memberIndex: number): IWrapperCandidate {
-    const label =
-      field.wrapperKind === 'choice'
-        ? VisualizationService.getChoiceMemberLabel(field)
-        : field.displayName || field.name;
+    const label = ChoiceFieldService.getChoiceFieldDisplayName(field);
     return {
       key,
       label,
@@ -129,7 +136,8 @@ export class ChoiceFieldService extends WrapperBaseService {
           selection: { memberIndex: index, substituteQName: qname },
         }));
       }
-      if (member.wrapperKind === 'sequence') return [];
+      // Plain elements and xs:sequence branches both map to a single candidate; fieldToCandidate
+      // derives a dissolved "(child | child)" label for the sequence from its children.
       return [this.fieldToCandidate(member, String(index), index)];
     });
   }

--- a/packages/ui/src/services/visualization/field-candidate.service.test.ts
+++ b/packages/ui/src/services/visualization/field-candidate.service.test.ts
@@ -38,6 +38,12 @@ describe('FieldCandidateService', () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    // clearMocks (vitest.config.mts) clears call data but doesn't restore vi.spyOn implementations
+    // on static methods (e.g. resolveCandidateField), so later tests could see a stale spy.
+    vi.restoreAllMocks();
+  });
+
   describe('computeAddFieldCandidates', () => {
     function createXmlSchemaDocument(): XmlSchemaDocument {
       const definition = new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.XML_SCHEMA, 'test');
@@ -242,6 +248,88 @@ describe('FieldCandidateService', () => {
       expect(result.candidates).toHaveLength(2);
       expect(result.fields[0]).toBe(singleChild);
       expect(result.fields[1]).toBe(collectionChild);
+    });
+
+    it('should include sequence-in-choice element children as add-field candidates', () => {
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const choiceField = new XmlSchemaField(parent, '__choice__', false);
+      choiceField.type = Types.Container;
+      choiceField.wrapperKind = 'choice';
+      choiceField.maxOccurs = 1;
+      const seqWrapper = new XmlSchemaField(choiceField, '__sequence__', false);
+      seqWrapper.wrapperKind = 'sequence';
+      const seqChildKey = new XmlSchemaField(seqWrapper, 'key', false);
+      seqChildKey.type = Types.String;
+      const seqChildValue = new XmlSchemaField(seqWrapper, 'value', false);
+      seqChildValue.type = Types.String;
+      seqWrapper.fields = [seqChildKey, seqChildValue];
+      const directMember = new XmlSchemaField(choiceField, 'dataValue', false);
+      directMember.type = Types.String;
+      choiceField.fields = [directMember, seqWrapper];
+      parent.fields = [choiceField];
+      doc.fields = [parent];
+
+      const result = FieldCandidateService.computeAddFieldCandidates(parent.fields, {}, []);
+
+      // choiceField itself: 1 direct member + 2 sequence children = 3 entries
+      // but since choice maxOccurs=1 the whole wrapper is one slot; the resolveChoiceMembers
+      // is called inside resolveFieldEntries, so we get 3 candidate entries
+      expect(result.candidates).toHaveLength(3);
+      expect(result.fields[0]).toBe(directMember);
+      expect(result.fields[1]).toBe(seqChildKey);
+      expect(result.fields[2]).toBe(seqChildValue);
+    });
+
+    it('should dissolve a choice and an abstract wrapper nested inside a sequence-in-choice branch', () => {
+      // choice > [directOption, sequence[seqField, choice[innerA, innerB], abstract{Cat, Dog}]]
+      // per the XSD nestedParticle model, a sequence can contain further choice/abstract/sequence
+      // particles — those must be dissolved the same way as at the top level, not dropped.
+      const doc = createXmlSchemaDocument();
+      const parent = new XmlSchemaField(doc, 'Parent', false);
+      parent.type = Types.Container;
+      const choiceField = new XmlSchemaField(parent, '__choice__', false);
+      choiceField.wrapperKind = 'choice';
+      choiceField.maxOccurs = 1;
+      const directOption = new XmlSchemaField(choiceField, 'directOption', false);
+      directOption.type = Types.String;
+
+      const seqWrapper = new XmlSchemaField(choiceField, '__sequence__', false);
+      seqWrapper.wrapperKind = 'sequence';
+      const seqField = new XmlSchemaField(seqWrapper, 'seqField', false);
+      seqField.type = Types.String;
+
+      const innerChoice = new XmlSchemaField(seqWrapper, '__choice__', false);
+      innerChoice.wrapperKind = 'choice';
+      const innerA = new XmlSchemaField(innerChoice, 'innerA', false);
+      innerA.type = Types.String;
+      const innerB = new XmlSchemaField(innerChoice, 'innerB', false);
+      innerB.type = Types.String;
+      innerChoice.fields = [innerA, innerB];
+
+      const abstractField = new XmlSchemaField(seqWrapper, 'payload', false);
+      abstractField.wrapperKind = 'abstract';
+      const catField = new XmlSchemaField(abstractField, 'Cat', false);
+      const dogField = new XmlSchemaField(abstractField, 'Dog', false);
+      abstractField.fields = [catField, dogField];
+
+      seqWrapper.fields = [seqField, innerChoice, abstractField];
+      choiceField.fields = [directOption, seqWrapper];
+      parent.fields = [choiceField];
+      doc.fields = [parent];
+
+      vi.mocked(FieldOverrideService.getFieldSubstitutionCandidates).mockReturnValue({
+        'ns:Cat': mockSubstituteInfo('Cat'),
+        'ns:Dog': mockSubstituteInfo('Dog'),
+      });
+      vi.spyOn(FieldCandidateService, 'resolveCandidateField').mockImplementation((_wrapper, qname) =>
+        qname === 'ns:Cat' ? catField : dogField,
+      );
+
+      const result = FieldCandidateService.computeAddFieldCandidates(parent.fields, {}, []);
+
+      expect(result.fields).toEqual([directOption, seqField, innerA, innerB, catField, dogField]);
     });
 
     it('should dissolve sequences and apply forEachContext filter to members', () => {

--- a/packages/ui/src/services/visualization/field-candidate.service.ts
+++ b/packages/ui/src/services/visualization/field-candidate.service.ts
@@ -97,7 +97,13 @@ export class FieldCandidateService extends WrapperBaseService {
     for (const member of choiceField.fields) {
       if (member.wrapperKind === 'abstract') {
         entries.push(...this.resolveAbstractSubstitutes(member, namespaceMap));
-      } else if (member.wrapperKind !== 'sequence') {
+      } else if (member.wrapperKind === 'sequence') {
+        // Delegate to the general recursive resolver so choice/abstract/sequence nested inside
+        // the sequence branch (per the XSD nestedParticle model) are dissolved the same way as
+        // at the top level, instead of being dropped.
+        const nested = this.computeAddFieldCandidates(member.fields, namespaceMap);
+        entries.push(...nested.candidates.map((candidate, i) => ({ candidate, field: nested.fields[i] })));
+      } else {
         entries.push({ candidate: ChoiceFieldService.fieldToCandidate(member, '', 0), field: member });
       }
     }

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -37,6 +37,7 @@ import {
   getShipOrderToShipOrderMultipleForEachXslt,
   getShipOrderToShipOrderXslt,
   getShipOrderWithCurrentXslt,
+  getTestDocumentXsd,
   getX12837PDfdlXsd,
   getX12837PXslt,
   getX12850DfdlXsd,
@@ -488,6 +489,55 @@ describe('MappingLinksService', () => {
       );
       expect(links[0].targetNodePath).not.toContain(abstractField.id);
       expect(links[0].targetNodePath).not.toContain(unboundedChoiceField.id);
+    });
+
+    it('should include the sequence wrapper segment for a field mapped inside a selected sequence-in-choice branch (#3802)', () => {
+      // Regression: selecting a sequence branch of a choice must not change how mapping links
+      // for its children resolve. The sequence's own field.id is a real intermediate segment
+      // (it renders as its own node, unlike a selected choice/abstract member which is replaced
+      // by its selection), and the mapped field itself must use its own FieldItem id — not its
+      // schema field id — otherwise the link points at a path with no matching rendered node.
+      const targetDefinition = new DocumentDefinition(
+        DocumentType.TARGET_BODY,
+        DocumentDefinitionType.XML_SCHEMA,
+        BODY_DOCUMENT_ID,
+        { 'testDocument.xsd': getTestDocumentXsd() },
+      );
+      const seqTargetDoc = XmlSchemaDocumentService.createXmlSchemaDocument(targetDefinition).document!;
+      const seqTree = new MappingTree(
+        seqTargetDoc.documentType,
+        seqTargetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+
+      const rootField = seqTargetDoc.fields[0];
+      DocumentUtilService.resolveTypeFragment(rootField);
+      const seqInChoiceField = rootField.fields.find((f: IField) => f.name === 'SequenceInChoiceElement')!;
+      DocumentUtilService.resolveTypeFragment(seqInChoiceField);
+      const choiceField = seqInChoiceField.fields.find((f: IField) => f.wrapperKind === 'choice')!;
+      const sequenceField = choiceField.fields.find((f: IField) => f.wrapperKind === 'sequence')!;
+      const keyField = sequenceField.fields.find((f: IField) => f.name === 'key')!;
+
+      choiceField.selectedMemberIndex = choiceField.fields.indexOf(sequenceField);
+
+      seqTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+      const rootItem = new FieldItem(seqTree, rootField);
+      seqTree.children.push(rootItem);
+      const seqInChoiceItem = new FieldItem(rootItem, seqInChoiceField);
+      rootItem.children.push(seqInChoiceItem);
+      // The mapping tree has no counterpart for the sequence compositor — key's FieldItem is a
+      // direct child of seqInChoiceItem, matching MappingActionService.getOrCreateFieldItem.
+      const keyItem = new FieldItem(seqInChoiceItem, keyField);
+      seqInChoiceItem.children.push(keyItem);
+      const valueSelector = new ValueOfSelector(keyItem);
+      valueSelector.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      keyItem.children.push(valueSelector);
+
+      const links = MappingLinksService.extractMappingLinks(seqTree, paramsMap, sourceDoc);
+      expect(links).toHaveLength(1);
+      expect(links[0].targetNodePath).toBe(
+        `targetBody:Body://${rootItem.id}/${seqInChoiceItem.id}/${sequenceField.id}/${keyItem.id}`,
+      );
     });
   });
 

--- a/packages/ui/src/services/visualization/visualization-util.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.test.ts
@@ -6,6 +6,7 @@ import {
   DocumentNodeData,
   FieldItemNodeData,
   FieldNodeData,
+  SequenceFieldNodeData,
   TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
   TargetDocumentNodeData,
@@ -142,6 +143,72 @@ describe('VisualizationUtilService', () => {
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, substituteField);
       abstractNode.abstractField = wrapperField;
       expect(VisualizationUtilService.isCollectionField(abstractNode)).toBe(false);
+    });
+
+    it('should return true for a selected sequence branch when the enclosing choice is a collection', () => {
+      // The enclosing collection choice may sit above intermediate wrappers, so the sequence's own
+      // maxOccurs (and its direct parent) are 1 — collection status comes from the choice back-ref.
+      const choiceWrapper = createMockField(sourceDoc.fields[0], { name: '__choice__', maxOccurs: 'unbounded' });
+      const sequenceField = createMockField(sourceDoc.fields[0], { name: '__sequence__', maxOccurs: 1 });
+      const sequenceNode = new SequenceFieldNodeData(sourceDocNode, sequenceField);
+      sequenceNode.choiceField = choiceWrapper;
+      expect(VisualizationUtilService.isCollectionField(sequenceNode)).toBe(true);
+    });
+
+    it('should return false for a selected sequence branch when the enclosing choice is not a collection', () => {
+      const choiceWrapper = createMockField(sourceDoc.fields[0], { name: '__choice__', maxOccurs: 1 });
+      const sequenceField = createMockField(sourceDoc.fields[0], { name: '__sequence__', maxOccurs: 1 });
+      const sequenceNode = new SequenceFieldNodeData(sourceDocNode, sequenceField);
+      sequenceNode.choiceField = choiceWrapper;
+      expect(VisualizationUtilService.isCollectionField(sequenceNode)).toBe(false);
+    });
+
+    it('should return true for a source child of a sequence branch inside a collection choice', () => {
+      // choice(unbounded) > sequence(1) > key(1): on the source side the child is a plain
+      // FieldNodeData whose collection status comes from DocumentService walking up the
+      // transparent sequence compositor to the repeating choice.
+      const choiceWrapper = createMockField(sourceDoc.fields[0], {
+        name: '__choice__',
+        maxOccurs: 'unbounded',
+        wrapperKind: 'choice',
+      });
+      const sequenceField = createMockField(sourceDoc.fields[0], {
+        name: '__sequence__',
+        maxOccurs: 1,
+        wrapperKind: 'sequence',
+        parent: choiceWrapper,
+      });
+      const keyField = createMockField(sourceDoc.fields[0], { name: 'key', maxOccurs: 1, parent: sequenceField });
+      const seqNode = new SequenceFieldNodeData(sourceDocNode, sequenceField);
+      seqNode.choiceField = choiceWrapper;
+      const keyNode = new FieldNodeData(seqNode, keyField);
+      expect(VisualizationUtilService.isCollectionField(keyNode)).toBe(true);
+    });
+  });
+
+  describe('isSequenceNode', () => {
+    it('should return true for a SequenceFieldNodeData', () => {
+      const sequenceField = createMockField(sourceDoc.fields[0], { name: '__sequence__', wrapperKind: 'sequence' });
+      const sequenceNode = new SequenceFieldNodeData(sourceDocNode, sequenceField);
+      expect(VisualizationUtilService.isSequenceNode(sequenceNode)).toBe(true);
+    });
+
+    it('should return true for a per-instance FieldItemNodeData whose field is a sequence', () => {
+      // A repeating (maxOccurs>1) choice renders its selected sequence branch as a FieldItemNodeData
+      // (not a SequenceFieldNodeData), so it must still be recognised as a sequence for the badge.
+      const sequenceField = createMockField(targetDoc.fields[0], { name: '__sequence__', wrapperKind: 'sequence' });
+      const fieldItem = new FieldItem(targetDocNode.mappingTree, sequenceField);
+      const fieldItemNode = new FieldItemNodeData(targetDocNode, fieldItem);
+      expect(VisualizationUtilService.isSequenceNode(fieldItemNode)).toBe(true);
+    });
+
+    it('should return false for a non-sequence FieldNodeData', () => {
+      const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
+      expect(VisualizationUtilService.isSequenceNode(fieldNode)).toBe(false);
+    });
+
+    it('should return false for a document node', () => {
+      expect(VisualizationUtilService.isSequenceNode(sourceDocNode)).toBe(false);
     });
   });
 

--- a/packages/ui/src/services/visualization/visualization-util.service.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.ts
@@ -41,8 +41,12 @@ export class VisualizationUtilService {
       return DocumentService.isCollectionField(nodeData.wrapperField);
     }
     if (DocumentService.isCollectionField(nodeData.field)) return true;
-    if (VisualizationUtilService.isChoiceField(nodeData)) {
-      return !!nodeData.choiceField && DocumentService.isCollectionField(nodeData.choiceField);
+    // A selected choice branch (choice member or an xs:sequence branch) inherits the repeating
+    // nature from its enclosing choice, which may sit above intermediate wrappers — so read it
+    // from the choice back-reference rather than the node's direct parent.
+    const selectedChoiceWrapper = VisualizationUtilService.getSelectedChoiceWrapper(nodeData);
+    if (selectedChoiceWrapper) {
+      return DocumentService.isCollectionField(selectedChoiceWrapper);
     }
     if (VisualizationUtilService.isAbstractField(nodeData)) {
       return !!nodeData.abstractField && DocumentService.isCollectionField(nodeData.abstractField);
@@ -72,12 +76,28 @@ export class VisualizationUtilService {
   }
 
   /**
-   * Returns `true` if the node is a choice field with a selected member (choiceField is set).
-   * Delegates to {@link isChoiceField} for the type check to avoid duplicating `instanceof` guards.
+   * Returns the enclosing choice wrapper of a node that represents a *selected* choice branch,
+   * or `undefined`. Both {@link ChoiceFieldNodeData} (a directly selected member) and
+   * {@link SequenceFieldNodeData} (an xs:sequence selected as one choice branch) carry this
+   * back-reference in their `choiceField`; this helper is the single place that knows which node
+   * types do, so the selection/menu code does not need per-type `instanceof` chains.
+   * @param nodeData - The node to inspect.
+   */
+  static getSelectedChoiceWrapper(nodeData: NodeData): IField | undefined {
+    if (VisualizationUtilService.isChoiceField(nodeData)) return nodeData.choiceField;
+    if (VisualizationUtilService.isSequenceField(nodeData)) return nodeData.choiceField;
+    return undefined;
+  }
+
+  /**
+   * Returns `true` if the node represents a choice branch that has a member selected. This is
+   * true for a {@link ChoiceFieldNodeData} with `choiceField` set, and also for a
+   * {@link SequenceFieldNodeData} rendered as the selected branch of an xs:choice — both cases
+   * are detected via {@link getSelectedChoiceWrapper}.
    * @param nodeData - The node to test.
    */
-  static isSelectedChoiceField(nodeData: NodeData): nodeData is ChoiceFieldNodeData | TargetChoiceFieldNodeData {
-    return VisualizationUtilService.isChoiceField(nodeData) && !!nodeData.choiceField;
+  static isSelectedChoiceField(nodeData: NodeData): boolean {
+    return !!VisualizationUtilService.getSelectedChoiceWrapper(nodeData);
   }
 
   /**
@@ -110,7 +130,10 @@ export class VisualizationUtilService {
    * @param nodeData - The node to test.
    */
   static isSelectedNestedChoice(nodeData: NodeData): boolean {
-    return VisualizationUtilService.isSelectedChoiceField(nodeData) && nodeData.field.wrapperKind === 'choice';
+    return (
+      VisualizationUtilService.isSelectedChoiceField(nodeData) &&
+      VisualizationUtilService.getField(nodeData)?.wrapperKind === 'choice'
+    );
   }
 
   /**
@@ -120,8 +143,9 @@ export class VisualizationUtilService {
    * Returns 0 for non-choice nodes.
    */
   static getSelectedChoiceDepth(nodeData: NodeData): number {
-    if (!VisualizationUtilService.isSelectedChoiceField(nodeData)) return 0;
-    return WrapperSelectionService.resolveOutermostSelectedWrapper(nodeData.choiceField).depth;
+    const choiceWrapper = VisualizationUtilService.getSelectedChoiceWrapper(nodeData);
+    if (!choiceWrapper) return 0;
+    return WrapperSelectionService.resolveOutermostSelectedWrapper(choiceWrapper).depth;
   }
 
   /**
@@ -182,6 +206,20 @@ export class VisualizationUtilService {
    */
   static isSequenceField(nodeData: NodeData): nodeData is SequenceFieldNodeData | TargetSequenceFieldNodeData {
     return nodeData instanceof SequenceFieldNodeData || nodeData instanceof TargetSequenceFieldNodeData;
+  }
+
+  /**
+   * Returns `true` if the node should render as an xs:sequence (i.e. show the "sequence" badge
+   * instead of a title). Unlike {@link isSequenceField}, this also matches a per-instance
+   * {@link FieldItemNodeData} whose own field is a sequence — the shape a repeating (maxOccurs>1)
+   * choice's selected sequence branch takes (built directly in generateCollectionWrapperNodes,
+   * bypassing {@link SequenceFieldNodeData}). Both must render identically as a bare "sequence"
+   * badge, since a sequence's synthetic `displayName` ("sequence") is never a meaningful title and
+   * its children are already shown as individual sub-nodes.
+   * @param nodeData - The node to test.
+   */
+  static isSequenceNode(nodeData: NodeData): boolean {
+    return VisualizationUtilService.getField(nodeData)?.wrapperKind === 'sequence';
   }
 
   /**

--- a/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
@@ -364,32 +364,32 @@ describe('VisualizationService / abstract fields', () => {
     it('should return candidate names joined with | in parentheses', () => {
       const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }, { name: 'Fish' }]);
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
-      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('(Cat | Dog | Fish)');
+      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('Cat | Dog | Fish');
     });
 
-    it('should return "(no candidates)" for abstract with no candidates', () => {
+    it('should return "no candidates" for abstract with no candidates', () => {
       const abstractField = createMockAbstractField([]);
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
-      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('(no candidates)');
+      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('no candidates');
     });
 
     it('should truncate long candidate lists showing first 3 and count', () => {
       const candidates = Array.from({ length: 10 }, (_, i) => ({ name: `animal${i}` }));
       const abstractField = createMockAbstractField(candidates);
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
-      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('(animal0 | animal1 | animal2 | +7 more)');
+      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('animal0 | animal1 | animal2 | +7 more');
     });
 
     it('should handle single candidate without truncation', () => {
       const abstractField = createMockAbstractField([{ name: 'Cat' }]);
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
-      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('(Cat)');
+      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('Cat');
     });
 
     it('should handle exactly 3 candidates without truncation', () => {
       const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }, { name: 'Fish' }]);
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
-      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('(Cat | Dog | Fish)');
+      expect(VisualizationService.getAbstractMemberLabel(abstractNode)).toBe('Cat | Dog | Fish');
     });
   });
 
@@ -397,7 +397,7 @@ describe('VisualizationService / abstract fields', () => {
     it('should return candidate label for unselected abstract wrapper (no abstractField)', () => {
       const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }]);
       const abstractNode = new AbstractFieldNodeData(sourceDocNode, abstractField);
-      expect(VisualizationService.createNodeTitle(abstractNode)).toBe('(Cat | Dog)');
+      expect(VisualizationService.createNodeTitle(abstractNode)).toBe('Cat | Dog');
     });
 
     it('should return nodeData.title for selected abstract candidate (abstractField set)', () => {
@@ -421,7 +421,7 @@ describe('VisualizationService / abstract fields', () => {
     it('should return candidate label for unselected TargetAbstractFieldNodeData', () => {
       const abstractField = createMockAbstractField([{ name: 'Cat' }, { name: 'Dog' }]);
       const abstractNode = new TargetAbstractFieldNodeData(targetDocNode, abstractField);
-      expect(VisualizationService.createNodeTitle(abstractNode)).toBe('(Cat | Dog)');
+      expect(VisualizationService.createNodeTitle(abstractNode)).toBe('Cat | Dog');
     });
   });
 
@@ -975,7 +975,7 @@ describe('VisualizationService / abstract fields', () => {
         (c) => c instanceof FieldItemNodeData && c.field.wrapperKind === 'abstract',
       ) as FieldItemNodeData;
       expect(wrapperNode).toBeDefined();
-      expect(VisualizationService.createNodeTitle(wrapperNode)).toBe('(Cat | Dog | Fish | +1 more)');
+      expect(VisualizationService.createNodeTitle(wrapperNode)).toBe('Cat | Dog | Fish | +1 more');
     });
 
     it('createNodeTitle should return candidate list label for AddMappingNodeData with abstract wrapper field', () => {
@@ -989,7 +989,7 @@ describe('VisualizationService / abstract fields', () => {
       const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
       const addNode = children.find((c) => c instanceof AddMappingNodeData) as AddMappingNodeData;
       expect(addNode).toBeDefined();
-      expect(VisualizationService.createNodeTitle(addNode)).toBe('(Cat | Dog | Fish | +1 more)');
+      expect(VisualizationService.createNodeTitle(addNode)).toBe('Cat | Dog | Fish | +1 more');
     });
   });
 
@@ -1129,7 +1129,7 @@ describe('VisualizationService / abstract fields', () => {
       ) as FieldItemNodeData;
       expect(wrapperNode).toBeDefined();
       expect(wrapperNode.wrapperField).toBe(abstractField);
-      expect(VisualizationService.createNodeTitle(wrapperNode)).toBe('(Cat | Dog)');
+      expect(VisualizationService.createNodeTitle(wrapperNode)).toBe('Cat | Dog');
 
       const leafChildren = VisualizationService.generateNonDocumentNodeDataChildren(wrapperNode);
       expect(leafChildren).toHaveLength(0);

--- a/packages/ui/src/services/visualization/visualization.service.choice.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.choice.test.ts
@@ -21,6 +21,7 @@ import {
   FieldItemNodeData,
   FieldNodeData,
   MappingNodeData,
+  SequenceFieldNodeData,
   TargetAbstractFieldNodeData,
   TargetChoiceFieldNodeData,
   TargetDocumentNodeData,
@@ -34,6 +35,8 @@ import { WrapperSelectionService } from '../document/wrapper-selection.service';
 import { XmlSchemaDocument } from '../document/xml-schema/xml-schema-document.model';
 import { XmlSchemaDocumentService } from '../document/xml-schema/xml-schema-document.service';
 import { MappingService } from '../mapping/mapping.service';
+import { AbstractFieldService } from './abstract-field.service';
+import { ChoiceFieldService } from './choice-field.service';
 import { MappingActionService } from './mapping-action.service';
 import { VisualizationService } from './visualization.service';
 import { VisualizationUtilService } from './visualization-util.service';
@@ -290,7 +293,7 @@ describe('VisualizationService / choice fields', () => {
         const choiceNode = choiceElementChildren[0] as ChoiceFieldNodeData;
         expect(choiceNode).toBeInstanceOf(ChoiceFieldNodeData);
         expect(choiceNode.title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(choiceNode)).toBe('(Choice1 | Choice2 | Group1Element1 | +1 more)');
+        expect(VisualizationService.createNodeTitle(choiceNode)).toBe('Choice1 | Choice2 | Group1Element1 | +1 more');
         const members = VisualizationService.generateNonDocumentNodeDataChildren(choiceNode);
         expect(members).toHaveLength(4);
         expect(members[0].title).toBe('Choice1');
@@ -305,10 +308,10 @@ describe('VisualizationService / choice fields', () => {
         expect(children).toHaveLength(2);
         expect(children[0]).toBeInstanceOf(ChoiceFieldNodeData);
         expect(children[0].title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(children[0] as ChoiceFieldNodeData)).toBe('(SibA1 | SibA2)');
+        expect(VisualizationService.createNodeTitle(children[0] as ChoiceFieldNodeData)).toBe('SibA1 | SibA2');
         expect(children[1]).toBeInstanceOf(ChoiceFieldNodeData);
         expect(children[1].title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(children[1] as ChoiceFieldNodeData)).toBe('(SibB1 | SibB2)');
+        expect(VisualizationService.createNodeTitle(children[1] as ChoiceFieldNodeData)).toBe('SibB1 | SibB2');
         const firstMembers = VisualizationService.generateNonDocumentNodeDataChildren(
           children[0] as ChoiceFieldNodeData,
         );
@@ -330,7 +333,7 @@ describe('VisualizationService / choice fields', () => {
         const outerChoiceNode = outerChoiceChildren[0] as ChoiceFieldNodeData;
         expect(outerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
         expect(outerChoiceNode.title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(outerChoiceNode)).toBe('(Direct1 | NestedDirect1 | NestedDirect2)');
+        expect(VisualizationService.createNodeTitle(outerChoiceNode)).toBe('Direct1 | NestedDirect1 | NestedDirect2');
         const outerMembers = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
         expect(outerMembers).toHaveLength(2);
         expect(outerMembers[0]).not.toBeInstanceOf(ChoiceFieldNodeData);
@@ -338,7 +341,7 @@ describe('VisualizationService / choice fields', () => {
         const innerChoiceNode = outerMembers[1] as ChoiceFieldNodeData;
         expect(innerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
         expect(innerChoiceNode.title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(innerChoiceNode)).toBe('(NestedDirect1 | NestedDirect2)');
+        expect(VisualizationService.createNodeTitle(innerChoiceNode)).toBe('NestedDirect1 | NestedDirect2');
         const innerMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceNode);
         expect(innerMembers).toHaveLength(2);
         expect(innerMembers[0].title).toBe('NestedDirect1');
@@ -352,17 +355,17 @@ describe('VisualizationService / choice fields', () => {
         const outerChoiceNode = outerChoiceChildren[0] as ChoiceFieldNodeData;
         expect(outerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
         expect(outerChoiceNode.title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(outerChoiceNode)).toBe('(InnerA1 | InnerA2 | InnerB1 | +1 more)');
+        expect(VisualizationService.createNodeTitle(outerChoiceNode)).toBe('InnerA1 | InnerA2 | InnerB1 | +1 more');
         const outerMembers = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
         expect(outerMembers).toHaveLength(2);
         const innerChoiceA = outerMembers[0] as ChoiceFieldNodeData;
         expect(innerChoiceA).toBeInstanceOf(ChoiceFieldNodeData);
         expect(innerChoiceA.title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(innerChoiceA)).toBe('(InnerA1 | InnerA2)');
+        expect(VisualizationService.createNodeTitle(innerChoiceA)).toBe('InnerA1 | InnerA2');
         const innerChoiceB = outerMembers[1] as ChoiceFieldNodeData;
         expect(innerChoiceB).toBeInstanceOf(ChoiceFieldNodeData);
         expect(innerChoiceB.title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(innerChoiceB)).toBe('(InnerB1 | InnerB2)');
+        expect(VisualizationService.createNodeTitle(innerChoiceB)).toBe('InnerB1 | InnerB2');
         const innerAMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceA);
         expect(innerAMembers).toHaveLength(2);
         expect(innerAMembers[0].title).toBe('InnerA1');
@@ -380,20 +383,20 @@ describe('VisualizationService / choice fields', () => {
         const outerChoiceNode = outerChoiceChildren[0] as ChoiceFieldNodeData;
         expect(outerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
         expect(outerChoiceNode.title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(outerChoiceNode)).toBe('(InnerA1 | InnerA2 | InnerB1 | +7 more)');
+        expect(VisualizationService.createNodeTitle(outerChoiceNode)).toBe('InnerA1 | InnerA2 | InnerB1 | +7 more');
         const outerMembers = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
         expect(outerMembers).toHaveLength(5);
         const innerChoices = outerMembers as ChoiceFieldNodeData[];
         expect(innerChoices[0]).toBeInstanceOf(ChoiceFieldNodeData);
-        expect(VisualizationService.createNodeTitle(innerChoices[0])).toBe('(InnerA1 | InnerA2)');
+        expect(VisualizationService.createNodeTitle(innerChoices[0])).toBe('InnerA1 | InnerA2');
         expect(innerChoices[1]).toBeInstanceOf(ChoiceFieldNodeData);
-        expect(VisualizationService.createNodeTitle(innerChoices[1])).toBe('(InnerB1 | InnerB2)');
+        expect(VisualizationService.createNodeTitle(innerChoices[1])).toBe('InnerB1 | InnerB2');
         expect(innerChoices[2]).toBeInstanceOf(ChoiceFieldNodeData);
-        expect(VisualizationService.createNodeTitle(innerChoices[2])).toBe('(InnerC1 | InnerC2)');
+        expect(VisualizationService.createNodeTitle(innerChoices[2])).toBe('InnerC1 | InnerC2');
         expect(innerChoices[3]).toBeInstanceOf(ChoiceFieldNodeData);
-        expect(VisualizationService.createNodeTitle(innerChoices[3])).toBe('(InnerD1 | InnerD2)');
+        expect(VisualizationService.createNodeTitle(innerChoices[3])).toBe('InnerD1 | InnerD2');
         expect(innerChoices[4]).toBeInstanceOf(ChoiceFieldNodeData);
-        expect(VisualizationService.createNodeTitle(innerChoices[4])).toBe('(InnerE1 | InnerE2)');
+        expect(VisualizationService.createNodeTitle(innerChoices[4])).toBe('InnerE1 | InnerE2');
         const innerAMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoices[0]);
         expect(innerAMembers).toHaveLength(2);
         expect(innerAMembers[0].title).toBe('InnerA1');
@@ -412,7 +415,7 @@ describe('VisualizationService / choice fields', () => {
         expect(outerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
         expect(outerChoiceNode.title).toBe('choice');
         expect(VisualizationService.createNodeTitle(outerChoiceNode)).toBe(
-          '(Indirect1 | ChoiceGroupEl1 | ChoiceGroupEl2)',
+          'Indirect1 | ChoiceGroupEl1 | ChoiceGroupEl2',
         );
         const outerMembers = VisualizationService.generateNonDocumentNodeDataChildren(outerChoiceNode);
         expect(outerMembers).toHaveLength(2);
@@ -421,11 +424,96 @@ describe('VisualizationService / choice fields', () => {
         const innerChoiceNode = outerMembers[1] as ChoiceFieldNodeData;
         expect(innerChoiceNode).toBeInstanceOf(ChoiceFieldNodeData);
         expect(innerChoiceNode.title).toBe('choice');
-        expect(VisualizationService.createNodeTitle(innerChoiceNode)).toBe('(ChoiceGroupEl1 | ChoiceGroupEl2)');
+        expect(VisualizationService.createNodeTitle(innerChoiceNode)).toBe('ChoiceGroupEl1 | ChoiceGroupEl2');
         const innerMembers = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceNode);
         expect(innerMembers).toHaveLength(2);
         expect(innerMembers[0].title).toBe('ChoiceGroupEl1');
         expect(innerMembers[1].title).toBe('ChoiceGroupEl2');
+      });
+
+      // Regression for #3802: an xs:sequence selected as a choice branch must render as a
+      // sequence node (not "abstract") and its selection must be clearable.
+      describe('sequence selected inside a choice (#3802)', () => {
+        function getSequenceInChoiceNode() {
+          const seqInChoiceNode = testDocumentChildren.find((n) => n.title === 'SequenceInChoiceElement')!;
+          const choiceNode = VisualizationService.generateNonDocumentNodeDataChildren(seqInChoiceNode)[0];
+          const choice = (choiceNode as ChoiceFieldNodeData).field;
+          const seqIndex = choice.fields.findIndex((f) => f.wrapperKind === 'sequence');
+          return { seqInChoiceNode, choice, seqIndex };
+        }
+
+        it('renders the selected sequence branch as a SequenceFieldNodeData showing its children', () => {
+          const { seqInChoiceNode, choice, seqIndex } = getSequenceInChoiceNode();
+          ChoiceFieldService.dispatchChoiceSelection(seqInChoiceNode, choice, { memberIndex: seqIndex }, {}, false);
+
+          const selectedNode = VisualizationService.generateNonDocumentNodeDataChildren(seqInChoiceNode)[0];
+          expect(selectedNode).toBeInstanceOf(SequenceFieldNodeData);
+          // badge: sequence, not abstract
+          expect(VisualizationUtilService.isSequenceField(selectedNode)).toBe(true);
+          expect(VisualizationUtilService.isUnselectedAbstractField(selectedNode)).toBe(false);
+          // the enclosing choice is recognised as a selected branch (so the menu offers Change/Clear)
+          expect(VisualizationUtilService.isSelectedChoiceField(selectedNode)).toBe(true);
+          expect(ChoiceFieldService.resolveInfo(selectedNode).choiceWrapperField).toBe(choice);
+          // title shows the sequence's own children, not the synthetic literal "sequence"
+          expect(VisualizationService.createNodeTitle(selectedNode)).toBe('key, value');
+          // children of the sequence branch are shown
+          const members = VisualizationService.generateNonDocumentNodeDataChildren(selectedNode);
+          expect(members.map((m) => m.title)).toEqual(['key', 'value']);
+        });
+
+        it('shows a descriptive title (not the literal "sequence") when previewing an unselected sequence candidate', () => {
+          const { seqInChoiceNode } = getSequenceInChoiceNode();
+          const choiceNode = VisualizationService.generateNonDocumentNodeDataChildren(seqInChoiceNode)[0];
+          const previewMembers = VisualizationService.generateNonDocumentNodeDataChildren(choiceNode);
+          const previewSequence = previewMembers.find((m) => m instanceof SequenceFieldNodeData)!;
+          expect(previewSequence).toBeDefined();
+          expect(VisualizationService.createNodeTitle(previewSequence)).toBe('key, value');
+        });
+
+        it('does not expose an abstract substitution menu on the selected sequence branch', () => {
+          const { seqInChoiceNode, choice, seqIndex } = getSequenceInChoiceNode();
+          ChoiceFieldService.dispatchChoiceSelection(seqInChoiceNode, choice, { memberIndex: seqIndex }, {}, false);
+          const selectedNode = VisualizationService.generateNonDocumentNodeDataChildren(seqInChoiceNode)[0];
+
+          const abstractInfo = AbstractFieldService.resolveInfo(selectedNode, {});
+          expect(abstractInfo.isSelectedSubstitution).toBe(false);
+          expect(abstractInfo.abstractWrapperField).toBeUndefined();
+        });
+
+        it('clears the sequence selection, reverting to the unselected choice wrapper', () => {
+          const { seqInChoiceNode, choice, seqIndex } = getSequenceInChoiceNode();
+          ChoiceFieldService.dispatchChoiceSelection(seqInChoiceNode, choice, { memberIndex: seqIndex }, {}, false);
+          expect(choice.selectedMemberIndex).toBe(seqIndex);
+
+          const selectedNode = VisualizationService.generateNonDocumentNodeDataChildren(seqInChoiceNode)[0];
+          ChoiceFieldService.clearChoiceSelectionOnField(selectedNode, choice, {}, false);
+          expect(choice.selectedMemberIndex).toBeUndefined();
+
+          const revertedNode = VisualizationService.generateNonDocumentNodeDataChildren(seqInChoiceNode)[0];
+          expect(revertedNode).toBeInstanceOf(ChoiceFieldNodeData);
+          expect(VisualizationUtilService.isUnselectedChoiceField(revertedNode)).toBe(true);
+        });
+
+        // GAP 1: a choice nested inside the selected sequence branch must be cleared when the
+        // outer choice is cleared (consistent with choice>choice).
+        it('clearing the outer choice also clears a choice nested inside the selected sequence', () => {
+          const outerNode = testDocumentChildren.find((n) => n.title === 'NestedChoiceInSequenceElement')!;
+          const outerChoice = (
+            VisualizationService.generateNonDocumentNodeDataChildren(outerNode)[0] as ChoiceFieldNodeData
+          ).field;
+          const seqIndex = outerChoice.fields.findIndex((f) => f.wrapperKind === 'sequence');
+
+          ChoiceFieldService.dispatchChoiceSelection(outerNode, outerChoice, { memberIndex: seqIndex }, {}, false);
+          const innerChoice = outerChoice.fields[seqIndex].fields.find((f) => f.wrapperKind === 'choice')!;
+          ChoiceFieldService.dispatchChoiceSelection(outerNode, innerChoice, { memberIndex: 0 }, {}, false);
+          expect(innerChoice.selectedMemberIndex).toBe(0);
+
+          const selectedNode = VisualizationService.generateNonDocumentNodeDataChildren(outerNode)[0];
+          ChoiceFieldService.clearChoiceSelectionOnField(selectedNode, outerChoice, {}, false);
+
+          expect(outerChoice.selectedMemberIndex).toBeUndefined();
+          expect(innerChoice.selectedMemberIndex).toBeUndefined();
+        });
       });
     });
   });
@@ -690,14 +778,14 @@ describe('VisualizationService / choice fields', () => {
   });
 
   describe('getChoiceMemberLabel', () => {
-    it('should return member names joined with | in parentheses', () => {
+    it('should return member names joined with |', () => {
       const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }, { name: 'fax' }]);
-      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('(email | phone | fax)');
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('email | phone | fax');
     });
 
-    it('should return "(empty)" for a choice with no members', () => {
+    it('should return "empty" for a choice with no members', () => {
       const choiceField = createMockChoiceField([]);
-      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('(empty)');
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('empty');
     });
 
     it('should dissolve a nested choice into its inner member names', () => {
@@ -719,7 +807,7 @@ describe('VisualizationService / choice fields', () => {
         wrapperKind: 'choice' as const,
         fields: [innerChoice, { ...baseField, name: 'direct', displayName: 'direct', fields: [] }],
       } as unknown as typeof baseField;
-      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('(InnerA | InnerB | direct)');
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('InnerA | InnerB | direct');
     });
 
     it('should fall back to nested choice displayName when it has no members', () => {
@@ -745,13 +833,13 @@ describe('VisualizationService / choice fields', () => {
         wrapperKind: 'choice' as const,
         fields: [inner1, inner2],
       } as unknown as typeof baseField;
-      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('(choice | choice)');
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('choice | choice');
     });
 
     it('should truncate long member lists showing first 3 and count', () => {
       const members = Array.from({ length: 10 }, (_, i) => ({ name: `member${i}` }));
       const choiceField = createMockChoiceField(members);
-      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('(member0 | member1 | member2 | +7 more)');
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('member0 | member1 | member2 | +7 more');
     });
 
     it('should dissolve abstract member into its substitution candidate names', () => {
@@ -773,7 +861,118 @@ describe('VisualizationService / choice fields', () => {
         wrapperKind: 'choice' as const,
         fields: [abstractMember, { ...baseField, name: 'Webhook', displayName: 'Webhook', fields: [] }],
       } as unknown as typeof baseField;
-      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('(Email | SMS | Webhook)');
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('Email | SMS | Webhook');
+    });
+
+    it('should dissolve a sequence member into its own parenthesised comma-joined group, distinct from the pipe-separated alternatives', () => {
+      // '|' separates choice alternatives (OR); ',' groups an xs:sequence's own fields (AND).
+      // The sequence's group is wrapped in its own parens since its separator differs from the
+      // outer choice's, keeping the grouping unambiguous.
+      const baseField = sourceDoc.fields[0];
+      const sequenceMember = {
+        ...baseField,
+        name: '__sequence__',
+        displayName: 'sequence',
+        wrapperKind: 'sequence' as const,
+        fields: [
+          { ...baseField, name: 'key', displayName: 'key', fields: [] },
+          { ...baseField, name: 'value', displayName: 'value', fields: [] },
+        ],
+      };
+      const choiceField = {
+        ...baseField,
+        name: '__choice__',
+        displayName: 'choice',
+        wrapperKind: 'choice' as const,
+        fields: [{ ...baseField, name: 'dataValue', displayName: 'dataValue', fields: [] }, sequenceMember],
+      } as unknown as typeof baseField;
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe('dataValue | (key, value)');
+    });
+
+    it('should render a choice or abstract nested one level beyond the dissolved sequence as a bracketed placeholder', () => {
+      // choice > [directOption, sequence[seqField, choice[innerA, innerB], abstract[50 substitutes]]]
+      // The sequence's own fields are shown, but a choice/abstract nested inside it is not
+      // dissolved further — an abstract can carry unbounded substitutes.
+      const baseField = sourceDoc.fields[0];
+      const innerChoice = {
+        ...baseField,
+        name: '__choice__',
+        displayName: 'choice',
+        wrapperKind: 'choice' as const,
+        fields: [
+          { ...baseField, name: 'innerA', displayName: 'innerA', fields: [] },
+          { ...baseField, name: 'innerB', displayName: 'innerB', fields: [] },
+        ],
+      };
+      const innerAbstract = {
+        ...baseField,
+        name: 'payload',
+        displayName: 'payload',
+        wrapperKind: 'abstract' as const,
+        fields: Array.from({ length: 50 }, (_, i) => ({
+          ...baseField,
+          name: `Substitute${i}`,
+          displayName: `Substitute${i}`,
+          fields: [],
+        })),
+      };
+      const sequenceMember = {
+        ...baseField,
+        name: '__sequence__',
+        displayName: 'sequence',
+        wrapperKind: 'sequence' as const,
+        fields: [{ ...baseField, name: 'seqField', displayName: 'seqField', fields: [] }, innerChoice, innerAbstract],
+      };
+      const choiceField = {
+        ...baseField,
+        name: '__choice__',
+        displayName: 'choice',
+        wrapperKind: 'choice' as const,
+        fields: [{ ...baseField, name: 'directOption', displayName: 'directOption', fields: [] }, sequenceMember],
+      } as unknown as typeof baseField;
+      expect(VisualizationService.getChoiceMemberLabel(choiceField)).toBe(
+        'directOption | (seqField, [choice], [abstract])',
+      );
+    });
+
+    it('should still dissolve a nested choice one level deep when called directly on its enclosing sequence', () => {
+      // Depth is relative to the field passed to getChoiceMemberLabel: calling it directly on the
+      // sequence (its own candidate label) still shows one level of detail for a wrapper nested
+      // inside it, even though that same wrapper is a placeholder when reached via the choice's badge.
+      const baseField = sourceDoc.fields[0];
+      const innerChoice = {
+        ...baseField,
+        name: '__choice__',
+        displayName: 'choice',
+        wrapperKind: 'choice' as const,
+        fields: [
+          { ...baseField, name: 'innerA', displayName: 'innerA', fields: [] },
+          { ...baseField, name: 'innerB', displayName: 'innerB', fields: [] },
+        ],
+      };
+      const sequenceField = {
+        ...baseField,
+        name: '__sequence__',
+        displayName: 'sequence',
+        wrapperKind: 'sequence' as const,
+        fields: [{ ...baseField, name: 'seqField', displayName: 'seqField', fields: [] }, innerChoice],
+      } as unknown as typeof baseField;
+      expect(VisualizationService.getChoiceMemberLabel(sequenceField)).toBe('seqField, (innerA | innerB)');
+    });
+
+    it('should comma-join a sequence field own children when called directly on the sequence', () => {
+      const baseField = sourceDoc.fields[0];
+      const sequenceField = {
+        ...baseField,
+        name: '__sequence__',
+        displayName: 'sequence',
+        wrapperKind: 'sequence' as const,
+        fields: [
+          { ...baseField, name: 'key', displayName: 'key', fields: [] },
+          { ...baseField, name: 'value', displayName: 'value', fields: [] },
+        ],
+      } as unknown as typeof baseField;
+      expect(VisualizationService.getChoiceMemberLabel(sequenceField)).toBe('key, value');
     });
   });
 
@@ -781,7 +980,7 @@ describe('VisualizationService / choice fields', () => {
     it('should return member label for unselected choice wrapper (no choiceField)', () => {
       const choiceField = createMockChoiceField([{ name: 'email' }, { name: 'phone' }]);
       const choiceNode = new ChoiceFieldNodeData(sourceDocNode, choiceField);
-      expect(VisualizationService.createNodeTitle(choiceNode)).toBe('(email | phone)');
+      expect(VisualizationService.createNodeTitle(choiceNode)).toBe('email | phone');
     });
 
     it('should return nodeData.title for selected choice member (choiceField set)', () => {
@@ -802,7 +1001,7 @@ describe('VisualizationService / choice fields', () => {
     it('should return member label for unselected TargetChoiceFieldNodeData', () => {
       const choiceField = createMockChoiceField([{ name: 'a' }, { name: 'b' }]);
       const choiceNode = new TargetChoiceFieldNodeData(targetDocNode, choiceField);
-      expect(VisualizationService.createNodeTitle(choiceNode)).toBe('(a | b)');
+      expect(VisualizationService.createNodeTitle(choiceNode)).toBe('a | b');
     });
   });
 
@@ -1375,7 +1574,7 @@ describe('VisualizationService / choice fields', () => {
 
       // Inner choice title should show member label, not a specific member name
       const innerTitle = VisualizationService.createNodeTitle(innerChoiceNode);
-      expect(innerTitle).toBe('(InnerA1 | InnerA2)');
+      expect(innerTitle).toBe('InnerA1 | InnerA2');
 
       // Inner choice children should be hidden (unconfigured target wrapper)
       const innerChoiceChildren = VisualizationService.generateNonDocumentNodeDataChildren(innerChoiceNode);
@@ -1492,7 +1691,7 @@ describe('VisualizationService / choice fields', () => {
         (c) => c instanceof FieldItemNodeData && c.field.wrapperKind === 'choice',
       ) as FieldItemNodeData;
       expect(wrapperNode).toBeDefined();
-      expect(VisualizationService.createNodeTitle(wrapperNode)).toBe('(email | phone)');
+      expect(VisualizationService.createNodeTitle(wrapperNode)).toBe('email | phone');
     });
 
     it('createNodeTitle should return pipe-connected label for AddMappingNodeData on choice wrapper', () => {
@@ -1506,7 +1705,7 @@ describe('VisualizationService / choice fields', () => {
       const children = VisualizationService.generateNonDocumentNodeDataChildren(freshParentNode);
       const addNode = children.find((c) => c instanceof AddMappingNodeData) as AddMappingNodeData;
       expect(addNode).toBeDefined();
-      expect(VisualizationService.createNodeTitle(addNode)).toBe('(email | phone)');
+      expect(VisualizationService.createNodeTitle(addNode)).toBe('email | phone');
     });
   });
 

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -107,8 +107,16 @@ const ABSTRACT_WRAPPER: WrapperSpec = {
 const SEQUENCE_WRAPPER: WrapperSpec = {
   createSourceNode: (parent, field) => new SequenceFieldNodeData(parent, field),
   createTargetNode: (parent, field, mapping) => new TargetSequenceFieldNodeData(parent, field, mapping),
-  setWrapperRef: () => {},
+  // When a sequence is the selected member of an xs:choice, keep a reference to that choice
+  // wrapper so the choice context menu recognises this node as a selected branch (change/clear).
+  setWrapperRef: (node, wrapperField) => {
+    (node as SequenceFieldNodeData | TargetSequenceFieldNodeData).choiceField = wrapperField;
+  },
   isTargetInstance: (node) => node instanceof TargetSequenceFieldNodeData,
+  // A sequence is never itself the mapped field — unlike a selected choice/abstract member,
+  // it's a transparent container whose children are mapped independently. resolveWrapperNodeMappings
+  // must keep walking up to the real mapped ancestor rather than treating the sequence's own
+  // (nonexistent) mapping as the source of its children's mappings.
   hasWrapperRef: () => false,
   isUnconfiguredTarget: () => false,
 };
@@ -171,6 +179,19 @@ export class VisualizationService {
   }
 
   /**
+   * Returns the spec to recurse into when a wrapper's selected member is itself a nested
+   * choice/abstract wrapper that should take over rendering (per {@link WrapperSelectionService.shouldFlattenNestedWrapper}),
+   * or `undefined` when no recursion is needed (no selection, a non-wrapper member, or a sequence
+   * branch — which renders in place). Keeps {@link doGenerateNodeDataFromWrapperField} flat.
+   */
+  private static resolveNestedWrapperSpec(field: IField, selectedMember: IField | undefined): WrapperSpec | undefined {
+    if (!selectedMember?.wrapperKind || !field.wrapperKind) return undefined;
+    if (selectedMember.wrapperKind === 'sequence') return undefined;
+    if (!WrapperSelectionService.shouldFlattenNestedWrapper(field.wrapperKind, selectedMember)) return undefined;
+    return selectedMember.wrapperKind === 'choice' ? CHOICE_WRAPPER : ABSTRACT_WRAPPER;
+  }
+
+  /**
    * Creates a {@link ChoiceFieldNodeData} or {@link TargetChoiceFieldNodeData} for a choice wrapper field.
    *
    * When no member is selected ({@link DocumentUtilService.getSelectedMember} returns `undefined`), the returned node's
@@ -190,17 +211,22 @@ export class VisualizationService {
   ): NodeData | null {
     const selectedMember = DocumentUtilService.getSelectedMember(field);
 
-    if (selectedMember?.wrapperKind && field.wrapperKind) {
-      if (WrapperSelectionService.shouldFlattenNestedWrapper(field.wrapperKind, selectedMember)) {
-        const innerSpec = selectedMember.wrapperKind === 'choice' ? CHOICE_WRAPPER : ABSTRACT_WRAPPER;
-        return VisualizationService.doGenerateNodeDataFromWrapperField(parent, selectedMember, mappings, innerSpec);
-      }
+    // When the selected member is itself a nested choice/abstract wrapper, it takes over rendering
+    // via its own spec — recurse so it presents its own selection UI.
+    const recurseSpec = VisualizationService.resolveNestedWrapperSpec(field, selectedMember);
+    if (recurseSpec && selectedMember) {
+      return VisualizationService.doGenerateNodeDataFromWrapperField(parent, selectedMember, mappings, recurseSpec);
     }
+
+    // A selected xs:sequence renders in place as a sequence node that keeps a back-reference to
+    // this choice wrapper (set by the spec's setWrapperRef in the shared tail below), so the
+    // choice context menu can still change or clear the branch.
+    const effectiveSpec = selectedMember?.wrapperKind === 'sequence' ? SEQUENCE_WRAPPER : spec;
 
     const nodeField = selectedMember ?? field;
     if (parent.isSource) {
-      const node = spec.createSourceNode(parent, nodeField);
-      if (selectedMember) spec.setWrapperRef(node, field);
+      const node = effectiveSpec.createSourceNode(parent, nodeField);
+      if (selectedMember) effectiveSpec.setWrapperRef(node, field);
       return node;
     }
 
@@ -208,8 +234,8 @@ export class VisualizationService {
       selectedMember && mappings ? MappingService.filterMappingsForField(mappings, selectedMember) : [];
     const mapping = mappingsForMember.find((m) => m instanceof FieldItem) as FieldItem;
     if (mappingsForMember.length > 0 && !mapping) return null;
-    const node = spec.createTargetNode(parent as TargetNodeData, nodeField, mapping);
-    if (selectedMember) spec.setWrapperRef(node, field);
+    const node = effectiveSpec.createTargetNode(parent as TargetNodeData, nodeField, mapping);
+    if (selectedMember) effectiveSpec.setWrapperRef(node, field);
     return node;
   }
 
@@ -594,31 +620,65 @@ export class VisualizationService {
   }
 
   /**
-   * Returns the member label string (e.g. `"(email | phone | fax)"`) for a choice wrapper field.
-   * Nested choice members are dissolved into their inner member names so the label
-   * reads `"(InnerA | InnerB | Plain)"` instead of `"(choice | Plain)"`.
-   * @param field - The choice wrapper field whose members should be described.
+   * Returns the member label string (e.g. `"email | phone | fax"`) for a choice wrapper field,
+   * or — when `field` is itself an xs:sequence — the comma-joined label for its own children
+   * (e.g. `"key, value"`).
+   *
+   * `|` separates choice alternatives (mutually exclusive, OR), while `,` groups an xs:sequence's
+   * fields (which must appear together, AND) — matching the convention used by other integration
+   * tools. Direct members are dissolved one level deep: a nested member whose own separator
+   * matches the outer one merges flat into the same list (e.g. an abstract's substitutes merge
+   * into the choice's `|` list); one whose separator differs — crossing the OR/AND boundary — is
+   * rendered as its own parenthesised sub-group, e.g. `"dataValue | (key, value)"`. Any wrapper
+   * found one level beyond that (e.g. a choice/abstract nested inside a sequence branch) is shown
+   * as a bracketed placeholder — `[choice]`, `[abstract]`, `[sequence]` — instead of being
+   * dissolved further, since an abstract can carry an unbounded number of substitutes and full
+   * recursive dissolution would make the label unreadable. Brackets distinguish the placeholder
+   * from a real field name, since `choice`/`abstract`/`sequence` could themselves be field names.
+   * @param field - The choice (or sequence) wrapper field whose members should be described.
    */
   static getChoiceMemberLabel(field: IField): string {
-    const members = field.fields ?? [];
-    const labels = members.flatMap((m) => {
-      if (m.wrapperKind === 'choice' || m.wrapperKind === 'abstract') {
-        const innerLabels = (m.fields ?? []).map((inner) => inner.displayName ?? inner.name);
-        return innerLabels.length > 0 ? innerLabels : [m.displayName ?? m.name];
-      }
-      return [m.displayName ?? m.name];
-    });
-    if (labels.length === 0) return '(empty)';
-    const maxVisible = 3;
-    if (labels.length > maxVisible) {
-      return `(${labels.slice(0, maxVisible).join(' | ')} | +${labels.length - maxVisible} more)`;
-    }
-    return `(${labels.join(' | ')})`;
+    const separator = field.wrapperKind === 'sequence' ? ', ' : ' | ';
+    const labels = VisualizationService.collectMemberLabels(field.fields ?? [], separator, 0);
+    return VisualizationService.joinMemberLabels(labels, separator);
   }
 
   /**
-   * Returns the candidate label string (e.g. `"(Cat | Dog | Fish)"`) for an unselected
-   * abstract wrapper node. Returns `"(no candidates)"` when the wrapper has zero candidates.
+   * Flat-maps each member into its label(s) for the given outer separator, dissolving one level
+   * of nested choice/abstract/sequence wrappers. A member reached at `depth >= 1` (i.e. nested
+   * inside an already-dissolved wrapper) is rendered as a `[wrapperKind]` placeholder rather than
+   * being dissolved further, keeping the label bounded regardless of how many substitutes or
+   * members that deeper wrapper has.
+   */
+  private static collectMemberLabels(members: IField[], outerSeparator: string, depth: number): string[] {
+    return members.flatMap((m) => {
+      if (!m.wrapperKind) return [m.displayName ?? m.name];
+      if (depth >= 1) return [`[${m.wrapperKind}]`];
+      const innerSeparator = m.wrapperKind === 'sequence' ? ', ' : ' | ';
+      const innerLabels = VisualizationService.collectMemberLabels(m.fields ?? [], innerSeparator, depth + 1);
+      if (innerLabels.length === 0) return [m.displayName ?? m.name];
+      return innerSeparator === outerSeparator ? innerLabels : [`(${innerLabels.join(innerSeparator)})`];
+    });
+  }
+
+  /**
+   * Joins member labels with `separator`, truncating to `"+N more"` beyond 3 entries. Unlike
+   * {@link collectMemberLabels}'s sub-groups, the top-level result is not itself wrapped in
+   * parentheses — the label is shown standalone (as a node title or badge), not embedded in a
+   * further list, so an outer pair would be redundant.
+   */
+  private static joinMemberLabels(labels: string[], separator: string): string {
+    if (labels.length === 0) return 'empty';
+    const maxVisible = 3;
+    if (labels.length > maxVisible) {
+      return `${labels.slice(0, maxVisible).join(separator)}${separator}+${labels.length - maxVisible} more`;
+    }
+    return labels.join(separator);
+  }
+
+  /**
+   * Returns the candidate label string (e.g. `"Cat | Dog | Fish"`) for an unselected
+   * abstract wrapper node. Returns `"no candidates"` when the wrapper has zero candidates.
    * @param node - The abstract wrapper node whose candidates should be described.
    */
   static getAbstractMemberLabel(node: AbstractFieldNodeData | TargetAbstractFieldNodeData): string {
@@ -628,19 +688,26 @@ export class VisualizationService {
   private static getAbstractMemberLabelFromField(field: IField): string {
     const members = field.fields ?? [];
     const labels = members.map((m) => m.displayName ?? m.name);
-    if (labels.length === 0) return '(no candidates)';
+    if (labels.length === 0) return 'no candidates';
     const maxVisible = 3;
     if (labels.length > maxVisible) {
-      return `(${labels.slice(0, maxVisible).join(' | ')} | +${labels.length - maxVisible} more)`;
+      return `${labels.slice(0, maxVisible).join(' | ')} | +${labels.length - maxVisible} more`;
     }
-    return `(${labels.join(' | ')})`;
+    return labels.join(' | ');
   }
 
   /**
    * Returns the display title for a node. Unselected choice wrappers delegate to
    * {@link getChoiceMemberLabel} and unselected abstract wrappers delegate to
    * {@link getAbstractMemberLabel} so the candidate list is rendered separately
-   * from the badge label. All other nodes return {@link NodeData.title}.
+   * from the badge label. Sequence wrapper nodes also delegate to
+   * {@link getChoiceMemberLabel} (selected or previewed as an unselected choice
+   * candidate) since their raw `displayName` is the synthetic literal `"sequence"`,
+   * never a meaningful name to show verbatim. All other nodes return {@link NodeData.title}.
+   *
+   * Note: a *selected* sequence renders its "sequence" badge in place of the title
+   * ({@link FieldNodeTitle}), so the label returned here is only shown for the unselected
+   * choice candidate preview, not the selected branch node itself.
    * @param nodeData - The node whose title should be resolved.
    */
   static createNodeTitle(nodeData: NodeData): string {
@@ -651,6 +718,9 @@ export class VisualizationService {
       return VisualizationService.getChoiceMemberLabel(nodeData.field);
     }
     if (nodeData instanceof FieldNodeData && VisualizationUtilService.isSelectedNestedChoice(nodeData)) {
+      return VisualizationService.getChoiceMemberLabel(nodeData.field);
+    }
+    if (nodeData instanceof SequenceFieldNodeData || nodeData instanceof TargetSequenceFieldNodeData) {
       return VisualizationService.getChoiceMemberLabel(nodeData.field);
     }
     if (

--- a/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
+++ b/packages/ui/src/stubs/datamapper/xml/TestDocument.xsd
@@ -130,6 +130,19 @@
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>
+                <!-- Collection choice with an xs:sequence branch: choice repeats, so the sequence's
+                     children (key/value) inherit collection semantics across choice instances -->
+                <xs:element name="CollectionSequenceInChoiceElement">
+                    <xs:complexType>
+                        <xs:choice maxOccurs="unbounded">
+                            <xs:element name="plainValue" type="xs:string"/>
+                            <xs:sequence>
+                                <xs:element name="seqKey" type="xs:string"/>
+                                <xs:element name="seqValue" type="xs:string"/>
+                            </xs:sequence>
+                        </xs:choice>
+                    </xs:complexType>
+                </xs:element>
                 <!-- xs:sequence directly inside xs:choice — elements grouped as one option -->
                 <xs:element name="SequenceInChoiceElement">
                     <xs:complexType>
@@ -206,6 +219,23 @@
                             <xs:group ref="ns0:Group1"/>
                             <xs:any minOccurs="0"/>
                         </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <!-- xs:choice whose sequence branch itself contains a nested xs:choice (XSD nestedParticle allows this).
+                     Used to verify that clearing the outer choice also clears a selection made in the choice nested
+                     inside the selected sequence branch. -->
+                <xs:element name="NestedChoiceInSequenceElement">
+                    <xs:complexType>
+                        <xs:choice>
+                            <xs:element name="plainOption" type="xs:string"/>
+                            <xs:sequence>
+                                <xs:element name="seqKey" type="xs:string"/>
+                                <xs:choice>
+                                    <xs:element name="innerA" type="xs:string"/>
+                                    <xs:element name="innerB" type="xs:string"/>
+                                </xs:choice>
+                            </xs:sequence>
+                        </xs:choice>
                     </xs:complexType>
                 </xs:element>
                 <xs:group ref="ns0:Group1"/>


### PR DESCRIPTION
Completes the sequence-in-choice support started in #3345. That PR modeled and rendered an `xs:sequence` nested in an `xs:choice`, but the **selection** side was never finished: sequence members were skipped when building choice candidates, so the user couldn't pick the sequence branch. Once selectable, the visualization layer also had gaps — no Change/Clear menu, the node rendered as "abstract", labels/titles showed the literal `"sequence"`, collection/cardinality didn't propagate into the sequence's children, and clearing an outer choice didn't reach choices nested inside a selected sequence.

### Changes

- **Selection & rendering** — sequence members are now selectable choice candidates; a selected sequence renders via `SEQUENCE_WRAPPER` with a `choiceField` back-reference so the Change/Clear menu recognizes it as a branch. Clearing an outer choice now descends through the sequence to clear nested choice/abstract selections. `getSelectedChoiceWrapper()` centralizes the choice/sequence resolution.
- **Labels, titles & badges** — `getChoiceMemberLabel` uses `|` for choice alternatives and `,` for a sequence's fields, with bracketed placeholders (`[choice]`/`[abstract]`) one level deeper and no surrounding parens. A selected sequence shows the bare `sequence` badge (including the per-instance `maxOccurs>1` form) and its node/menu labels no longer leak the literal `"sequence"`.
- **Collection & cardinality inheritance** — new `getEnclosingCollectionCompositor()` is the single source of truth: `isCollectionField` and the field-details popover's Max Occurs both walk up through transparent `choice`/`sequence` compositors, so children of a sequence branch inside a repeating choice inherit collection semantics (a scalar under a real repeating element does not).
- **Regression fix** — `SEQUENCE_WRAPPER.hasWrapperRef` stays `() => false` (a sequence is never itself the mapped field), keeping mapping paths correct for fields inside a selected sequence.

### Testing

Added/updated coverage for: selecting/clearing a sequence branch and its nested wrappers, add-field candidates, member-label formatting, sequence badges/titles, collection & cardinality inheritance through compositors, and mapping paths. Fixtures `NestedChoiceInSequenceElement` and `CollectionSequenceInChoiceElement` added to `TestDocument.xsd`.

Fixes #3802

<img width="1092" height="910" alt="Screen Recording 2026-08-28 at 14 40 40" src="https://github.com/user-attachments/assets/f1ebdbd0-4664-45b1-8e75-22498112bf67" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed selection indicators for fields selected through nested choice branches.
- Clearing a selected branch now resets nested choices and abstract substitutions.
- Corrected collection handling, maximum-occurrence details, and mapping paths for sequence branches within choices.

## Improvements
- Sequence branches now appear in choice-member labels, previews, and field suggestions.
- Improved display and editing of fields within selected sequence branches.
- Improved handling of nested choices and sequence-based selections.
- Simplified choice and abstract-field labels by removing surrounding parentheses.
- Added clearer sequence badges and labels in document views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
