### PR TITLE
Fix repeated XmlSchemaFacet union type

### DIFF
--- a/packages/ui/src/xml-schema-ts/facet/XmlSchemaFacet.ts
+++ b/packages/ui/src/xml-schema-ts/facet/XmlSchemaFacet.ts
@@ -1,16 +1,18 @@
 import { XmlSchemaAnnotated } from '../XmlSchemaAnnotated';
 
+type FacetValue = object | string | number | bigint | null;
+
 export abstract class XmlSchemaFacet extends XmlSchemaAnnotated {
   fixed: boolean | undefined;
-  value: object | string | number | bigint | null;
+  value: FacetValue;
 
-  constructor(value?: object | string | number | bigint | null, fixed?: boolean) {
+  constructor(value?: FacetValue, fixed?: boolean) {
     super();
     this.value = value || null;
     this.fixed = fixed;
   }
 
-  getValue(): object | string | number | bigint | null {
+  getValue(): FacetValue {
     return this.value;
   }
   isFixed(): boolean {
@@ -19,7 +21,7 @@ export abstract class XmlSchemaFacet extends XmlSchemaAnnotated {
   setFixed(fixed: boolean) {
     this.fixed = fixed;
   }
-  setValue(value: object | string | number | bigint | null) {
+  setValue(value: FacetValue) {
     this.value = value;
   }
 }


### PR DESCRIPTION
### Description

Extract the repeated inline union used by `XmlSchemaFacet` into a local `FacetValue` type alias and reuse it for the field, constructor, getter, and setter. This resolves the `typescript:S4323` finding without changing runtime behavior or adding a new public export.

Closes #3741

#### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update
- [ ] Other (please describe)

#### How Has This Been Tested?
- `yarn workspace @kaoto/kaoto build`
- `yarn workspace @kaoto/kaoto lint:fix`
- `yarn workspace @kaoto/kaoto lint:style:fix`
- Full test suite: 7,082 passed; one unrelated form test timed out at 10 seconds under full-suite load
- Re-ran the timed-out test file independently: 2/2 passed

#### Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have followed the coding style and conventions of the project.
- [x] I have tested my changes and ensured that they work as expected.
- [ ] I have updated any relevant [documentation](https://github.com/KaotoIO/kaoto.io/tree/main/content/docs). (Not applicable: type-only refactor.)
- [ ] I have added tests that prove my fix or feature works. (Not applicable: no runtime behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the public type definition used for XML Schema facet values.
  * Improved consistency across facet value properties, constructors, and methods without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->