### PR TITLE
chore(AI): add back the fix lint commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ Before declaring a task complete, verify ALL of the following pass:
 ```bash
 yarn workspace @kaoto/kaoto build            # typecheck — tests and lint do NOT run tsc
 yarn workspace @kaoto/kaoto test
-yarn workspace @kaoto/kaoto lint
-yarn workspace @kaoto/kaoto lint:style
+yarn workspace @kaoto/kaoto lint:fix
+yarn workspace @kaoto/kaoto lint:style:fix
 ```
 
 Additionally:


### PR DESCRIPTION
Small fix to bring back the linter fix commands before agents finish a task

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Definition of Done checks to run separate autofixing ESLint and style-lint tasks.
  * Improved automated code-quality checks by applying supported fixes during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->