### PR TITLE
fix(ui): hide Topology nav item for single-route resource types

### DIFF
--- a/packages/ui/src/layout/Navigation.tsx
+++ b/packages/ui/src/layout/Navigation.tsx
@@ -22,7 +22,11 @@ export const Navigation: FunctionComponent<INavigationSidebar> = (props) => {
         children: [
           { title: 'Design', to: Links.Home },
           { title: 'Source Code', to: Links.SourceCode },
-          { title: 'Topology', to: Links.Topology },
+          {
+            title: 'Topology',
+            to: Links.Topology,
+            hidden: () => !NAVIGATION_ELEMENTS.Topology.includes(currentSchemaType),
+          },
         ],
       },
       {
@@ -136,4 +140,5 @@ const NAVIGATION_ELEMENTS = {
   ],
   PipeErrorHandler: [SourceSchemaType.KameletBinding, SourceSchemaType.Pipe],
   DataMapper: [SourceSchemaType.RouteYaml, SourceSchemaType.Kamelet],
+  Topology: [SourceSchemaType.RouteYaml, SourceSchemaType.RouteXml, SourceSchemaType.Integration],
 };

--- a/packages/ui/src/layout/__snapshots__/Navigation.test.tsx.snap
+++ b/packages/ui/src/layout/__snapshots__/Navigation.test.tsx.snap
@@ -374,7 +374,7 @@ exports[`Navigation Component > navigation sidebar for: Kamelet 1`] = `
                     </a>
                   </li>
                   <li
-                    class="pf-v6-c-nav__item"
+                    class="pf-v6-c-nav__item pf-v6-u-hidden"
                     data-ouia-component-id="OUIA-Generated-NavItem-_r_16_"
                     data-ouia-component-type="PF6/NavItem"
                     data-ouia-safe="true"
@@ -650,7 +650,7 @@ exports[`Navigation Component > navigation sidebar for: KameletBinding 1`] = `
                     </a>
                   </li>
                   <li
-                    class="pf-v6-c-nav__item"
+                    class="pf-v6-c-nav__item pf-v6-u-hidden"
                     data-ouia-component-id="OUIA-Generated-NavItem-_r_26_"
                     data-ouia-component-type="PF6/NavItem"
                     data-ouia-safe="true"
@@ -926,7 +926,7 @@ exports[`Navigation Component > navigation sidebar for: Pipe 1`] = `
                     </a>
                   </li>
                   <li
-                    class="pf-v6-c-nav__item"
+                    class="pf-v6-c-nav__item pf-v6-u-hidden"
                     data-ouia-component-id="OUIA-Generated-NavItem-_r_1m_"
                     data-ouia-component-type="PF6/NavItem"
                     data-ouia-safe="true"


### PR DESCRIPTION
## Summary

The Topology view shows cross-route endpoint relationships, which is only
meaningful for resource types that support multiple routes (`RouteYaml`,
`RouteXml`, `Integration`). For `Kamelet`, `Pipe`, `KameletBinding`, and
`Test` it always renders a single isolated node with no edges, adding noise.

This adds a `hidden` guard to the Topology nav item, following the same
`NAVIGATION_ELEMENTS` pattern already used by Beans, Metadata, RestDsl, Pipe
ErrorHandler, and DataMapper.

## Changes

- Add a `hidden` guard to the Topology child nav item in `Navigation.tsx`.
- Add `Topology` to `NAVIGATION_ELEMENTS`, limited to `RouteYaml`, `RouteXml`,
  and `Integration`.

## Verification

- `yarn workspace @kaoto/kaoto build` — typecheck + vite build pass
- `yarn workspace @kaoto/kaoto test` — 7087 passed, snapshots updated
- `yarn workspace @kaoto/kaoto lint` — clean
- `yarn workspace @kaoto/kaoto lint:style` — clean

Closes #3830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Topology navigation option is now shown only for supported schema types.
  * Removed the Topology option from navigation contexts where it isn’t applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->