### PR TITLE
fx(sonar): typescript:S7772: Use node: prefix for built-in Node.js mo…

### DIFF
--- a/packages/ui/src/stubs/datamapper/data-mapper.ts
+++ b/packages/ui/src/stubs/datamapper/data-mapper.ts
@@ -1,5 +1,6 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { parse } from 'yaml';
 
 import {


### PR DESCRIPTION
…dule imports

fixes: https://github.com/KaotoIO/kaoto/issues/3730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal Node.js import references for improved compatibility and consistency.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->