### PR TITLE
refactor(CamelCatalogService): remove unused getCatalogLookup method

### DIFF
--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.test.ts
@@ -3,18 +3,15 @@ import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
 import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
 import { ICamelComponentDefinition } from '../../camel/camel-components-catalog';
-import { IKameletDefinition } from '../../camel/kamelets-catalog';
 import { CatalogKind } from '../../catalog-kind';
 import { CamelCatalogService } from './camel-catalog.service';
 
 describe('CamelCatalogService', () => {
   let componentCatalogMap: Record<string, ICamelComponentDefinition>;
-  let kameletCatalogMap: Record<string, IKameletDefinition>;
 
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     componentCatalogMap = catalogsMap.componentCatalogMap;
-    kameletCatalogMap = catalogsMap.kameletsCatalogMap;
     CamelCatalogService.setCatalogKey(CatalogKind.Component, catalogsMap.componentCatalogMap);
   });
 
@@ -34,61 +31,6 @@ describe('CamelCatalogService', () => {
       const component = CamelCatalogService.getComponent(CatalogKind.Component);
 
       expect(component).toBeUndefined();
-    });
-  });
-
-  describe('getCatalogLookup', () => {
-    it('should return `undefined` for an empty string component name', () => {
-      const lookup = CamelCatalogService.getCatalogLookup('');
-
-      expect(lookup).toBeUndefined();
-    });
-
-    it('should return a component from the catalog lookup', () => {
-      const lookup = CamelCatalogService.getCatalogLookup('timer');
-
-      expect(lookup).toEqual({
-        catalogKind: CatalogKind.Component,
-        definition: (componentCatalogMap as Record<string, unknown>).timer,
-      });
-    });
-
-    it('should return a kamelet from the catalog lookup', () => {
-      // Add a test kamelet to the catalog
-      const testKameletCatalog = {
-        ...kameletCatalogMap,
-        'chuck-norris-source': {
-          kind: 'Kamelet',
-          metadata: { name: 'chuck-norris-source' },
-          spec: { definition: {} },
-        } as IKameletDefinition,
-      };
-
-      CamelCatalogService.setCatalogKey(
-        CatalogKind.Kamelet,
-        testKameletCatalog as unknown as Record<string, IKameletDefinition>,
-      );
-
-      const lookup = CamelCatalogService.getCatalogLookup('kamelet:chuck-norris-source');
-
-      expect(lookup).toEqual({
-        catalogKind: CatalogKind.Kamelet,
-        definition: testKameletCatalog['chuck-norris-source'],
-      });
-    });
-
-    it('should return the kamelet component for unknown kamelets', () => {
-      CamelCatalogService.setCatalogKey(
-        CatalogKind.Kamelet,
-        kameletCatalogMap as unknown as Record<string, IKameletDefinition>,
-      );
-
-      const lookup = CamelCatalogService.getCatalogLookup('kamelet:non-existing-kamelet');
-
-      expect(lookup).toEqual({
-        catalogKind: CatalogKind.Component,
-        definition: (componentCatalogMap as Record<string, unknown>).kamelet,
-      });
     });
   });
 });

--- a/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
+++ b/packages/ui/src/models/visualization/flows/camel-catalog.service.ts
@@ -76,43 +76,4 @@ export class CamelCatalogService {
   static clearCatalogs(): void {
     this.catalogs = {};
   }
-
-  /** Method to return whether this is a Camel Component or a Kamelet */
-  static getCatalogLookup(componentName: string): {
-    catalogKind: CatalogKind.Component;
-    definition?: ICamelComponentDefinition;
-  };
-  static getCatalogLookup(componentName: string): {
-    catalogKind: CatalogKind.Kamelet;
-    definition?: IKameletDefinition;
-  };
-  static getCatalogLookup(
-    componentName: string,
-  ): { catalogKind: CatalogKind; definition?: ComponentsCatalogTypes } | undefined {
-    if (!componentName) {
-      return undefined;
-    }
-
-    if (componentName.startsWith('kamelet:')) {
-      const definition = this.getComponent(CatalogKind.Kamelet, componentName.replace('kamelet:', ''));
-
-      if (definition) {
-        return {
-          catalogKind: CatalogKind.Kamelet,
-          definition,
-        };
-      }
-
-      // If the Kamelet is not found, we fallback to the Kamelet component
-      return {
-        catalogKind: CatalogKind.Component,
-        definition: this.getComponent(CatalogKind.Component, 'kamelet'),
-      };
-    }
-
-    return {
-      catalogKind: CatalogKind.Component,
-      definition: this.getComponent(CatalogKind.Component, componentName),
-    };
-  }
 }


### PR DESCRIPTION
The getCatalogLookup method had all its call sites removed in the previous refactor. This commit removes the dead code itself:
- Delete the getCatalogLookup overloads and implementation from CamelCatalogService
- Remove the corresponding describe block and its 4 tests from camel-catalog.service.test.ts
- Drop the now-unused IKameletDefinition import and kameletCatalogMap variable from the test file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the catalog lookup functionality for resolving component and Kamelet definitions.
  * Updated related validation coverage to focus on component retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->