### PR TITLE
fix(ui): replace FileReader with Blob.text()

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -16,6 +16,16 @@ import { DebugLayout } from './DebugLayout';
 
 const dndHandler = new SourceTargetDnDHandler();
 
+// Helper to create a File with mocked .text() for JSDOM (which lacks File.text())
+const createFile = (content: string, name: string) => {
+  const file = new File([content], name, { type: 'text/plain' });
+  Object.defineProperty(file, 'text', {
+    value: vi.fn().mockResolvedValue(content),
+    configurable: true,
+  });
+  return file;
+};
+
 const TestProviders: FunctionComponent<PropsWithChildren> = ({ children }) => (
   <DataMapperProvider>
     <DataMapperDndProvider handler={dndHandler}>
@@ -150,9 +160,7 @@ describe('DebugLayout', () => {
       fireEvent.click(mainMenuButton);
       const importButton = screen.getByTestId('dm-debug-import-mappings-button');
       fireEvent.click(importButton);
-      const fileContent = new File([new Blob([getShipOrderToShipOrderXslt()])], 'ShipOrderToShipOrder.xsl', {
-        type: 'text/plain',
-      });
+      const fileContent = createFile(getShipOrderToShipOrderXslt(), 'ShipOrderToShipOrder.xsl');
       const fileInput = screen.getByTestId('dm-debug-import-mappings-file-input');
       expect(spyOnMappingTree!.children).toHaveLength(0);
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });

--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -12,19 +12,10 @@ import { MappingSerializerService } from '../../../services/mapping/mapping-seri
 import { MappingLinksService } from '../../../services/visualization/mapping-links.service';
 import { useDocumentTreeStore } from '../../../store';
 import { getShipOrderToShipOrderXslt, TestUtil } from '../../../stubs/datamapper/data-mapper';
+import { createFile } from '../../../stubs/read-file-as-string';
 import { DebugLayout } from './DebugLayout';
 
 const dndHandler = new SourceTargetDnDHandler();
-
-// Helper to create a File with mocked .text() for JSDOM (which lacks File.text())
-const createFile = (content: string, name: string) => {
-  const file = new File([content], name, { type: 'text/plain' });
-  Object.defineProperty(file, 'text', {
-    value: vi.fn().mockResolvedValue(content),
-    configurable: true,
-  });
-  return file;
-};
 
 const TestProviders: FunctionComponent<PropsWithChildren> = ({ children }) => (
   <DataMapperProvider>

--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -5,6 +5,7 @@ import { MappingLinksProvider } from '../../providers/data-mapping-links.provide
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { BrowserFilePickerMetadataProvider } from '../../stubs/BrowserFilePickerMetadataProvider';
 import { getShipOrderJsonSchema, getShipOrderXsd } from '../../stubs/datamapper/data-mapper';
+import { createFile } from '../../stubs/read-file-as-string';
 import { ExpansionPanels } from '../ExpansionPanels/ExpansionPanels';
 import { ParametersSection } from './Parameters';
 
@@ -18,16 +19,6 @@ describe('ParametersSection', () => {
         </VirtuosoMockContext.Provider>
       ),
     });
-  };
-
-  // Helper to create a File with mocked .text() for JSDOM (which lacks File.text())
-  const createFile = (content: string, name: string) => {
-    const file = new File([content], name, { type: 'text/plain' });
-    Object.defineProperty(file, 'text', {
-      value: vi.fn().mockResolvedValue(content),
-      configurable: true,
-    });
-    return file;
   };
 
   it('should add, rename, and remove a parameter', async () => {

--- a/packages/ui/src/components/Document/Parameters.test.tsx
+++ b/packages/ui/src/components/Document/Parameters.test.tsx
@@ -20,6 +20,16 @@ describe('ParametersSection', () => {
     });
   };
 
+  // Helper to create a File with mocked .text() for JSDOM (which lacks File.text())
+  const createFile = (content: string, name: string) => {
+    const file = new File([content], name, { type: 'text/plain' });
+    Object.defineProperty(file, 'text', {
+      value: vi.fn().mockResolvedValue(content),
+      configurable: true,
+    });
+    return file;
+  };
+
   it('should add, rename, and remove a parameter', async () => {
     const mockUpdateDocument = vi.fn();
     const mockDeleteParameter = vi.fn();
@@ -131,7 +141,7 @@ describe('ParametersSection', () => {
     const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
     fireEvent.click(importButton);
 
-    const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
+    const fileContent = createFile(getShipOrderXsd(), 'ShipOrder.xsd');
     const fileInput = screen.getByTestId('attach-schema-file-input');
     fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
 
@@ -181,7 +191,7 @@ describe('ParametersSection', () => {
     const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
     fireEvent.click(importButton);
 
-    const fileContent = new File([new Blob([getShipOrderJsonSchema()])], 'ShipOrder.json', { type: 'text/plain' });
+    const fileContent = createFile(getShipOrderJsonSchema(), 'ShipOrder.json');
     const fileInput = screen.getByTestId('attach-schema-file-input');
     fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
 

--- a/packages/ui/src/components/View/SourceTargetView.test.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.test.tsx
@@ -5,6 +5,7 @@ import { MappingLinksProvider } from '../../providers/data-mapping-links.provide
 import { DataMapperProvider } from '../../providers/datamapper.provider';
 import { BrowserFilePickerMetadataProvider } from '../../stubs/BrowserFilePickerMetadataProvider';
 import { getCamelYamlDslJsonSchema, getShipOrderJsonSchema, getShipOrderXsd } from '../../stubs/datamapper/data-mapper';
+import { createFile } from '../../stubs/read-file-as-string';
 import { SourceTargetView } from './SourceTargetView';
 
 // Mock ResizeObserver for ExpansionPanels
@@ -21,16 +22,6 @@ beforeAll(() => {
     }
   };
 });
-
-// Helper to create a File with mocked .text() for JSDOM (which lacks File.text())
-const createFile = (content: string, name: string) => {
-  const file = new File([content], name, { type: 'text/plain' });
-  Object.defineProperty(file, 'text', {
-    value: vi.fn().mockResolvedValue(content),
-    configurable: true,
-  });
-  return file;
-};
 
 describe('SourceTargetView', () => {
   // Helper to wrap components with VirtuosoMockContext for testing

--- a/packages/ui/src/components/View/SourceTargetView.test.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.test.tsx
@@ -22,6 +22,16 @@ beforeAll(() => {
   };
 });
 
+// Helper to create a File with mocked .text() for JSDOM (which lacks File.text())
+const createFile = (content: string, name: string) => {
+  const file = new File([content], name, { type: 'text/plain' });
+  Object.defineProperty(file, 'text', {
+    value: vi.fn().mockResolvedValue(content),
+    configurable: true,
+  });
+  return file;
+};
+
 describe('SourceTargetView', () => {
   // Helper to wrap components with VirtuosoMockContext for testing
   const renderWithVirtuoso = (component: React.ReactElement) => {
@@ -50,7 +60,7 @@ describe('SourceTargetView', () => {
       const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
       fireEvent.click(importButton);
 
-      const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const fileContent = createFile(getShipOrderXsd(), 'ShipOrder.xsd');
       fireEvent.click(attachButton);
       const fileInput = screen.getByTestId('attach-schema-file-input');
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
@@ -107,7 +117,7 @@ describe('SourceTargetView', () => {
       const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
       fireEvent.click(importButton);
 
-      const fileContent = new File([new Blob([getShipOrderXsd()])], 'ShipOrder.xsd', { type: 'text/plain' });
+      const fileContent = createFile(getShipOrderXsd(), 'ShipOrder.xsd');
       fireEvent.click(attachButton);
       const fileInput = screen.getByTestId('attach-schema-file-input');
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
@@ -148,7 +158,7 @@ describe('SourceTargetView', () => {
       const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
       fireEvent.click(importButton);
 
-      const fileContent = new File([new Blob([getShipOrderJsonSchema()])], 'ShipOrder.json', { type: 'text/plain' });
+      const fileContent = createFile(getShipOrderJsonSchema(), 'ShipOrder.json');
       fireEvent.click(attachButton);
       const fileInput = screen.getByTestId('attach-schema-file-input');
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });
@@ -190,9 +200,7 @@ describe('SourceTargetView', () => {
       const importButton = await screen.findByTestId('attach-schema-modal-btn-file');
       fireEvent.click(importButton);
 
-      const fileContent = new File([new Blob([getCamelYamlDslJsonSchema()])], 'CamelYamlDsl.json', {
-        type: 'text/plain',
-      });
+      const fileContent = createFile(getCamelYamlDslJsonSchema(), 'CamelYamlDsl.json');
       fireEvent.click(attachButton);
       const fileInput = screen.getByTestId('attach-schema-file-input');
       fireEvent.change(fileInput, { target: { files: { item: () => fileContent, length: 1, 0: fileContent } } });

--- a/packages/ui/src/stubs/read-file-as-string.test.ts
+++ b/packages/ui/src/stubs/read-file-as-string.test.ts
@@ -6,8 +6,12 @@ if (typeof Blob !== 'undefined' && !Blob.prototype.text) {
   Blob.prototype.text = async function (this: Blob): Promise<string> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as string);
-      reader.onerror = () => reject(reader.error);
+      reader.onload = () => {
+        resolve(reader.result as string);
+      };
+      reader.onerror = () => {
+        reject(reader.error);
+      };
       reader.readAsText(this);
     });
   };

--- a/packages/ui/src/stubs/read-file-as-string.test.ts
+++ b/packages/ui/src/stubs/read-file-as-string.test.ts
@@ -1,5 +1,18 @@
 import { readFileAsString } from './read-file-as-string';
 
+// Local polyfill for Blob.text() / File.text() - not implemented in JSDOM
+// See https://github.com/jsdom/jsdom/issues/3405
+if (typeof Blob !== 'undefined' && !Blob.prototype.text) {
+  Blob.prototype.text = async function (this: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(this);
+    });
+  };
+}
+
 describe('readFileAsString()', () => {
   it('should read', async () => {
     const file = new File(['foo'], 'foo.txt', {

--- a/packages/ui/src/stubs/read-file-as-string.test.ts
+++ b/packages/ui/src/stubs/read-file-as-string.test.ts
@@ -1,28 +1,21 @@
 import { readFileAsString } from './read-file-as-string';
 
-// Local polyfill for Blob.text() / File.text() - not implemented in JSDOM
-// See https://github.com/jsdom/jsdom/issues/3405
-if (typeof Blob !== 'undefined' && !Blob.prototype.text) {
-  Blob.prototype.text = async function (this: Blob): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        resolve(reader.result as string);
-      };
-      reader.onerror = () => {
-        reject(reader.error);
-      };
-      reader.readAsText(this);
-    });
-  };
-}
-
 describe('readFileAsString()', () => {
   it('should read', async () => {
     const file = new File(['foo'], 'foo.txt', {
       type: 'text/plain',
     });
+
+    // JSDOM doesn't implement File.text(), add it for testing
+    Object.defineProperty(file, 'text', {
+      value: vi.fn().mockResolvedValue('foo'),
+      writable: true,
+      configurable: true,
+    });
+
     const answer = await readFileAsString(file);
+
     expect(answer).toBe('foo');
+    expect(file.text).toHaveBeenCalledOnce();
   });
 });

--- a/packages/ui/src/stubs/read-file-as-string.ts
+++ b/packages/ui/src/stubs/read-file-as-string.ts
@@ -1,3 +1,13 @@
 export const readFileAsString = (file: File): Promise<string> => {
   return file.text();
 };
+
+// Test helper to create a File with mocked .text() for JSDOM (which lacks File.text())
+export const createFile = (content: string, name: string) => {
+  const file = new File([content], name, { type: 'text/plain' });
+  Object.defineProperty(file, 'text', {
+    value: () => Promise.resolve(content),
+    configurable: true,
+  });
+  return file;
+};

--- a/packages/ui/src/stubs/read-file-as-string.ts
+++ b/packages/ui/src/stubs/read-file-as-string.ts
@@ -1,15 +1,3 @@
 export const readFileAsString = (file: File): Promise<string> => {
-  const reader = new FileReader();
-  return new Promise<string>((resolve, reject) => {
-    reader.onload = (e) => {
-      e.target ? resolve(e.target.result as string) : reject(new Error('Failed to read file'));
-    };
-    reader.onerror = () => {
-      reject(new Error('Error reading file'));
-    };
-    reader.onabort = () => {
-      reject(new Error('File reading aborted'));
-    };
-    reader.readAsText(file);
-  });
+  return file.text();
 };

--- a/packages/ui/vitest-setup.ts
+++ b/packages/ui/vitest-setup.ts
@@ -235,19 +235,6 @@ Object.defineProperty(globalThis, 'fail', {
   },
 });
 
-// Polyfill for Blob.text() / File.text() - not implemented in JSDOM
-// See https://github.com/jsdom/jsdom/issues/3405
-if (typeof Blob !== 'undefined' && !Blob.prototype.text) {
-  Blob.prototype.text = async function (this: Blob): Promise<string> {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => resolve(reader.result as string);
-      reader.onerror = () => reject(reader.error);
-      reader.readAsText(this);
-    });
-  };
-}
-
 // Suppress Monaco Editor CancellationError from unhandled rejections
 // Monaco Editor's clipboard service creates deferred promises that get cancelled
 // during test cleanup, which causes unhandled rejection errors

--- a/packages/ui/vitest-setup.ts
+++ b/packages/ui/vitest-setup.ts
@@ -235,6 +235,19 @@ Object.defineProperty(globalThis, 'fail', {
   },
 });
 
+// Polyfill for Blob.text() / File.text() - not implemented in JSDOM
+// See https://github.com/jsdom/jsdom/issues/3405
+if (typeof Blob !== 'undefined' && !Blob.prototype.text) {
+  Blob.prototype.text = async function (this: Blob): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(this);
+    });
+  };
+}
+
 // Suppress Monaco Editor CancellationError from unhandled rejections
 // Monaco Editor's clipboard service creates deferred promises that get cancelled
 // during test cleanup, which causes unhandled rejection errors


### PR DESCRIPTION
Closes #3732 

Replaces the legacy `FileReader#readAsText()` implementation with the modern Promise-based `Blob.text()` / `File.text()` API.

- Simplified `readFileAsString()` from 14 lines to 3 lines
- Added JSDOM polyfill in test setup since `Blob.text()` isn't implemented in JSDOM yet
- All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified file reading by using the platform’s native text-reading capability, improving consistency and reducing unnecessary handling.

* **Tests**
  * Updated file-reading tests to mock native text reading per test and verify it is invoked correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->