### PR TITLE
fix(canvas): Apply pasted Pipe and Kamelet templates

### DIFF
--- a/packages/ui/src/hooks/usePasteEntity.test.tsx
+++ b/packages/ui/src/hooks/usePasteEntity.test.tsx
@@ -193,7 +193,9 @@ describe('usePasteEntity', () => {
       await result.current.onPasteEntity();
     });
 
-    expect(addNewEntitySpy).toHaveBeenCalled();
+    expect(addNewEntitySpy).toHaveBeenCalledWith('route', {
+      route: expect.objectContaining({ from: { uri: 'timer:tick' } }),
+    });
     expect(toggleFlowVisibleSpy).toHaveBeenCalledWith('new-route-id');
     expect(updateEntitiesFromCamelResourceSpy).toHaveBeenCalled();
   });
@@ -232,7 +234,44 @@ describe('usePasteEntity', () => {
         }),
       );
       expect(removeEntitySpy).toHaveBeenCalledWith(['existing-entity']);
-      expect(addNewEntitySpy).toHaveBeenCalled();
+      expect(addNewEntitySpy).toHaveBeenCalledWith('route', expect.objectContaining({ from: { uri: 'timer:tick' } }));
+    });
+
+    it('should pass the raw pipe definition instead of wrapping it', async () => {
+      vi.spyOn(navigator.permissions, 'query').mockResolvedValueOnce({ state: 'granted' } as PermissionStatus);
+      const pipeContent: IClipboardContent = {
+        name: 'pipe',
+        definition: {
+          metadata: { name: 'copied-pipe' },
+          spec: { steps: [{ ref: { name: 'delay-action' } }] },
+        },
+      };
+      vi.spyOn(ClipboardService, 'paste').mockResolvedValue(pipeContent);
+      vi.spyOn(camelResource, 'getType').mockReturnValue(SourceSchemaType.Pipe);
+      vi.spyOn(camelResource, 'getVisualEntities').mockReturnValue([
+        { id: 'existing-entity' } as unknown as CamelRouteVisualEntity,
+      ]);
+      mockActionConfirmationContext.actionConfirmation.mockResolvedValue(ACTION_ID_CONFIRM);
+      addNewEntitySpy.mockReturnValue('copied-pipe');
+
+      const { result } = renderHook(() => usePasteEntity(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isCompatible).toBe(true);
+      });
+
+      await act(async () => {
+        await result.current.onPasteEntity();
+      });
+
+      expect(addNewEntitySpy).toHaveBeenCalledWith(
+        'pipe',
+        expect.objectContaining({
+          metadata: { name: 'copied-pipe' },
+          spec: { steps: [{ ref: { name: 'delay-action' } }] },
+        }),
+      );
+      expect(addNewEntitySpy).not.toHaveBeenCalledWith('pipe', expect.objectContaining({ pipe: expect.anything() }));
     });
 
     it('should not paste when user cancels replacement', async () => {

--- a/packages/ui/src/hooks/usePasteEntity.ts
+++ b/packages/ui/src/hooks/usePasteEntity.ts
@@ -136,10 +136,11 @@ export const usePasteEntity = () => {
     // Clone and update IDs to prevent duplication
     const updatedContent = updateIds(cloneDeep(clipboardContent));
 
-    // Add the new entity
-    const newId = camelResource.addNewEntity(updatedContent.name as EntityType, {
-      [updatedContent.name]: updatedContent.definition,
-    });
+    const entityTemplate = supportsMultiple
+      ? { [updatedContent.name]: updatedContent.definition }
+      : updatedContent.definition;
+
+    const newId = camelResource.addNewEntity(updatedContent.name as EntityType, entityTemplate);
 
     // Make the new entity visible
     if (newId) {

--- a/packages/ui/src/models/camel/camel-k-resource.ts
+++ b/packages/ui/src/models/camel/camel-k-resource.ts
@@ -80,6 +80,10 @@ export abstract class CamelKResource implements KaotoResource {
     this.metadata = undefined;
   }
 
+  protected syncMetadataFromResource(): void {
+    this.metadata = this.resource.metadata ? new MetadataEntity(this.resource) : undefined;
+  }
+
   getEntities(): BaseEntity[] {
     const answer = [];
     if (this.resource.metadata && this.metadata) {

--- a/packages/ui/src/models/camel/kamelet-binding-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-binding-resource.ts
@@ -23,9 +23,4 @@ export class KameletBindingResource extends PipeResource {
   getType(): SourceSchemaType {
     return SourceSchemaType.KameletBinding;
   }
-
-  addNewEntity(): string {
-    //TODO
-    return '';
-  }
 }

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -153,6 +153,44 @@ describe('KameletResource', () => {
     });
   });
 
+  describe('addNewEntity', () => {
+    it('should apply a pasted kamelet template including intermediate steps', async () => {
+      const resource = new KameletResource();
+      await resource.initialize();
+      resource.removeEntity();
+
+      const id = resource.addNewEntity(undefined, cloneDeep(kameletJson));
+
+      expect(id).toBe('user-source');
+      const from = resource.getVisualEntities()[0].toJSON().from;
+      expect(from.uri).toBe('timer');
+      expect(from.steps).toHaveLength(2);
+    });
+
+    it('should rebuild beans from the replacement template', async () => {
+      const withBeans = cloneDeep(kameletJson);
+      withBeans.spec.template.beans = [{ name: 'myBean' }];
+      const resource = new KameletResource();
+      await resource.initialize();
+      resource.createRouteTemplateBeansEntity();
+
+      resource.addNewEntity(undefined, withBeans);
+
+      expect(resource.getRouteTemplateBeansEntity()?.parent.beans).toEqual([{ name: 'myBean' }]);
+    });
+
+    it('should clear beans when the replacement template has none', async () => {
+      const resource = new KameletResource(cloneDeep(kameletJson));
+      await resource.initialize();
+      resource.createRouteTemplateBeansEntity();
+      expect(resource.getRouteTemplateBeansEntity()).toBeDefined();
+
+      resource.addNewEntity(undefined, cloneDeep(kameletJson));
+
+      expect(resource.getRouteTemplateBeansEntity()).toBeUndefined();
+    });
+  });
+
   it('should support RouteTemplateBeansAwareResource methods', async () => {
     const model = cloneDeep(kameletJson);
     expect(model.spec.template.beans).toBeUndefined();

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -2,6 +2,7 @@ import { parse } from 'yaml';
 
 import { TileFilter } from '../../components/Catalog/Catalog.models';
 import { setValue } from '../../utils';
+import { EntityType } from '../entities';
 import { RouteTemplateBeansAwareResource } from '../kaoto-resource';
 import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { CamelComponentFilterService } from '../visualization/flows/support/camel-component-filter.service';
@@ -49,6 +50,18 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
 
   getType(): SourceSchemaType {
     return SourceSchemaType.Kamelet;
+  }
+
+  addNewEntity(_entityType?: EntityType, entityTemplate?: unknown): string {
+    if (entityTemplate) {
+      this.resource = entityTemplate as IKameletDefinition;
+      this.flow = new KameletVisualEntity(this.resource as IKameletDefinition);
+      this.beans = this.flow.kamelet.spec.template.beans
+        ? new RouteTemplateBeansEntity(this.flow.kamelet.spec.template as RouteTemplateBeansParentType)
+        : undefined;
+      this.syncMetadataFromResource();
+    }
+    return this.flow.getId();
   }
 
   getVisualEntities(): KameletVisualEntity[] {

--- a/packages/ui/src/models/camel/pipe-resource.test.ts
+++ b/packages/ui/src/models/camel/pipe-resource.test.ts
@@ -1,3 +1,5 @@
+import { cloneDeep } from 'lodash';
+
 import { pipeJson } from '../../stubs/pipe';
 import { PipeResource } from './pipe-resource';
 import { SourceSchemaType } from './source-schema-type';
@@ -55,6 +57,46 @@ describe('PipeResource', () => {
       const compatibleRuntimes = resource.getCompatibleRuntimes();
 
       expect(compatibleRuntimes).toEqual(['Main', 'Quarkus', 'Spring Boot']);
+    });
+  });
+
+  describe('addNewEntity', () => {
+    it('should apply a pasted pipe template including intermediate steps', async () => {
+      const resource = new PipeResource();
+      await resource.initialize();
+      resource.removeEntity();
+
+      const id = resource.addNewEntity(undefined, cloneDeep(pipeJson));
+
+      expect(id).toBe('webhook-binding');
+      const vis = resource.getVisualEntities()[0];
+      expect(vis.pipe.spec!.source!.ref!.name).toBe('webhook-source');
+      expect(vis.pipe.spec!.steps![0].ref?.name).toBe('delay-action');
+      expect(vis.pipe.spec!.sink!.ref!.name).toBe('log-sink');
+    });
+
+    it('should rebuild the error handler from the replacement template', async () => {
+      const resource = new PipeResource();
+      await resource.initialize();
+      resource.createErrorHandlerEntity();
+
+      resource.addNewEntity(undefined, cloneDeep(pipeJson));
+
+      expect(resource.getErrorHandlerEntity()?.parent.errorHandler!.log).toBeDefined();
+    });
+
+    it('should clear the error handler when the replacement template has none', async () => {
+      const resource = new PipeResource(cloneDeep(pipeJson));
+      await resource.initialize();
+      expect(resource.getErrorHandlerEntity()).toBeDefined();
+
+      const withoutErrorHandler = cloneDeep(pipeJson);
+      delete withoutErrorHandler.spec!.errorHandler;
+
+      resource.addNewEntity(undefined, withoutErrorHandler);
+
+      expect(resource.getErrorHandlerEntity()).toBeUndefined();
+      expect(resource.toJSON().spec!.errorHandler).toBeUndefined();
     });
   });
 

--- a/packages/ui/src/models/camel/pipe-resource.ts
+++ b/packages/ui/src/models/camel/pipe-resource.ts
@@ -3,7 +3,7 @@ import { parse } from 'yaml';
 
 import { ITile, TileFilter } from '../../components/Catalog/Catalog.models';
 import { CatalogKind } from '../catalog-kind';
-import { BaseEntity, PipeSpecErrorHandler } from '../entities';
+import { BaseEntity, EntityType, PipeSpecErrorHandler } from '../entities';
 import { AddStepMode, IVisualizationNodeData } from '../visualization/base-visual-entity';
 import { PipeVisualEntity } from '../visualization/flows';
 import { FlowTemplateService } from '../visualization/flows/support/flow-templates-service';
@@ -54,6 +54,22 @@ export class PipeResource extends CamelKResource {
 
   getType(): SourceSchemaType {
     return SourceSchemaType.Pipe;
+  }
+
+  addNewEntity(_entityType?: EntityType, entityTemplate?: unknown): string {
+    if (entityTemplate) {
+      this.pipe = entityTemplate as PipeType;
+      this.resource = this.pipe;
+      if (!this.pipe.spec) {
+        this.pipe.spec = {};
+      }
+      this.flow = new PipeVisualEntity(this.pipe);
+      this.errorHandler = this.pipe.spec.errorHandler
+        ? new PipeErrorHandlerEntity(this.pipe.spec as PipeSpecErrorHandler)
+        : undefined;
+      this.syncMetadataFromResource();
+    }
+    return this.flow?.id ?? '';
   }
 
   refreshVisualMetadata() {


### PR DESCRIPTION
When you copy a full Pipe or Kamelet and confirm replace, Kaoto currently resets to a blank template. Those resources inherit a no-op addNewEntity, so the pasted steps never land.

This implements addNewEntity for Pipe and Kamelet so the copied definition is applied, including beans, error handler, and metadata. Paste now hands those resources the raw clipboard definition. KameletBinding inherits the Pipe path.

Fixes #3446

I ran `yarn workspace @kaoto/kaoto test`, `lint:fix`, `lint:style:fix`, and `build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paste and replacement behavior for routes, pipes, and kamelets.
  * Pasted single-entity definitions are now applied in the expected format.
  * Replaced resources now correctly refresh metadata, intermediate steps, beans, and error handlers.
  * Stale configuration is cleared when replacement data lacks beans or error-handler settings.
  * Route templates now preserve the correct route configuration when saved.
* **Tests**
  * Added coverage for pasted entity replacement and associated configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->