### PR TITLE
fix(test): use assertion in waitFor to guard against null element in CanvasFormBody test

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
@@ -412,7 +412,9 @@ describe('CanvasFormBody', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
-    await waitFor(() => expect(formPageObject.getFieldByDisplayName('Name')).not.toBeNull());
+    await waitFor(() => {
+      expect(formPageObject.getFieldByDisplayName('Name')).not.toBeNull();
+    });
     const inputField = formPageObject.getFieldByDisplayName('Name')!;
 
     fireEvent.focus(inputField);

--- a/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx
@@ -412,7 +412,7 @@ describe('CanvasFormBody', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
-    await waitFor(() => formPageObject.getFieldByDisplayName('Name'));
+    await waitFor(() => expect(formPageObject.getFieldByDisplayName('Name')).not.toBeNull());
     const inputField = formPageObject.getFieldByDisplayName('Name')!;
 
     fireEvent.focus(inputField);


### PR DESCRIPTION
## Summary

Fixes the CI failure on `main`: https://github.com/KaotoIO/kaoto/actions/runs/33198207770

Fixes https://github.com/KaotoIO/kaoto/issues/3819

## Root cause

The `should show suggestions` test in `CanvasFormBody.test.tsx` used:

```ts
await waitFor(() => formPageObject.getFieldByDisplayName('Name'));
```

`waitFor` from `@testing-library/react` only retries while the callback **throws**. `getFieldByDisplayName` calls `screen.queryByRole(...)` internally — which returns `null` instead of throwing when no element is found. So `waitFor` exited immediately.

`CanvasFormBody` uses the async `useParsedDefinition` hook and renders `null` on the first tick (before the promise resolves). With the premature `waitFor` exit, `inputField` was `null`, and `fireEvent.focus(null)` crashed:

```
Error: Unable to fire a "focusin" event - please provide a DOM element.
  ❯ src/components/Visualization/Canvas/Form/CanvasFormBody.test.tsx:418:15
```

## Fix

```ts
// Before
await waitFor(() => formPageObject.getFieldByDisplayName('Name'));

// After
await waitFor(() => expect(formPageObject.getFieldByDisplayName('Name')).not.toBeNull());
```

Wrapping the lookup in an `expect` assertion causes `waitFor` to keep retrying until the element is actually present in the DOM.

## Testing

All 7 tests in `CanvasFormBody.test.tsx` pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test validation for canvas form suggestions by confirming that the **Name** field is available before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->