### PR TITLE
refactor(kamelet): update Kamelet structure to use `route.from` instead of `from`

### DIFF
--- a/packages/ui-tests/cypress/e2e/designer/basicNodeActions/stepCopy.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/basicNodeActions/stepCopy.cy.ts
@@ -107,15 +107,17 @@ describe('Tests for Design page', { browser: '!firefox' }, () => {
           types: { out: { mediaType: 'application/json' } },
           dependencies: ['camel:timer', 'camel:http', 'camel:kamelet'],
           template: {
-            from: {
-              id: 'from-1870',
-              uri: 'timer:user',
-              parameters: { period: '{{period}}' },
-              steps: [
-                { setBody: { id: 'setBody-3387', expression: { simple: {} } } },
-                { marshal: { id: 'marshal-1414' } },
-                { to: { uri: 'kamelet:sink', parameters: {} } },
-              ],
+            route: {
+              from: {
+                id: 'from-1870',
+                uri: 'timer:user',
+                parameters: { period: '{{period}}' },
+                steps: [
+                  { setBody: { id: 'setBody-3387', expression: { simple: {} } } },
+                  { marshal: { id: 'marshal-1414' } },
+                  { to: { uri: 'kamelet:sink', parameters: {} } },
+                ],
+              },
             },
           },
         },

--- a/packages/ui-tests/cypress/e2e/designer/basicNodeActions/stepCopy.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/basicNodeActions/stepCopy.cy.ts
@@ -110,8 +110,8 @@ describe('Tests for Design page', { browser: '!firefox' }, () => {
             route: {
               from: {
                 id: 'from-1870',
-                uri: 'timer:user',
-                parameters: { period: '{{period}}' },
+                uri: 'timer',
+                parameters: { period: '{{period}}', timerName: 'user' },
                 steps: [
                   { setBody: { id: 'setBody-3387', expression: { simple: {} } } },
                   { marshal: { id: 'marshal-1414' } },

--- a/packages/ui-tests/cypress/e2e/designer/branchingFlows/branchingStepAddition.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/branchingFlows/branchingStepAddition.cy.ts
@@ -63,8 +63,8 @@ describe('Test for Branching actions from the canvas', () => {
     cy.checkNodeExist('activemq', 1);
     cy.checkEdgeExists(
       'eip-action',
-      'template.from.steps.1.choice.when.0.steps.1.setHeader',
-      'template.from.steps.1.choice.when.0.steps.2.to',
+      'template.route.from.steps.1.choice.when.0.steps.1.setHeader',
+      'template.route.from.steps.1.choice.when.0.steps.2.to',
     );
   });
 
@@ -79,8 +79,8 @@ describe('Test for Branching actions from the canvas', () => {
     cy.checkNodeExist('activemq', 1);
     cy.checkEdgeExists(
       'eip-action',
-      'template.from.steps.1.choice.when.0.steps.0.to',
-      'template.from.steps.1.choice.when.0.steps.1.to',
+      'template.route.from.steps.1.choice.when.0.steps.0.to',
+      'template.route.from.steps.1.choice.when.0.steps.1.to',
     );
   });
 
@@ -93,6 +93,6 @@ describe('Test for Branching actions from the canvas', () => {
     cy.chooseFromCatalog('component', 'activemq');
 
     cy.checkNodeExist('activemq', 1);
-    cy.checkEdgeExists('eip-action', 'template.from.steps.2.to', 'template.from.steps.3.filter');
+    cy.checkEdgeExists('eip-action', 'template.route.from.steps.2.to', 'template.route.from.steps.3.filter');
   });
 });

--- a/packages/ui-tests/cypress/e2e/designer/routeDocumentation/exportRouteDocumentation.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/routeDocumentation/exportRouteDocumentation.cy.ts
@@ -26,7 +26,8 @@ describe('Test documentation generation functionality', () => {
     cy.generateDocumentationPreview();
 
     const expectedStepsTableData = [
-      ['from-1870', 'from', 'timer:user', 'period', '{{period}}'],
+      ['from-1870', 'from', 'timer', 'period', '{{period}}'],
+      ['', '', '', 'timerName', 'user'],
       ['setBody-3387', 'setBody', '', 'expression (simple)', ''],
       ['marshal-1414', 'marshal', '', '', ''],
       ['', 'to', 'kamelet:sink', '', ''],

--- a/packages/ui-tests/cypress/e2e/designer/specialKamelets/serializeTemplateFrom.cy.ts
+++ b/packages/ui-tests/cypress/e2e/designer/specialKamelets/serializeTemplateFrom.cy.ts
@@ -1,0 +1,17 @@
+describe('Tests for Serializing Kamelets', () => {
+  beforeEach(() => {
+    cy.openHomePage();
+  });
+
+  it('Design - move steps in Kamelet', () => {
+    cy.uploadFixture('flows/kamelet/template-from.yaml');
+    cy.openDesignPage();
+
+    cy.openStepConfigurationTab('timer');
+    cy.selectFormTab('All');
+    cy.interactWithConfigInputObject('parameters.period', '{{period}}', { parseSpecialCharSequences: false });
+
+    cy.openSourceCode();
+    cy.compareFileWithMonacoEditor('flows/kamelet/basic.yaml');
+  });
+});

--- a/packages/ui-tests/cypress/fixtures/flows/kamelet/basic.yaml
+++ b/packages/ui-tests/cypress/fixtures/flows/kamelet/basic.yaml
@@ -24,18 +24,19 @@ spec:
     - camel:http
     - camel:kamelet
   template:
-    from:
-      id: from-1870
-      uri: timer:user
-      parameters:
-        period: "{{period}}"
-      steps:
-        - setBody:
-            id: setBody-3387
-            expression:
-              simple: {}
-        - marshal:
-            id: marshal-1414
-        - to:
-            uri: kamelet:sink
-            parameters: {}
+    route:
+      from:
+        id: from-1870
+        uri: timer:user
+        parameters:
+          period: "{{period}}"
+        steps:
+          - setBody:
+              id: setBody-3387
+              expression:
+                simple: {}
+          - marshal:
+              id: marshal-1414
+          - to:
+              uri: kamelet:sink
+              parameters: {}

--- a/packages/ui-tests/cypress/fixtures/flows/kamelet/template-from.yaml
+++ b/packages/ui-tests/cypress/fixtures/flows/kamelet/template-from.yaml
@@ -24,20 +24,18 @@ spec:
     - camel:http
     - camel:kamelet
   template:
-    route:
-      from:
-        id: from-1870
-        uri: timer
-        parameters:
-          period: "{{period}}"
-          timerName: user
-        steps:
-          - setBody:
-              id: setBody-3387
-              expression:
-                simple: {}
-          - marshal:
-              id: marshal-1414
-          - to:
-              uri: kamelet:sink
-              parameters: {}
+    from:
+      id: from-1870
+      uri: timer:user
+      parameters:
+        period: "1000"
+      steps:
+        - setBody:
+            id: setBody-3387
+            expression:
+              simple: {}
+        - marshal:
+            id: marshal-1414
+        - to:
+            uri: kamelet:sink
+            parameters: {}

--- a/packages/ui-tests/cypress/support/cypress.d.ts
+++ b/packages/ui-tests/cypress/support/cypress.d.ts
@@ -105,8 +105,16 @@ declare global {
       DnDOnEdge(sourceNode: string, targetEdge: string): Chainable<JQuery<Element>>;
       retryClickDropdown(dropdownSelector: string, listSelector: string): Chainable<JQuery<Element>>;
       // nodeConfiguration
-      interactWithConfigInputObject(inputName: string, value?: string): Chainable<JQuery<Element>>;
-      interactWithExpressionInputObject(inputName: string, value?: string, index?: number): Chainable<JQuery<Element>>;
+      interactWithConfigInputObject(
+        inputName: string,
+        value?: string,
+        options?: Partial<Cypress.TypeOptions>,
+      ): Chainable<JQuery<Element>>;
+      interactWithExpressionInputObject(
+        inputName: string,
+        value?: string,
+        options?: Partial<Cypress.TypeOptions>,
+      ): Chainable<JQuery<Element>>;
       addExpressionResultType(value: string, index?: number): Chainable<JQuery<Element>>;
       checkExpressionResultType(value: string): Chainable<JQuery<Element>>;
       checkConfigCheckboxObject(inputName: string, value: boolean): Chainable<JQuery<Element>>;
@@ -117,7 +125,6 @@ declare global {
       configureBeanReference(inputName: string, value: string): Chainable<JQuery<Element>>;
       configureNewBeanReference(inputName: string): Chainable<JQuery<Element>>;
       selectDataformat(dataformat: string): Chainable<JQuery<Element>>;
-      selectCustomMetadataEditor(type: string, expression: string): Chainable<JQuery<Element>>;
       configureDropdownValue(inputName: string, value: string): Chainable<JQuery<Element>>;
       deselectNodeBean(inputName: string): Chainable<JQuery<Element>>;
       addProperty(propertyName: string): Chainable<JQuery<Element>>;

--- a/packages/ui-tests/cypress/support/next-commands/nodeConfiguration.ts
+++ b/packages/ui-tests/cypress/support/next-commands/nodeConfiguration.ts
@@ -1,16 +1,22 @@
-Cypress.Commands.add('interactWithConfigInputObject', (inputName: string, value?: string) => {
-  cy.interactWithExpressionInputObject(`#.${inputName}`, value);
-});
+Cypress.Commands.add(
+  'interactWithConfigInputObject',
+  (inputName: string, value?: string, options?: Partial<Cypress.TypeOptions>) => {
+    cy.interactWithExpressionInputObject(`#.${inputName}`, value, options);
+  },
+);
 
-Cypress.Commands.add('interactWithExpressionInputObject', (inputName: string, value?: string) => {
-  if (value !== undefined && value !== null) {
-    cy.get(`input[name="${inputName}"], textarea[name="${inputName}"]`).clear();
-    cy.get(`input[name="${inputName}"], textarea[name="${inputName}"]`).type(value);
-  } else {
-    /** We need to use {force:true} because the `Switch` component is wrapped by a label component, blocking the click event */
-    cy.get(`input[name="${inputName}"], textarea[name="${inputName}"]`).click({ force: true });
-  }
-});
+Cypress.Commands.add(
+  'interactWithExpressionInputObject',
+  (inputName: string, value?: string, options?: Partial<Cypress.TypeOptions>) => {
+    if (value !== undefined && value !== null) {
+      cy.get(`input[name="${inputName}"], textarea[name="${inputName}"]`).clear();
+      cy.get(`input[name="${inputName}"], textarea[name="${inputName}"]`).type(value, options);
+    } else {
+      /** We need to use {force:true} because the `Switch` component is wrapped by a label component, blocking the click event */
+      cy.get(`input[name="${inputName}"], textarea[name="${inputName}"]`).click({ force: true });
+    }
+  },
+);
 
 Cypress.Commands.add('addExpressionResultType', (value: string) => {
   cy.get(`input.pf-v6-c-text-input-group__text-input`).clear();
@@ -91,12 +97,8 @@ Cypress.Commands.add('configureNewBeanReference', (inputName: string) => {
 });
 
 Cypress.Commands.add('selectDataformat', (dataformat: string) => {
-  cy.selectCustomMetadataEditor('dataformat', dataformat);
-});
-
-Cypress.Commands.add('selectCustomMetadataEditor', (type: string, format: string) => {
   cy.get(`div[data-testid="#__oneof-list-typeahead-select-input"]`).click();
-  cy.get('.pf-v6-c-menu__item-text').contains(format).first().click();
+  cy.get('.pf-v6-c-menu__item-text').contains(dataformat).first().click();
 });
 
 Cypress.Commands.add('configureDropdownValue', (inputName: string, value?: string) => {

--- a/packages/ui/src/models/__snapshots__/kaoto-resource.test.ts.snap
+++ b/packages/ui/src/models/__snapshots__/kaoto-resource.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`CamelResourceFactory.createCamelResource > should create an empty KameletResource if no args is specified 1`] = `
 [
   {
-    "from": {},
+    "route": {
+      "from": {},
+    },
   },
 ]
 `;

--- a/packages/ui/src/models/camel/__snapshots__/kamelet-resource.test.ts.snap
+++ b/packages/ui/src/models/camel/__snapshots__/kamelet-resource.test.ts.snap
@@ -60,6 +60,7 @@ exports[`KameletResource > should convert to JSON 1`] = `
           ],
           "uri": "timer",
         },
+        "id": "route-1234",
       },
     },
     "types": {
@@ -131,6 +132,7 @@ exports[`KameletResource > should create a new KameletResource 1`] = `
           ],
           "uri": "timer",
         },
+        "id": "route-1234",
       },
     },
     "types": {
@@ -204,6 +206,7 @@ exports[`KameletResource > should get the visual entities (Camel Route Visual En
         ],
         "uri": "timer",
       },
+      "id": "route-1234",
     },
   },
 ]

--- a/packages/ui/src/models/camel/__snapshots__/kamelet-resource.test.ts.snap
+++ b/packages/ui/src/models/camel/__snapshots__/kamelet-resource.test.ts.snap
@@ -38,26 +38,28 @@ exports[`KameletResource > should convert to JSON 1`] = `
     ],
     "template": {
       "beans": undefined,
-      "from": {
-        "id": "from-1234",
-        "parameters": {
-          "period": "{{period}}",
-          "timerName": "user",
-        },
-        "steps": [
-          {
-            "to": {
-              "parameters": {
-                "httpUri": "random-data-api.com/api/v2/users",
+      "route": {
+        "from": {
+          "id": "from-1234",
+          "parameters": {
+            "period": "{{period}}",
+            "timerName": "user",
+          },
+          "steps": [
+            {
+              "to": {
+                "parameters": {
+                  "httpUri": "random-data-api.com/api/v2/users",
+                },
+                "uri": "https",
               },
-              "uri": "https",
             },
-          },
-          {
-            "to": "kamelet:sink",
-          },
-        ],
-        "uri": "timer",
+            {
+              "to": "kamelet:sink",
+            },
+          ],
+          "uri": "timer",
+        },
       },
     },
     "types": {
@@ -107,26 +109,28 @@ exports[`KameletResource > should create a new KameletResource 1`] = `
     ],
     "template": {
       "beans": undefined,
-      "from": {
-        "id": "from-1234",
-        "parameters": {
-          "period": "{{period}}",
-          "timerName": "user",
-        },
-        "steps": [
-          {
-            "to": {
-              "parameters": {
-                "httpUri": "random-data-api.com/api/v2/users",
+      "route": {
+        "from": {
+          "id": "from-1234",
+          "parameters": {
+            "period": "{{period}}",
+            "timerName": "user",
+          },
+          "steps": [
+            {
+              "to": {
+                "parameters": {
+                  "httpUri": "random-data-api.com/api/v2/users",
+                },
+                "uri": "https",
               },
-              "uri": "https",
             },
-          },
-          {
-            "to": "kamelet:sink",
-          },
-        ],
-        "uri": "timer",
+            {
+              "to": "kamelet:sink",
+            },
+          ],
+          "uri": "timer",
+        },
       },
     },
     "types": {
@@ -163,10 +167,12 @@ exports[`KameletResource > should create a new KameletResource with a kamelet 1`
     "dependencies": [],
     "template": {
       "beans": [],
-      "from": {
-        "id": "from",
-        "steps": [],
-        "uri": "kamelet:source",
+      "route": {
+        "from": {
+          "id": "from",
+          "steps": [],
+          "uri": "kamelet:source",
+        },
       },
     },
   },
@@ -176,26 +182,28 @@ exports[`KameletResource > should create a new KameletResource with a kamelet 1`
 exports[`KameletResource > should get the visual entities (Camel Route Visual Entity) 1`] = `
 [
   {
-    "from": {
-      "id": "from-1234",
-      "parameters": {
-        "period": "{{period}}",
-        "timerName": "user",
-      },
-      "steps": [
-        {
-          "to": {
-            "parameters": {
-              "httpUri": "random-data-api.com/api/v2/users",
+    "route": {
+      "from": {
+        "id": "from-1234",
+        "parameters": {
+          "period": "{{period}}",
+          "timerName": "user",
+        },
+        "steps": [
+          {
+            "to": {
+              "parameters": {
+                "httpUri": "random-data-api.com/api/v2/users",
+              },
+              "uri": "https",
             },
-            "uri": "https",
           },
-        },
-        {
-          "to": "kamelet:sink",
-        },
-      ],
-      "uri": "timer",
+          {
+            "to": "kamelet:sink",
+          },
+        ],
+        "uri": "timer",
+      },
     },
   },
 ]

--- a/packages/ui/src/models/camel/kamelet-resource.test.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.test.ts
@@ -43,12 +43,14 @@ describe('KameletResource', () => {
         },
         dependencies: [],
         template: {
-          from: {
-            id: 'from',
-            uri: 'kamelet:source',
-            steps: [],
-          },
           beans: [],
+          route: {
+            from: {
+              id: 'from',
+              uri: 'kamelet:source',
+              steps: [],
+            },
+          },
         },
       },
     });

--- a/packages/ui/src/models/camel/kamelet-resource.ts
+++ b/packages/ui/src/models/camel/kamelet-resource.ts
@@ -69,7 +69,7 @@ export class KameletResource extends CamelKResource implements RouteTemplateBean
     // Call toJSON() on the flow entity to apply property sorting
     const flowJson = this.flow.toJSON();
     setValue(this.resource, 'metadata.name', this.flow.getId());
-    setValue(this.resource, 'spec.template.from', flowJson.from);
+    setValue(this.resource, 'spec.template.route', flowJson.route);
     setValue(this.resource, 'spec.template.beans', this.beans?.parent.beans);
     return this.resource as IKameletDefinition;
   }

--- a/packages/ui/src/models/camel/kamelets-catalog.ts
+++ b/packages/ui/src/models/camel/kamelets-catalog.ts
@@ -1,4 +1,4 @@
-import { BeanFactory, FromDefinition, Kamelet } from '@kaoto/camel-catalog/types';
+import { BeanFactory, FromDefinition, Kamelet, RouteDefinition } from '@kaoto/camel-catalog/types';
 
 import { KaotoSchemaDefinition } from '../kaoto-schema';
 import { SourceSchemaType } from './source-schema-type';
@@ -49,7 +49,8 @@ export interface IKameletSpec {
   dependencies: string[];
   template: {
     beans?: BeanFactory[];
-    from: FromDefinition;
+    route: RouteDefinition;
+    from?: FromDefinition;
   };
   dataTypes?: {
     in?: {

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -236,7 +236,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
   canDragNode(path?: string) {
     if (!isDefined(path)) return false;
 
-    return path !== 'route' && path !== 'route.from' && path !== 'template.from';
+    return path !== 'route' && path !== 'route.from' && path !== 'template.route.from';
   }
 
   canDropOnNode(path?: string) {

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
@@ -54,7 +54,9 @@ describe('KameletVisualEntity', () => {
           type: 'source',
         },
         template: {
-          from: camelFromJson.from,
+          route: {
+            from: camelFromJson.from,
+          },
         },
         dependencies: [],
       },
@@ -63,6 +65,12 @@ describe('KameletVisualEntity', () => {
 
   it('should create an instance', () => {
     expect(new KameletVisualEntity(kameletDef)).toBeTruthy();
+  });
+
+  it('should normalize template.from to template.route.from and remove template.from', () => {
+    const kameletVisualEntity = new KameletVisualEntity(kameletDef);
+    expect(kameletVisualEntity.kamelet.spec.template.from).toBeUndefined();
+    expect(kameletVisualEntity.kamelet.spec.template.route?.from).toEqual(camelFromJson.from);
   });
 
   it('should set the id to the name if provided', () => {
@@ -138,12 +146,27 @@ describe('KameletVisualEntity', () => {
     expect(fetchNodeSchemaSpy).toHaveBeenCalledWith(ids);
   });
 
-  it('should return the root uri', () => {
+  it('should return the root uri when using template.from (short syntax)', () => {
     class KameletVisualEntityTest extends KameletVisualEntity {
       getRootUri(): string | undefined {
         return super.getRootUri();
       }
     }
+    const kamelet = new KameletVisualEntityTest(kameletDef);
+    expect(kamelet.getRootUri()).toBe('timer');
+  });
+
+  it('should return the root uri when using template.route.from', () => {
+    class KameletVisualEntityTest extends KameletVisualEntity {
+      getRootUri(): string | undefined {
+        return super.getRootUri();
+      }
+    }
+    kameletDef.spec.template = {
+      route: {
+        from: camelFromJson.from,
+      },
+    };
     const kamelet = new KameletVisualEntityTest(kameletDef);
     expect(kamelet.getRootUri()).toBe('timer');
   });

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.test.ts
@@ -1,5 +1,6 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { CatalogLibrary } from '@kaoto/camel-catalog/types';
+import { CatalogLibrary, RouteDefinition } from '@kaoto/camel-catalog/types';
+import { cloneDeep } from 'lodash';
 
 import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { mockRandomValues } from '../../../stubs';
@@ -68,7 +69,11 @@ describe('KameletVisualEntity', () => {
   });
 
   it('should normalize template.from to template.route.from and remove template.from', () => {
-    const kameletVisualEntity = new KameletVisualEntity(kameletDef);
+    const kameletDefWithFrom = cloneDeep(kameletDef);
+    kameletDefWithFrom.spec.template.from = kameletDefWithFrom.spec.template.route.from;
+    kameletDefWithFrom.spec.template.route = undefined as unknown as RouteDefinition;
+
+    const kameletVisualEntity = new KameletVisualEntity(kameletDefWithFrom);
     expect(kameletVisualEntity.kamelet.spec.template.from).toBeUndefined();
     expect(kameletVisualEntity.kamelet.spec.template.route?.from).toEqual(camelFromJson.from);
   });

--- a/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/kamelet-visual-entity.ts
@@ -1,4 +1,4 @@
-import { FromDefinition } from '@kaoto/camel-catalog/types';
+import { RouteDefinition } from '@kaoto/camel-catalog/types';
 import { isDefined } from '@kaoto/forms';
 
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
@@ -15,18 +15,26 @@ import { IClipboardContent } from '../clipboard';
 import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { CamelComponentDefaultService } from './support/camel-component-default.service';
 
-export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string; template: { from: FromDefinition } }> {
+export class KameletVisualEntity extends AbstractCamelVisualEntity<{
+  id: string;
+  template: { route: RouteDefinition };
+}> {
   id: string;
   readonly type = EntityType.Kamelet;
-  static readonly ROOT_PATH = 'template';
+  static readonly ROOT_PATH = 'template.route';
 
   constructor(public kamelet: IKameletDefinition) {
+    const { route, from, ...templateWithoutFrom } = kamelet.spec?.template ?? {};
+
     const spec: IKameletSpec = {
       ...kamelet.spec,
       template: {
-        ...kamelet.spec?.template,
-        from: {
-          ...kamelet.spec?.template?.from,
+        ...templateWithoutFrom,
+        route: {
+          ...route,
+          from: {
+            ...(from ?? route?.from),
+          },
         },
       },
       definition: {
@@ -35,7 +43,7 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
         ...(kamelet.spec?.definition?.description ? { description: kamelet.spec?.definition?.description } : {}),
       },
     };
-    super({ id: kamelet.metadata?.name, template: { from: spec.template.from } });
+    super({ id: kamelet.metadata?.name, template: { route: spec.template.route } });
     this.id = (kamelet?.metadata?.name as string) ?? getCamelRandomId('kamelet');
     this.kamelet.metadata = kamelet?.metadata ?? { name: this.id };
     this.kamelet.metadata.name = kamelet?.metadata.name ?? this.id;
@@ -71,8 +79,8 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
     return super.getNodeLabel(path, labelType, ids);
   }
 
-  toJSON(): { from: FromDefinition } {
-    return { from: this.entityDef.template.from };
+  toJSON(): { route: RouteDefinition } {
+    return { route: this.entityDef.template.route };
   }
 
   async fetchNodeSchema(ids: IVisualizationNodeIds): Promise<KaotoSchemaDefinition['schema'] | undefined> {
@@ -130,10 +138,10 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
     if (
       options.mode === AddStepMode.ReplaceStep &&
       options.data.path === `${this.getRootPath()}.from` &&
-      isDefined(this.entityDef.template.from)
+      isDefined(this.entityDef.template.route.from)
     ) {
       const fromValue = CamelComponentDefaultService.getDefaultFromDefinitionValue(options.definedComponent);
-      Object.assign(this.entityDef.template.from, fromValue);
+      Object.assign(this.entityDef.template.route.from, fromValue);
       return;
     }
 
@@ -166,7 +174,7 @@ export class KameletVisualEntity extends AbstractCamelVisualEntity<{ id: string;
   }
 
   protected getRootUri(): string | undefined {
-    return this.kamelet.spec.template.from?.uri;
+    return this.kamelet.spec.template.route.from.uri;
   }
 
   private async getRootKameletSchema(): Promise<KaotoSchemaDefinition['schema']> {

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.test.ts
@@ -338,7 +338,7 @@ describe('CamelComponentFilterService', () => {
     it('should not provide ProducerOnly components', () => {
       const filterFn = CamelComponentFilterService.getKameletCompatibleComponents(AddStepMode.ReplaceStep, {
         name: 'from',
-        path: 'template.from',
+        path: 'template.route.from',
         processorName: 'from' as keyof ProcessorDefinition,
         label: 'timer',
         isPlaceholder: false,

--- a/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-filter.service.ts
@@ -63,7 +63,7 @@ export class CamelComponentFilterService {
     const camelComponentFilter = this.getCamelCompatibleComponents(mode, visualEntityData, definition);
 
     /** For the `from` step we want to add kamelet:source and leverage the existing getCamelCompatibleComponents method */
-    if (mode === AddStepMode.ReplaceStep && visualEntityData.path === 'template.from') {
+    if (mode === AddStepMode.ReplaceStep && visualEntityData.path === 'template.route.from') {
       return (item: ITile) => {
         return (item.type === CatalogKind.Kamelet && item.name === 'source') || camelComponentFilter(item);
       };
@@ -82,7 +82,7 @@ export class CamelComponentFilterService {
   private static replaceFilter(mode: AddStepMode, visualEntityData: IVisualizationNodeData): TileFilter | undefined {
     if (
       mode === AddStepMode.ReplaceStep &&
-      (visualEntityData.path === 'route.from' || visualEntityData.path === 'template.from')
+      (visualEntityData.path === 'route.from' || visualEntityData.path === 'template.route.from')
     ) {
       /**
        * For the `from` step we want to show only components which are not `producerOnly`,

--- a/packages/ui/src/models/visualization/flows/templates/kamelet.ts
+++ b/packages/ui/src/models/visualization/flows/templates/kamelet.ts
@@ -34,16 +34,18 @@ spec:
     - "camel:http"
     - "camel:kamelet"
   template:
-    from:
-      id: ${getCamelRandomId('from')}
-      uri: timer
-      parameters:
-        period: "{{period}}"
-        timerName: user
-      steps:
-      - to:
-          uri: https
-          parameters:
-            httpUri: random-data-api.com/api/v2/users
-      - to: "kamelet:sink"`;
+    route:
+      id: ${getCamelRandomId('route')}
+      from:
+        id: ${getCamelRandomId('from')}
+        uri: timer
+        parameters:
+          period: "{{period}}"
+          timerName: user
+        steps:
+        - to:
+            uri: https
+            parameters:
+              httpUri: random-data-api.com/api/v2/users
+        - to: "kamelet:sink"`;
 };

--- a/packages/ui/src/services/parsers/kamelet-parser.ts
+++ b/packages/ui/src/services/parsers/kamelet-parser.ts
@@ -9,7 +9,7 @@ export class KameletParser {
   static parseKameletEntity(entity: KameletVisualEntity): ParsedTable[] {
     const answer: ParsedTable[] = [];
 
-    const routeTable = KameletParser.parseRoute(entity.kamelet.spec.template.from);
+    const routeTable = KameletParser.parseRoute(entity.kamelet.spec.template.route.from);
     answer.push(routeTable);
 
     const definitionTable = KameletParser.parseDefinition(entity.kamelet.spec.definition);

--- a/packages/ui/src/utils/__snapshots__/update-kamelet-from-custom-schema.test.ts.snap
+++ b/packages/ui/src/utils/__snapshots__/update-kamelet-from-custom-schema.test.ts.snap
@@ -40,26 +40,28 @@ exports[`updateKameletFromCustomSchema > should get the kamelet schema from the 
       "camel:kamelet",
     ],
     "template": {
-      "from": {
-        "id": "from-3836",
-        "parameters": {
-          "period": "{{period}}",
-          "timerName": "user",
-        },
-        "steps": [
-          {
-            "to": {
-              "parameters": {
-                "httpUri": "random-data-api.com/api/v2/users",
+      "route": {
+        "from": {
+          "id": "from-3836",
+          "parameters": {
+            "period": "{{period}}",
+            "timerName": "user",
+          },
+          "steps": [
+            {
+              "to": {
+                "parameters": {
+                  "httpUri": "random-data-api.com/api/v2/users",
+                },
+                "uri": "https",
               },
-              "uri": "https",
             },
-          },
-          {
-            "to": "kamelet:sink",
-          },
-        ],
-        "uri": "timer",
+            {
+              "to": "kamelet:sink",
+            },
+          ],
+          "uri": "timer",
+        },
       },
     },
     "types": {
@@ -104,26 +106,28 @@ exports[`updateKameletFromCustomSchema > should get the kamelet schema from the 
       "camel:kamelet",
     ],
     "template": {
-      "from": {
-        "id": "from-3836",
-        "parameters": {
-          "period": "{{period}}",
-          "timerName": "user",
-        },
-        "steps": [
-          {
-            "to": {
-              "parameters": {
-                "httpUri": "random-data-api.com/api/v2/users",
+      "route": {
+        "from": {
+          "id": "from-3836",
+          "parameters": {
+            "period": "{{period}}",
+            "timerName": "user",
+          },
+          "steps": [
+            {
+              "to": {
+                "parameters": {
+                  "httpUri": "random-data-api.com/api/v2/users",
+                },
+                "uri": "https",
               },
-              "uri": "https",
             },
-          },
-          {
-            "to": "kamelet:sink",
-          },
-        ],
-        "uri": "timer",
+            {
+              "to": "kamelet:sink",
+            },
+          ],
+          "uri": "timer",
+        },
       },
     },
     "types": {
@@ -168,26 +172,28 @@ exports[`updateKameletFromCustomSchema > should not preserve kamelet properties 
       "camel:kamelet",
     ],
     "template": {
-      "from": {
-        "id": "from-3836",
-        "parameters": {
-          "period": "{{period}}",
-          "timerName": "user",
-        },
-        "steps": [
-          {
-            "to": {
-              "parameters": {
-                "httpUri": "random-data-api.com/api/v2/users",
+      "route": {
+        "from": {
+          "id": "from-3836",
+          "parameters": {
+            "period": "{{period}}",
+            "timerName": "user",
+          },
+          "steps": [
+            {
+              "to": {
+                "parameters": {
+                  "httpUri": "random-data-api.com/api/v2/users",
+                },
+                "uri": "https",
               },
-              "uri": "https",
             },
-          },
-          {
-            "to": "kamelet:sink",
-          },
-        ],
-        "uri": "timer",
+            {
+              "to": "kamelet:sink",
+            },
+          ],
+          "uri": "timer",
+        },
       },
     },
     "types": {
@@ -232,26 +238,28 @@ exports[`updateKameletFromCustomSchema > should preserve kamelet properties orig
       "camel:kamelet",
     ],
     "template": {
-      "from": {
-        "id": "from-3836",
-        "parameters": {
-          "period": "{{period}}",
-          "timerName": "user",
-        },
-        "steps": [
-          {
-            "to": {
-              "parameters": {
-                "httpUri": "random-data-api.com/api/v2/users",
+      "route": {
+        "from": {
+          "id": "from-3836",
+          "parameters": {
+            "period": "{{period}}",
+            "timerName": "user",
+          },
+          "steps": [
+            {
+              "to": {
+                "parameters": {
+                  "httpUri": "random-data-api.com/api/v2/users",
+                },
+                "uri": "https",
               },
-              "uri": "https",
             },
-          },
-          {
-            "to": "kamelet:sink",
-          },
-        ],
-        "uri": "timer",
+            {
+              "to": "kamelet:sink",
+            },
+          ],
+          "uri": "timer",
+        },
       },
     },
     "types": {

--- a/packages/ui/src/utils/get-custom-schema-from-kamelet.test.ts
+++ b/packages/ui/src/utils/get-custom-schema-from-kamelet.test.ts
@@ -44,26 +44,28 @@ describe('getCustomSchemaFromKamelet', () => {
         },
         dependencies: ['camel:timer', 'camel:http', 'camel:kamelet'],
         template: {
-          from: {
-            steps: [
-              {
-                to: {
-                  uri: 'https',
-                  parameters: {
-                    httpUri: 'random-data-api.com/api/v2/users',
+          route: {
+            from: {
+              steps: [
+                {
+                  to: {
+                    uri: 'https',
+                    parameters: {
+                      httpUri: 'random-data-api.com/api/v2/users',
+                    },
                   },
                 },
+                {
+                  to: 'kamelet:sink',
+                },
+              ],
+              id: 'from-3836',
+              parameters: {
+                period: '{{period}}',
+                timerName: 'user',
               },
-              {
-                to: 'kamelet:sink',
-              },
-            ],
-            id: 'from-3836',
-            parameters: {
-              period: '{{period}}',
-              timerName: 'user',
+              uri: 'timer',
             },
-            uri: 'timer',
           },
         },
         types: {

--- a/packages/ui/src/utils/update-kamelet-from-custom-schema.test.ts
+++ b/packages/ui/src/utils/update-kamelet-from-custom-schema.test.ts
@@ -42,26 +42,28 @@ describe('updateKameletFromCustomSchema', () => {
         },
         dependencies: ['camel:timer', 'camel:http', 'camel:kamelet'],
         template: {
-          from: {
-            steps: [
-              {
-                to: {
-                  uri: 'https',
-                  parameters: {
-                    httpUri: 'random-data-api.com/api/v2/users',
+          route: {
+            from: {
+              steps: [
+                {
+                  to: {
+                    uri: 'https',
+                    parameters: {
+                      httpUri: 'random-data-api.com/api/v2/users',
+                    },
                   },
                 },
+                {
+                  to: 'kamelet:sink',
+                },
+              ],
+              id: 'from-3836',
+              parameters: {
+                period: '{{period}}',
+                timerName: 'user',
               },
-              {
-                to: 'kamelet:sink',
-              },
-            ],
-            id: 'from-3836',
-            parameters: {
-              period: '{{period}}',
-              timerName: 'user',
+              uri: 'timer',
             },
-            uri: 'timer',
           },
         },
         types: {


### PR DESCRIPTION
### Context

Kamelets support both `route.from` and `from` definitions. At the moment, Kaoto supports `from` only, leaving other types of Kamelet without support.

This commit reads both Kamelet's type but serializes it to the more expressive one to keep backward compatibility

fixes: https://github.com/KaotoIO/kaoto/issues/3839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Kamelet route definitions are now represented under `template.route`, with source routes available at `template.route.from`.
  - Kamelet parsing, serialization, visualization, editing, and compatibility checks now support the updated structure.
  - Timer sources now represent the endpoint and timer name as separate values.
  - Route content and metadata remain unchanged apart from the revised template nesting.
  - Added coverage for route serialization, timer parameter editing, copying, branching, and documentation output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->