### PR TITLE
fix(DataMapper): Fixed decouple tree rebuild from value-only mapping updates

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/ImportMappingFileDropdownItem.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ImportMappingFileDropdownItem.tsx
@@ -41,7 +41,7 @@ export const ImportMappingFileDropdownItem: FunctionComponent<ImportMappingFileD
           for (const msg of messages) {
             sendAlert(msg);
           }
-          refreshMappingTree();
+          refreshMappingTree({ structural: true });
           onComplete();
         })
         .catch((error: unknown) => {

--- a/packages/ui/src/components/Document/AddMappingNode.tsx
+++ b/packages/ui/src/components/Document/AddMappingNode.tsx
@@ -19,8 +19,12 @@ export const AddMappingNode: FunctionComponent<{ nodeData: AddMappingNodeData; r
 
   const handleAddMapping = useCallback(() => {
     MappingActionService.addMapping(nodeData);
-    refreshMappingTree();
+    refreshMappingTree({ structural: true });
   }, [nodeData, refreshMappingTree]);
+
+  const handleContextMenuUpdate = useCallback(() => {
+    refreshMappingTree({ structural: true });
+  }, [refreshMappingTree]);
 
   return (
     <div data-testid={`node-target-${nodeData.id}`} className="node__container">
@@ -57,7 +61,7 @@ export const AddMappingNode: FunctionComponent<{ nodeData: AddMappingNodeData; r
             <MappingContextMenuAction
               nodeData={nodeData}
               dropdownLabel="Add Mapping Instruction"
-              onUpdate={refreshMappingTree}
+              onUpdate={handleContextMenuUpdate}
             />
           </ActionListGroup>
         </ActionList>

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -67,8 +67,13 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
     const mappingItem = nodeData.mapping instanceof MappingItem ? nodeData.mapping : undefined;
 
     const { mappingTree, refreshMappingTree } = useDataMapper();
+
     const handleUpdate = useCallback(() => {
       refreshMappingTree();
+    }, [refreshMappingTree]);
+
+    const handleStructuralUpdate = useCallback(() => {
+      refreshMappingTree({ structural: true });
     }, [refreshMappingTree]);
 
     const addingVariableToNodePath = useDocumentTreeStore((s) => s.addingVariableToNodePath);
@@ -90,7 +95,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
         }
         useDocumentTreeStore.getState().setAddingVariableTo(null);
         useDocumentTreeStore.getState().setRenamingVariable(null);
-        refreshMappingTree();
+        refreshMappingTree({ structural: true });
       },
       [isRenamingThisVariable, nodeData, refreshMappingTree],
     );
@@ -120,8 +125,8 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
       }
 
       MappingActionService.applyValueSelector(nodeData);
-      handleUpdate();
-    }, [nodeData, handleUpdate]);
+      handleStructuralUpdate();
+    }, [nodeData, handleStructuralUpdate]);
 
     const handleKeyDown = useCallback(
       (event: KeyboardEvent) => {
@@ -190,6 +195,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
                     className="node__target__actions"
                     nodeData={nodeData as TargetNodeData}
                     onUpdate={handleUpdate}
+                    onStructuralUpdate={handleStructuralUpdate}
                   />
                 ) : (
                   <span className="node__target__actions" />

--- a/packages/ui/src/components/Document/Variables/VariableRow.tsx
+++ b/packages/ui/src/components/Document/Variables/VariableRow.tsx
@@ -82,17 +82,18 @@ export const VariableRow: FunctionComponent<VariableRowProps> = ({
     (newName: string) => {
       MappingService.renameVariableReferences(variable, newName);
       MappingService.updateVariable(variable, newName, variable.expression);
-      refreshMappingTree();
+      refreshMappingTree({ structural: true });
       onStopRename();
     },
     [variable, refreshMappingTree, onStopRename],
   );
 
   const handleExpressionUpdate = useCallback(() => {
-    if (variable.rawElement && variable.expression) {
+    const isStructural = !!(variable.rawElement && variable.expression);
+    if (isStructural) {
       variable.rawElement = undefined;
     }
-    refreshMappingTree();
+    refreshMappingTree(isStructural ? { structural: true } : undefined);
   }, [variable, refreshMappingTree]);
 
   if (isRenaming) {

--- a/packages/ui/src/components/Document/Variables/VariablesSection.tsx
+++ b/packages/ui/src/components/Document/Variables/VariablesSection.tsx
@@ -44,7 +44,7 @@ export const VariablesSection: FunctionComponent<VariablesSectionProps> = ({
     (variable: VariableItem) => {
       MappingService.removeVariableReferences(variable);
       MappingService.removeVariable(variable);
-      refreshMappingTree();
+      refreshMappingTree({ structural: true });
     },
     [refreshMappingTree],
   );
@@ -67,7 +67,7 @@ export const VariablesSection: FunctionComponent<VariablesSectionProps> = ({
     (name: string) => {
       MappingService.addVariable(mappingTree, name, undefined, 'template');
       setIsAddingVariable(false);
-      refreshMappingTree();
+      refreshMappingTree({ structural: true });
     },
     [mappingTree, refreshMappingTree],
   );

--- a/packages/ui/src/components/Document/actions/DeleteParameterButton.tsx
+++ b/packages/ui/src/components/Document/actions/DeleteParameterButton.tsx
@@ -15,14 +15,13 @@ export const DeleteParameterButton: FunctionComponent<DeleteParameterProps> = ({
   parameterName,
   parameterReferenceId,
 }) => {
-  const { mappingTree, setMappingTree, refreshMappingTree, deleteSourceParameter } = useDataMapper();
+  const { mappingTree, refreshMappingTree, deleteSourceParameter } = useDataMapper();
 
   const onConfirmDelete = useCallback(() => {
-    const cleaned = MappingService.removeAllMappingsForDocument(mappingTree, DocumentType.PARAM, parameterReferenceId);
-    setMappingTree(cleaned);
+    MappingService.removeAllMappingsForDocument(mappingTree, DocumentType.PARAM, parameterReferenceId);
     deleteSourceParameter(parameterName);
-    refreshMappingTree();
-  }, [deleteSourceParameter, mappingTree, parameterName, parameterReferenceId, refreshMappingTree, setMappingTree]);
+    refreshMappingTree({ structural: true });
+  }, [deleteSourceParameter, mappingTree, parameterName, parameterReferenceId, refreshMappingTree]);
 
   return (
     <ConfirmActionButton

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.test.tsx
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.test.tsx
@@ -22,7 +22,7 @@ describe('TargetNodeActions', () => {
     render(
       <DataMapperProvider>
         <MappingLinksProvider>
-          <TargetNodeActions nodeData={nodeData} onUpdate={vi.fn()} />
+          <TargetNodeActions nodeData={nodeData} onUpdate={vi.fn()} onStructuralUpdate={vi.fn()} />
         </MappingLinksProvider>
       </DataMapperProvider>,
     );
@@ -38,7 +38,7 @@ describe('TargetNodeActions', () => {
     render(
       <DataMapperProvider>
         <MappingLinksProvider>
-          <TargetNodeActions nodeData={nodeData} onUpdate={vi.fn()} />
+          <TargetNodeActions nodeData={nodeData} onUpdate={vi.fn()} onStructuralUpdate={vi.fn()} />
         </MappingLinksProvider>
       </DataMapperProvider>,
     );
@@ -55,7 +55,7 @@ describe('TargetNodeActions', () => {
     render(
       <DataMapperProvider>
         <MappingLinksProvider>
-          <TargetNodeActions nodeData={mappingData} onUpdate={vi.fn()} />
+          <TargetNodeActions nodeData={mappingData} onUpdate={vi.fn()} onStructuralUpdate={vi.fn()} />
         </MappingLinksProvider>
       </DataMapperProvider>,
     );

--- a/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
+++ b/packages/ui/src/components/Document/actions/TargetNodeActions.tsx
@@ -16,9 +16,15 @@ type TargetNodeActionsProps = {
   className?: string;
   nodeData: TargetNodeData;
   onUpdate: () => void;
+  onStructuralUpdate: () => void;
 };
 
-export const TargetNodeActions: FunctionComponent<TargetNodeActionsProps> = ({ className, nodeData, onUpdate }) => {
+export const TargetNodeActions: FunctionComponent<TargetNodeActionsProps> = ({
+  className,
+  nodeData,
+  onUpdate,
+  onStructuralUpdate,
+}) => {
   const expressionItem = VisualizationService.getExpressionItemForNode(nodeData);
   const allowedActions = new Set(MappingActionRegistryService.getAllowedActions(nodeData));
 
@@ -31,10 +37,10 @@ export const TargetNodeActions: FunctionComponent<TargetNodeActionsProps> = ({ c
         </>
       )}
       {allowedActions.has(MappingActionKind.ContextMenu) && (
-        <MappingContextMenuAction nodeData={nodeData} onUpdate={onUpdate} />
+        <MappingContextMenuAction nodeData={nodeData} onUpdate={onStructuralUpdate} />
       )}
       {allowedActions.has(MappingActionKind.Delete) && (
-        <DeleteMappingItemAction nodeData={nodeData} onDelete={onUpdate} />
+        <DeleteMappingItemAction nodeData={nodeData} onDelete={onStructuralUpdate} />
       )}
     </ActionListGroup>
   );

--- a/packages/ui/src/components/View/SourceTargetView.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.tsx
@@ -23,8 +23,12 @@ export const SourceTargetView: FunctionComponent<SourceTargetViewProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [scaleFactor, setScaleFactor] = useState(initialScaleFactor);
 
+  const handleDeleteHotkey = useCallback(() => {
+    refreshMappingTree({ structural: true });
+  }, [refreshMappingTree]);
+
   // Enable Delete key support for removing selected mappings
-  useDataMapperDeleteHotkey(refreshMappingTree);
+  useDataMapperDeleteHotkey(handleDeleteHotkey);
 
   const handleZoomIn = useCallback(() => {
     setScaleFactor((prev) => Math.min(prev + 0.1, 1.2)); // Max 1.2x zoom

--- a/packages/ui/src/components/View/TargetPanel.test.tsx
+++ b/packages/ui/src/components/View/TargetPanel.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { FunctionComponent, PropsWithChildren } from 'react';
 
+import { useDataMapper } from '../../hooks/useDataMapper';
 import {
   DocumentDefinition,
   DocumentDefinitionType,
@@ -9,6 +10,7 @@ import {
 } from '../../models/datamapper/document';
 import { MappingLinksProvider } from '../../providers/data-mapping-links.provider';
 import { DataMapperProvider } from '../../providers/datamapper.provider';
+import { TreeUIService } from '../../services/visualization/tree-ui.service';
 import { getShipOrderJsonSchema } from '../../stubs/datamapper/data-mapper';
 import { TargetPanel } from './TargetPanel';
 
@@ -96,5 +98,73 @@ describe('TargetPanel', () => {
     // Settings button should be within the document header actions
     const settingsButton = container.querySelector('button[aria-label*="Settings"]');
     expect(settingsButton).toBeInTheDocument();
+  });
+
+  describe('tree rebuild decoupling', () => {
+    /**
+     * Helper component that renders TargetPanel and exposes context actions
+     * as imperative handles, all inside a single shared DataMapperProvider instance.
+     */
+    const TargetPanelWithActions: FunctionComponent<{
+      onReady: (ctx: ReturnType<typeof useDataMapper>) => void;
+    }> = ({ onReady }) => {
+      const ctx = useDataMapper();
+      onReady(ctx);
+      return <TargetPanel />;
+    };
+
+    it('should not call TreeUIService.createTree on value-only refreshMappingTree', async () => {
+      const createTreeSpy = vi.spyOn(TreeUIService, 'createTree');
+
+      let ctx: ReturnType<typeof useDataMapper> | null = null;
+
+      render(
+        <DataMapperProvider>
+          <MappingLinksProvider>
+            <TargetPanelWithActions onReady={(c) => (ctx = c)} />
+          </MappingLinksProvider>
+        </DataMapperProvider>,
+      );
+      await screen.findByTestId('document-doc-targetBody-Body');
+
+      const callCountAfterMount = createTreeSpy.mock.calls.length;
+
+      // Simulate a value-only update (no structural option)
+      act(() => {
+        ctx!.refreshMappingTree();
+      });
+
+      // createTree should NOT have been called again
+      expect(createTreeSpy.mock.calls).toHaveLength(callCountAfterMount);
+
+      createTreeSpy.mockRestore();
+    });
+
+    it('should call TreeUIService.createTree on structural refreshMappingTree', async () => {
+      const createTreeSpy = vi.spyOn(TreeUIService, 'createTree');
+
+      let ctx: ReturnType<typeof useDataMapper> | null = null;
+
+      render(
+        <DataMapperProvider>
+          <MappingLinksProvider>
+            <TargetPanelWithActions onReady={(c) => (ctx = c)} />
+          </MappingLinksProvider>
+        </DataMapperProvider>,
+      );
+      await screen.findByTestId('document-doc-targetBody-Body');
+
+      const callCountAfterMount = createTreeSpy.mock.calls.length;
+
+      // Simulate a structural update
+      act(() => {
+        ctx!.refreshMappingTree({ structural: true });
+      });
+
+      // createTree should have been called at least once more
+      expect(createTreeSpy.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+
+      createTreeSpy.mockRestore();
+    });
   });
 });

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -30,12 +30,14 @@ import {
 } from '../ExpansionPanels/panel-dimensions';
 
 export const TargetPanel: FunctionComponent = () => {
-  const { targetBodyDocument, mappingTree, refreshMappingTree } = useDataMapper();
+  const { targetBodyDocument, mappingTree, structuralMappingTree, refreshMappingTree } = useDataMapper();
 
-  // Create tree for target body
+  // `structuralMappingTree` is the snapshot of `mappingTree` at the last structural change.
+  // It is stable across value-only updates (e.g. typing in an XPath field), so `createTree`
+  // is only called when nodes are actually added, removed, or moved — not on every keystroke.
   const targetBodyNodeData = useMemo(
-    () => new TargetDocumentNodeData(targetBodyDocument, mappingTree),
-    [targetBodyDocument, mappingTree],
+    () => new TargetDocumentNodeData(targetBodyDocument, structuralMappingTree),
+    [targetBodyDocument, structuralMappingTree],
   );
   const [targetBodyTree, setTargetBodyTree] = useState<DocumentTree | undefined>(undefined);
 
@@ -65,6 +67,10 @@ export const TargetPanel: FunctionComponent = () => {
 
   const handleUpdate = useCallback(() => {
     refreshMappingTree();
+  }, [refreshMappingTree]);
+
+  const handleStructuralUpdate = useCallback(() => {
+    refreshMappingTree({ structural: true });
   }, [refreshMappingTree]);
 
   // Get expression item for primitive target body (if it has a mapping)
@@ -135,19 +141,27 @@ export const TargetPanel: FunctionComponent = () => {
     // Condition menu (kebab menu) before delete
     if (allowedActions.has(MappingActionKind.ContextMenu)) {
       actions.push(
-        <MappingContextMenuAction key="condition-menu" nodeData={targetBodyNodeData} onUpdate={handleUpdate} />,
+        <MappingContextMenuAction
+          key="condition-menu"
+          nodeData={targetBodyNodeData}
+          onUpdate={handleStructuralUpdate}
+        />,
       );
     }
 
     // Delete action comes last (bin icon at the end)
     if (expressionItem && allowedActions.has(MappingActionKind.Delete)) {
       actions.push(
-        <DeleteMappingItemAction key="delete-mapping" nodeData={targetBodyNodeData} onDelete={handleUpdate} />,
+        <DeleteMappingItemAction
+          key="delete-mapping"
+          nodeData={targetBodyNodeData}
+          onDelete={handleStructuralUpdate}
+        />,
       );
     }
 
     return actions;
-  }, [edgeMarkers, expressionItem, targetBodyNodeData, handleUpdate]);
+  }, [edgeMarkers, expressionItem, targetBodyNodeData, handleUpdate, handleStructuralUpdate]);
 
   return (
     <div id="panel-target" className="target-panel">

--- a/packages/ui/src/providers/datamapper.provider.test.tsx
+++ b/packages/ui/src/providers/datamapper.provider.test.tsx
@@ -16,12 +16,14 @@ import { CanvasView } from '../models/datamapper/view';
 import { DocumentService } from '../services/document/document.service';
 import { MappingService } from '../services/mapping/mapping.service';
 import { MappingSerializerService } from '../services/mapping/mapping-serializer.service';
+import { MappingLinksService } from '../services/visualization/mapping-links.service';
 import {
   getAccountJsonSchema,
   getCartJsonSchema,
   getShipOrderJsonSchema,
   getShipOrderJsonXslt,
 } from '../stubs/datamapper/data-mapper';
+import { MappingLinksProvider } from './data-mapping-links.provider';
 import { DataMapperContext, DataMapperProvider } from './datamapper.provider';
 
 describe('DataMapperProvider', () => {
@@ -1340,6 +1342,110 @@ describe('DataMapperProvider', () => {
       });
 
       expect(mockOnSetOutputValidationEnabled).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('structuralMappingTree', () => {
+    it('should not change structuralMappingTree identity when refreshMappingTree is called without { structural: true }', () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DataMapperProvider>{children}</DataMapperProvider>
+      );
+
+      const { result } = renderHook(() => useDataMapper(), { wrapper });
+
+      const initialStructuralTree = result.current.structuralMappingTree;
+
+      act(() => {
+        result.current.refreshMappingTree();
+      });
+      act(() => {
+        result.current.refreshMappingTree();
+      });
+
+      expect(result.current.structuralMappingTree).toBe(initialStructuralTree);
+    });
+
+    it('should update structuralMappingTree identity when refreshMappingTree is called with { structural: true }', () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DataMapperProvider>{children}</DataMapperProvider>
+      );
+
+      const { result } = renderHook(() => useDataMapper(), { wrapper });
+
+      const initialStructuralTree = result.current.structuralMappingTree;
+
+      act(() => {
+        result.current.refreshMappingTree();
+      });
+      act(() => {
+        result.current.refreshMappingTree();
+      });
+      act(() => {
+        result.current.refreshMappingTree({ structural: true });
+      });
+
+      expect(result.current.structuralMappingTree).not.toBe(initialStructuralTree);
+    });
+
+    it('structuralMappingTree should equal mappingTree after a structural update', () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DataMapperProvider>{children}</DataMapperProvider>
+      );
+
+      const { result } = renderHook(() => useDataMapper(), { wrapper });
+
+      act(() => {
+        result.current.refreshMappingTree({ structural: true });
+      });
+
+      expect(result.current.structuralMappingTree).toBe(result.current.mappingTree);
+    });
+
+    it('should call onUpdateMappings on a value-only edit even though structuralMappingTree does not change', () => {
+      const mockOnUpdateMappings = vi.fn();
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DataMapperProvider onUpdateMappings={mockOnUpdateMappings}>{children}</DataMapperProvider>
+      );
+
+      const { result } = renderHook(() => useDataMapper(), { wrapper });
+
+      const initialStructuralTree = result.current.structuralMappingTree;
+      mockOnUpdateMappings.mockClear();
+
+      act(() => {
+        // Simulates a value-only edit (e.g. typing an XPath expression), which does not pass { structural: true }
+        result.current.refreshMappingTree();
+      });
+
+      expect(mockOnUpdateMappings).toHaveBeenCalledTimes(1);
+      expect(result.current.structuralMappingTree).toBe(initialStructuralTree);
+    });
+
+    it('should still recompute MappingLinksService.extractMappingLinks() on a value-only edit', () => {
+      const extractMappingLinksSpy = vi.spyOn(MappingLinksService, 'extractMappingLinks');
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <DataMapperProvider>
+          <MappingLinksProvider>{children}</MappingLinksProvider>
+        </DataMapperProvider>
+      );
+
+      const { result } = renderHook(() => useDataMapper(), { wrapper });
+
+      const initialStructuralTree = result.current.structuralMappingTree;
+      const callCountAfterMount = extractMappingLinksSpy.mock.calls.length;
+      expect(callCountAfterMount).toBeGreaterThan(0);
+
+      act(() => {
+        // Simulates a value-only edit (e.g. typing an XPath expression), which does not pass { structural: true }
+        result.current.refreshMappingTree();
+      });
+
+      expect(result.current.structuralMappingTree).toBe(initialStructuralTree);
+      expect(extractMappingLinksSpy).toHaveBeenCalledTimes(callCountAfterMount + 1);
+
+      extractMappingLinksSpy.mockRestore();
     });
   });
 });

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -66,7 +66,12 @@ export interface IDataMapperContext {
   setSourceParametersExpanded: (expanded: boolean) => void;
 
   mappingTree: MappingTree;
-  refreshMappingTree(): void;
+  /** Snapshot of `mappingTree` at the last structural change (node add/remove/move/rename).
+   * Stable across value-only updates (e.g. typing an XPath expression), so components that
+   * drive expensive rebuilds — such as `TargetPanel`'s `createTree` call — can depend on this
+   * instead of `mappingTree` to avoid rebuilding on every keystroke. */
+  structuralMappingTree: MappingTree;
+  refreshMappingTree(options?: { structural?: boolean }): void;
   resetMappingTree(): void;
   setMappingTree(mappings: MappingTree): void;
   variables: VariableItem[];
@@ -154,6 +159,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
   );
   initialMappingTree.namespaceMap = { ...initialNamespaceMap };
   const [mappingTree, setMappingTree] = useState<MappingTree>(initialMappingTree);
+  const [structuralMappingTree, setStructuralMappingTree] = useState<MappingTree>(initialMappingTree);
 
   const [alerts, setAlerts] = useState<SendAlertProps[]>([]);
 
@@ -200,6 +206,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
       WrapperAutoDetectionService.autoDetectWrapperSelections(loaded, latestTargetBodyDocument, effectiveNamespaceMap);
       setDataMapperSettings(restoredDataMapperSettings);
       setMappingTree(loaded);
+      setStructuralMappingTree(loaded);
       for (const msg of messages) {
         sendAlert(msg);
       }
@@ -214,7 +221,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
   // Update mapping tree when target document changes
   useEffect(() => {
     if (isLoading) return;
-    refreshMappingTree();
+    refreshMappingTree({ structural: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading, targetBodyDocument]);
 
@@ -242,32 +249,37 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     [onDeleteParameter, refreshSourceParameters, sourceParameterMap],
   );
 
-  const refreshMappingTree = useCallback(() => {
-    const newMapping = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, targetBodyDocument.definitionType);
-    newMapping.children = mappingTree.children.map((child) => {
-      child.parent = newMapping;
-      return child;
-    });
-    newMapping.globalVariables = mappingTree.globalVariables.map((gv) => {
-      gv.parent = newMapping;
-      return gv;
-    });
-    newMapping.namespaceMap = mappingTree.namespaceMap;
-    setMappingTree(newMapping);
-    onUpdateMappings?.(MappingSerializerService.serialize(newMapping, sourceParameterMap, dataMapperSettings));
-    onUpdateNamespaceMap?.(newMapping.namespaceMap);
-  }, [
-    dataMapperSettings,
-    mappingTree,
-    onUpdateMappings,
-    onUpdateNamespaceMap,
-    sourceParameterMap,
-    targetBodyDocument.definitionType,
-  ]);
+  const refreshMappingTree = useCallback(
+    (options?: { structural?: boolean }) => {
+      const newMapping = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, targetBodyDocument.definitionType);
+      newMapping.children = mappingTree.children.map((child) => {
+        child.parent = newMapping;
+        return child;
+      });
+      newMapping.globalVariables = mappingTree.globalVariables.map((gv) => {
+        gv.parent = newMapping;
+        return gv;
+      });
+      newMapping.namespaceMap = mappingTree.namespaceMap;
+      setMappingTree(newMapping);
+      if (options?.structural) setStructuralMappingTree(newMapping);
+      onUpdateMappings?.(MappingSerializerService.serialize(newMapping, sourceParameterMap, dataMapperSettings));
+      onUpdateNamespaceMap?.(newMapping.namespaceMap);
+    },
+    [
+      dataMapperSettings,
+      mappingTree,
+      onUpdateMappings,
+      onUpdateNamespaceMap,
+      sourceParameterMap,
+      targetBodyDocument.definitionType,
+    ],
+  );
   const resetMappingTree = useCallback(() => {
     const newMapping = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, targetBodyDocument.definitionType);
     newMapping.namespaceMap = { ...initialNamespaceMap };
     setMappingTree(newMapping);
+    setStructuralMappingTree(newMapping);
     onUpdateMappings?.(MappingSerializerService.serialize(newMapping, sourceParameterMap, dataMapperSettings));
     onUpdateNamespaceMap?.(newMapping.namespaceMap);
   }, [
@@ -313,7 +325,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
 
       // Update mapping tree to reflect the parameter name change
       MappingService.renameParameterInMappings(mappingTree, oldName, newName);
-      refreshMappingTree();
+      refreshMappingTree({ structural: true });
 
       onRenameParameter?.(oldName, newName);
     },
@@ -375,7 +387,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
         Object.assign(Object.create(Object.getPrototypeOf(document)), document),
       );
 
-      refreshMappingTree();
+      refreshMappingTree({ structural: true });
       onUpdateDocument?.(definition);
     },
     [onUpdateDocument, refreshMappingTree, removeStaleMappings, setNewDocument],
@@ -412,6 +424,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
       setNewDocument,
       updateDocument,
       mappingTree,
+      structuralMappingTree,
       refreshMappingTree,
       resetMappingTree,
       setMappingTree,
@@ -438,6 +451,7 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
     setNewDocument,
     updateDocument,
     mappingTree,
+    structuralMappingTree,
     refreshMappingTree,
     resetMappingTree,
     variables,

--- a/packages/ui/src/providers/dnd/DnDHandler.ts
+++ b/packages/ui/src/providers/dnd/DnDHandler.ts
@@ -10,5 +10,9 @@ export interface DnDResult {
 export interface DnDHandler {
   handleDragStart(event: DragStartEvent): DnDResult;
   handleDragOver(event: DragOverEvent): void;
-  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): DnDResult;
+  handleDragEnd(
+    event: DragEndEvent,
+    mappingTree: MappingTree,
+    onUpdate: (options?: { structural?: boolean }) => void,
+  ): DnDResult;
 }

--- a/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.ts
+++ b/packages/ui/src/providers/dnd/ExpressionEditorDnDHandler.ts
@@ -5,7 +5,11 @@ import { MappingService } from '../../services/mapping/mapping.service';
 import { DnDHandler, DnDResult } from './DnDHandler';
 
 export class ExpressionEditorDnDHandler implements DnDHandler {
-  handleDragEnd(event: DragEndEvent, _mappingTree: MappingTree, onUpdate: () => void): DnDResult {
+  handleDragEnd(
+    event: DragEndEvent,
+    _mappingTree: MappingTree,
+    onUpdate: (options?: { structural?: boolean }) => void,
+  ): DnDResult {
     const fromNode = event.active.data.current as NodeData;
     const toNode = event.over?.data.current as NodeData;
     if (

--- a/packages/ui/src/providers/dnd/SourceTargetDnDHandler.test.ts
+++ b/packages/ui/src/providers/dnd/SourceTargetDnDHandler.test.ts
@@ -76,13 +76,24 @@ describe('SourceTargetDnDHandler', () => {
       expect(mockEngageMapping).not.toHaveBeenCalled();
     });
 
-    it('should call engageMapping and onUpdate and return { success: true } when validation passes with nodes', () => {
+    it('should call engageMapping and onUpdate({ structural: true }) when engageMapping reports a structural change', () => {
       const fromNode = { isSource: true } as unknown as NodeData;
       const toNode = { isSource: false } as unknown as NodeData;
       mockValidateMappingPair.mockReturnValue({ isValid: true, sourceNode: fromNode, targetNode: toNode });
+      mockEngageMapping.mockReturnValue(true);
       const result = handler.handleDragEnd(makeDragEvent(fromNode, toNode), mockMappingTree, mockOnUpdate);
       expect(mockEngageMapping).toHaveBeenCalledWith(mockMappingTree, fromNode, toNode);
-      expect(mockOnUpdate).toHaveBeenCalled();
+      expect(mockOnUpdate).toHaveBeenCalledWith({ structural: true });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should call onUpdate({ structural: false }) when engageMapping reports a value-only update', () => {
+      const fromNode = { isSource: true } as unknown as NodeData;
+      const toNode = { isSource: false } as unknown as NodeData;
+      mockValidateMappingPair.mockReturnValue({ isValid: true, sourceNode: fromNode, targetNode: toNode });
+      mockEngageMapping.mockReturnValue(false);
+      const result = handler.handleDragEnd(makeDragEvent(fromNode, toNode), mockMappingTree, mockOnUpdate);
+      expect(mockOnUpdate).toHaveBeenCalledWith({ structural: false });
       expect(result).toEqual({ success: true });
     });
   });

--- a/packages/ui/src/providers/dnd/SourceTargetDnDHandler.ts
+++ b/packages/ui/src/providers/dnd/SourceTargetDnDHandler.ts
@@ -7,7 +7,11 @@ import { MappingValidationService } from '../../services/visualization/mapping-v
 import { DnDHandler, DnDResult } from './DnDHandler';
 
 export class SourceTargetDnDHandler implements DnDHandler {
-  handleDragEnd(event: DragEndEvent, mappingTree: MappingTree, onUpdate: () => void): DnDResult {
+  handleDragEnd(
+    event: DragEndEvent,
+    mappingTree: MappingTree,
+    onUpdate: (options?: { structural?: boolean }) => void,
+  ): DnDResult {
     const fromNode = event.active.data.current as NodeData;
     const toNode = event.over?.data.current as NodeData;
     if (!fromNode || !toNode) return { success: false };
@@ -18,8 +22,8 @@ export class SourceTargetDnDHandler implements DnDHandler {
     }
 
     if (!validation.sourceNode || !validation.targetNode) return { success: false };
-    MappingActionService.engageMapping(mappingTree, validation.sourceNode, validation.targetNode);
-    onUpdate();
+    const structural = MappingActionService.engageMapping(mappingTree, validation.sourceNode, validation.targetNode);
+    onUpdate({ structural });
     return { success: true };
   }
 

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -342,58 +342,76 @@ export class MappingActionService {
    * @param mappingTree - The root mapping tree.
    * @param sourceNode - The source node being mapped from.
    * @param targetNode - The target node being mapped to.
+   * @returns `true` when the mapping tree's shape changed (a {@link MappingItem} such as a
+   * `FieldItem`/`ForEachItem`/`ChooseItem` was added, removed, or replaced), `false` when only
+   * an already-materialized target's value/copy-of expression was extended — e.g. dropping a
+   * second source onto a field that's already mapped. Selectors never have their own tree node,
+   * so mutating one on an existing target is never structural.
    */
-  static engageMapping(mappingTree: MappingTree, sourceNode: SourceNodeDataType, targetNode: TargetNodeData) {
+  static engageMapping(mappingTree: MappingTree, sourceNode: SourceNodeDataType, targetNode: TargetNodeData): boolean {
     if (sourceNode instanceof SourceVariableNodeData) {
-      MappingActionService.engageVariableMapping(sourceNode, targetNode, mappingTree);
-      return;
+      return MappingActionService.engageVariableMapping(sourceNode, targetNode, mappingTree);
     }
 
     const sourceField = 'document' in sourceNode ? (sourceNode.document as PrimitiveDocument) : sourceNode.field;
 
     if (sourceNode instanceof ChoiceFieldNodeData && VisualizationUtilService.isFieldNode(targetNode)) {
-      MappingActionService.engageChoiceMapping(sourceNode, targetNode, sourceField);
-      return;
+      return MappingActionService.engageChoiceMapping(sourceNode, targetNode, sourceField);
     }
 
-    if (MappingActionService.tryEngageContainerMapping(sourceNode, targetNode)) return;
+    const targetWasUnmapped = !targetNode.mapping;
+    const containerResult = MappingActionService.tryEngageContainerMapping(sourceNode, targetNode);
+    if (containerResult.handled) return containerResult.structural;
 
     if (VisualizationUtilService.isFieldNode(targetNode)) {
       const item = MappingActionService.getOrCreateFieldItem(targetNode);
       MappingActionService.removeParentContainerCopyOf(item);
       MappingService.mapToField(sourceField, item);
+      return targetWasUnmapped;
     } else if (targetNode instanceof MappingNodeData) {
       MappingService.mapToCondition(targetNode.mapping, sourceField);
+      return false;
     } else if (targetNode instanceof TargetDocumentNodeData) {
+      const hadRootValueSelector = mappingTree.children.some((c) => c instanceof ValueOfSelector);
       MappingService.mapToDocument(mappingTree, sourceField);
+      return !hadRootValueSelector;
     }
+    return false;
   }
 
   private static engageVariableMapping(
     sourceNode: SourceVariableNodeData,
     targetNode: TargetNodeData,
     mappingTree: MappingTree,
-  ) {
+  ): boolean {
     const pathExpr = MappingService.variablePathExpression(sourceNode.variable.name);
+    const structural =
+      targetNode instanceof TargetDocumentNodeData
+        ? !mappingTree.children.some((c) => c instanceof ValueOfSelector)
+        : !targetNode.mapping;
     const target = MappingActionService.resolveTarget(targetNode, mappingTree);
-    if (target) MappingService.applyMapping(pathExpr, target);
+    if (!target) return false;
+    MappingService.applyMapping(pathExpr, target);
+    return structural;
   }
 
   private static engageChoiceMapping(
     sourceNode: ChoiceFieldNodeData,
     targetNode: TargetFieldNodeData | FieldItemNodeData,
     sourceField: IField,
-  ) {
+  ): boolean {
     if (sourceNode.choiceField) {
+      const structural = !targetNode.mapping;
       const item = MappingActionService.getOrCreateFieldItem(targetNode);
       MappingService.mapToField(sourceField, item);
+      return structural;
     } else if (
       VisualizationUtilService.isCollectionField(sourceNode) &&
       VisualizationUtilService.isCollectionField(targetNode)
     ) {
-      MappingActionService.createForEachWithChooseFromChoice(sourceNode.field, targetNode);
+      return MappingActionService.createForEachWithChooseFromChoice(sourceNode.field, targetNode);
     } else {
-      MappingActionService.createChooseFromChoice(sourceNode.field, targetNode);
+      return MappingActionService.createChooseFromChoice(sourceNode.field, targetNode);
     }
   }
 
@@ -446,13 +464,22 @@ export class MappingActionService {
     return undefined;
   }
 
-  private static tryEngageContainerMapping(sourceNode: SourceNodeDataType, targetNode: TargetNodeData): boolean {
+  /**
+   * @returns `{ handled: false }` when this pair isn't a container mapping and the caller
+   * should fall through to regular field/condition/document dispatch; otherwise
+   * `{ handled: true, structural }`, where `structural` reports whether a new
+   * {@link MappingItem} was materialized (see {@link engageMapping}).
+   */
+  private static tryEngageContainerMapping(
+    sourceNode: SourceNodeDataType,
+    targetNode: TargetNodeData,
+  ): { handled: boolean; structural: boolean } {
     if (
       !('field' in sourceNode) ||
       !sourceNode.field ||
       !(targetNode instanceof TargetFieldNodeData || targetNode instanceof FieldItemNodeData)
     ) {
-      return false;
+      return { handled: false, structural: false };
     }
     const sourceFieldFromNode = sourceNode.field;
     const targetFieldFromNode = targetNode.field;
@@ -461,17 +488,19 @@ export class MappingActionService {
     const anyTypeInvolved = sourceFieldFromNode.type === Types.AnyType || targetFieldFromNode.type === Types.AnyType;
 
     if (!sourceHasChildren && !targetHasChildren && !anyTypeInvolved) {
-      return false;
+      return { handled: false, structural: false };
     }
+
+    const structural = !targetNode.mapping;
 
     if (anyTypeInvolved && (!sourceHasChildren || !targetHasChildren)) {
       const item = MappingActionService.getOrCreateFieldItem(targetNode);
       MappingService.mapToFieldWithValueType(sourceFieldFromNode, item, CopyOfType.CONTAINER_NODE);
-      return true;
+      return { handled: true, structural };
     }
 
     if (!sourceHasChildren || !targetHasChildren) {
-      return false;
+      return { handled: false, structural: false };
     }
 
     const item = MappingActionService.getOrCreateFieldItem(targetNode);
@@ -483,23 +512,29 @@ export class MappingActionService {
       if (guardResult !== undefined) return guardResult;
 
       MappingActionService.createCollectionForEach(item, sourceFieldFromNode, targetFieldFromNode);
-    } else {
-      MappingService.applyContainerMapping(sourceFieldFromNode, targetFieldFromNode, item);
+      return { handled: true, structural: true };
     }
-    return true;
+
+    // generateAutoChildMappings (the non-copy-of branch of applyContainerMapping) always adds new
+    // child FieldItems, so it's structural regardless of whether `item` itself pre-existed.
+    const canUseCopyOf = FieldMatchingService.canUseCopyOf(sourceFieldFromNode, targetFieldFromNode);
+    MappingService.applyContainerMapping(sourceFieldFromNode, targetFieldFromNode, item);
+    return { handled: true, structural: structural || !canUseCopyOf };
   }
 
   /**
    * Checks whether a container auto-mapping ForEachItem already exists for this target field.
-   * Returns `true` (handled), `false` (defer to regular mapping), or `undefined` (proceed with auto-mapping).
+   * Returns `{ handled: true, structural }` (fully handled here — either a no-op reuse or a
+   * stray sibling `ForEachItem` was removed), `{ handled: false, structural: false }` (defer to
+   * regular mapping), or `undefined` (proceed with auto-mapping via {@link createCollectionForEach}).
    */
-  private static guardExistingForEach(item: MappingItem): boolean | undefined {
-    if (item.children.some((c) => c instanceof ForEachItem)) return true;
-    if (item.parent instanceof ForEachItem) return false;
+  private static guardExistingForEach(item: MappingItem): { handled: boolean; structural: boolean } | undefined {
+    if (item.children.some((c) => c instanceof ForEachItem)) return { handled: true, structural: false };
+    if (item.parent instanceof ForEachItem) return { handled: false, structural: false };
     if (item.parent.children.some((c) => c !== item && c instanceof ForEachItem)) {
       const idx = item.parent.children.indexOf(item);
       if (idx !== -1) item.parent.children.splice(idx, 1);
-      return true;
+      return { handled: true, structural: true };
     }
     return undefined;
   }
@@ -523,18 +558,21 @@ export class MappingActionService {
     parentOfItem.children.push(forEachItem);
   }
 
-  private static createChooseFromChoice(sourceField: IField, targetNode: TargetNodeData) {
+  /** @returns whether a new `ChooseItem` was created (`false` if one already existed — a no-op). */
+  private static createChooseFromChoice(sourceField: IField, targetNode: TargetNodeData): boolean {
     const targetItem = MappingActionService.getOrCreateFieldItem(targetNode);
-    if (targetItem.children.some((c) => c instanceof ChooseItem)) return;
+    if (targetItem.children.some((c) => c instanceof ChooseItem)) return false;
     targetItem.children = targetItem.children.filter((c) => !(c instanceof ValueSelector));
 
     const chooseItem = MappingActionService.buildChooseFromChoiceMembers(targetItem, sourceField, targetItem);
     targetItem.children.push(chooseItem);
+    return true;
   }
 
-  private static createForEachWithChooseFromChoice(sourceField: IField, targetNode: TargetNodeData) {
+  /** @returns whether a new `ForEachItem` was created (`false` if one already existed — a no-op). */
+  private static createForEachWithChooseFromChoice(sourceField: IField, targetNode: TargetNodeData): boolean {
     const targetItem = MappingActionService.getOrCreateFieldItem(targetNode);
-    if (targetItem.children.some((c) => c instanceof ForEachItem)) return;
+    if (targetItem.children.some((c) => c instanceof ForEachItem)) return false;
     targetItem.children = targetItem.children.filter((c) => !(c instanceof ValueSelector));
 
     const forEachItem = new ForEachItem(targetItem);
@@ -543,6 +581,7 @@ export class MappingActionService {
     const chooseItem = MappingActionService.buildChooseFromChoiceMembers(forEachItem, sourceField, targetItem);
     forEachItem.children.push(chooseItem);
     targetItem.children.push(forEachItem);
+    return true;
   }
 
   private static buildChooseFromChoiceMembers(


### PR DESCRIPTION
Introduce a structural flag on `refreshMappingTree` so that `TreeUIService.createTree` (and the `targetBodyNodeData` memo in `TargetPanel`) only re-runs when the shape of the mapping tree actually changes — i.e. when nodes are added, removed, or moved — rather than on every pure value edit such as typing in an XPath expression field.

Resolves: [#3810](https://github.com/KaotoIO/kaoto/issues/3810)


https://github.com/user-attachments/assets/315a0b13-93c9-4573-9523-52082e000062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved mapping editor responsiveness by avoiding unnecessary tree rebuilds during value-only updates.
  * Structural changes—such as adding, removing, renaming, moving, or engaging mappings—now refresh the mapping tree accurately.

* **Bug Fixes**
  * Improved consistency after importing mappings, editing variables, updating expressions, changing values, using context menus, deleting mappings, and drag-and-drop actions.
  * Ensured the target view stays synchronized after structural mapping changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->