### PR TITLE
fix(test): replace raw DOM .click() with userEvent in ComponentMode tests

### DIFF
--- a/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
@@ -1,4 +1,5 @@
-import { act, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Mock, MockedFunction, vi } from 'vitest';
 
 import { useProcessorTooltips } from '../../hooks/use-processor-tooltips.hook';
@@ -60,20 +61,20 @@ describe('ComponentMode', () => {
   });
 
   it('should not call updateSourceCodeFromEntities if we are switching to the same EIP', async () => {
+    const user = userEvent.setup();
     const vizNode = getMockVizNode('to');
     const wrapper = render(<ComponentMode vizNode={vizNode} />);
 
     const toButton = wrapper.getByText('Static');
     expect(toButton).toBeInTheDocument();
 
-    await act(async () => {
-      toButton.click();
-    });
+    await user.click(toButton);
 
     expect(mockUpdateSourceCodeFromEntities).not.toHaveBeenCalled();
   });
 
   it('should not call updateSourceCodeFromEntities if the vizNode does not contain a path', async () => {
+    const user = userEvent.setup();
     const vizNode = getMockVizNode('to');
     vizNode.data.path = undefined;
     const wrapper = render(<ComponentMode vizNode={vizNode} />);
@@ -81,14 +82,13 @@ describe('ComponentMode', () => {
     const toButton = wrapper.getByText('Static');
     expect(toButton).toBeInTheDocument();
 
-    await act(async () => {
-      toButton.click();
-    });
+    await user.click(toButton);
 
     expect(mockUpdateSourceCodeFromEntities).not.toHaveBeenCalled();
   });
 
   it('calls updateModel when switching from "to" to "poll"', async () => {
+    const user = userEvent.setup();
     const vizNode = getMockVizNode('to');
     const wrapper = render(<ComponentMode vizNode={vizNode} />);
 
@@ -100,9 +100,7 @@ describe('ComponentMode', () => {
       expect(vizNode.getParsedDefinition as ReturnType<typeof vi.fn>).toHaveBeenCalled();
     });
 
-    await act(async () => {
-      pollButton.click();
-    });
+    await user.click(pollButton);
 
     expect(vizNode.updateModel).toHaveBeenCalledWith(undefined);
     expect(vizNode.data.path).toBe('route.from.steps.0.poll');
@@ -110,6 +108,7 @@ describe('ComponentMode', () => {
   });
 
   it('calls updateModel when switching from "to" to "toD"', async () => {
+    const user = userEvent.setup();
     const vizNode = getMockVizNode('to');
     const wrapper = render(<ComponentMode vizNode={vizNode} />);
 
@@ -121,9 +120,7 @@ describe('ComponentMode', () => {
       expect(vizNode.getParsedDefinition as ReturnType<typeof vi.fn>).toHaveBeenCalled();
     });
 
-    await act(async () => {
-      toDButton.click();
-    });
+    await user.click(toDButton);
 
     expect(vizNode.updateModel).toHaveBeenCalledWith(undefined);
     expect(vizNode.data.path).toBe('route.from.steps.0.toD');
@@ -131,6 +128,7 @@ describe('ComponentMode', () => {
   });
 
   it('calls updateModel when switching from "poll" to "to"', async () => {
+    const user = userEvent.setup();
     const vizNode = getMockVizNode('poll');
     const wrapper = render(<ComponentMode vizNode={vizNode} />);
 
@@ -141,13 +139,8 @@ describe('ComponentMode', () => {
     await waitFor(() => {
       expect(vizNode.getParsedDefinition as ReturnType<typeof vi.fn>).toHaveBeenCalled();
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
 
-    await act(async () => {
-      toButton.click();
-    });
+    await user.click(toButton);
 
     expect(vizNode.updateModel).toHaveBeenCalledWith(undefined);
     expect(vizNode.data.path).toBe('route.from.steps.0.to');
@@ -155,6 +148,7 @@ describe('ComponentMode', () => {
   });
 
   it('calls updateSourceCodeFromEntities when switching from "poll" to "to"', async () => {
+    const user = userEvent.setup();
     const vizNode = getMockVizNode('poll');
     const wrapper = render(<ComponentMode vizNode={vizNode} />);
 
@@ -165,13 +159,8 @@ describe('ComponentMode', () => {
     await waitFor(() => {
       expect(vizNode.getParsedDefinition as ReturnType<typeof vi.fn>).toHaveBeenCalled();
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
 
-    await act(async () => {
-      toButton.click();
-    });
+    await user.click(toButton);
 
     expect(mockUpdateSourceCodeFromEntities).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Replace all raw `element.click()` calls (wrapped in `await act()`) with `@testing-library/user-event`'s `await user.click()` in `ComponentMode.test.tsx`.

## Root Cause

PatternFly's `ToggleGroupItem` does not use a native `onClick` handler — it uses an `onChange` callback triggered through an internal event chain. When `element.click()` is used directly, JSDOM's event propagation is not deterministic enough; depending on Vitest worker timing, the internal PF event chain may not have completed by the time `act()` resolves. This causes the spy to record 0 calls intermittently.

## Fix

`userEvent.click()` simulates the full browser event sequence (`pointerdown` → `mousedown` → `pointerup` → `mouseup` → `click`) and internally awaits all pending React state updates, making the tests deterministic.

Additionally removed two unnecessary `await act(async () => { await Promise.resolve(); })` flush workarounds that are no longer needed with `userEvent`.

Fixes https://github.com/KaotoIO/kaoto/issues/3816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved interaction test coverage and reliability for component mode controls.
  * Updated tests to use realistic user interactions while preserving existing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->