### PR TITLE
fix(DataMapper): consistent value-of/copy-of rendering and mixed cont…

### DIFF
--- a/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/FieldNodeTitle.tsx
@@ -27,8 +27,11 @@ export const FieldNodeTitle: FunctionComponent<FieldNodeTitleProps> = ({ classNa
   const repeatingField0 = nodeData.field.minOccurs >= 0 && nodeData.field.maxOccurs === 'unbounded';
   const repeatingField1 = nodeData.field.minOccurs >= 1 && nodeData.field.maxOccurs === 'unbounded';
 
+  const inlineCopyOf = VisualizationUtilService.getInlineContainerCopyOf(nodeData);
+
   return (
     <div className={clsx('node-title-container', { 'node-title-container__abstract': isAbstractWrapper })}>
+      {inlineCopyOf && <Label data-testid="field-copy-of-label">{inlineCopyOf.name}</Label>}
       {isChoiceWrapper && <Label>choice</Label>}
       {isSelectedChoiceWrapper && (
         <Label color="green" icon={<CheckIcon />}>

--- a/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
+++ b/packages/ui/src/components/Document/NodeTitle/NodeTitle.test.tsx
@@ -8,16 +8,25 @@ import {
   DocumentType,
   PrimitiveDocument,
 } from '../../../models/datamapper/document';
-import { IfItem, MappingTree, UnknownMappingItem } from '../../../models/datamapper/mapping';
+import {
+  CopyOfSelector,
+  CopyOfType,
+  FieldItem,
+  IfItem,
+  MappingTree,
+  UnknownMappingItem,
+} from '../../../models/datamapper/mapping';
 import {
   AbstractFieldNodeData,
   ChoiceFieldNodeData,
   DocumentNodeData,
+  FieldItemNodeData,
   FieldNodeData,
   MappingNodeData,
   TargetDocumentNodeData,
   UnknownMappingNodeData,
 } from '../../../models/datamapper/visualization';
+import { VisualizationService } from '../../../services/visualization/visualization.service';
 import { TestUtil } from '../../../stubs/datamapper/data-mapper';
 import { NodeTitle } from './NodeTitle';
 
@@ -282,5 +291,44 @@ describe('NodeTitle', () => {
       },
       { timeout: 1000 },
     );
+  });
+
+  describe('copy-of label on FieldNodeTitle', () => {
+    const createFieldItemNodeData = (copyOfType: CopyOfType) => {
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const tree = new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA);
+      const targetDocNodeData = new TargetDocumentNodeData(targetDoc, tree);
+      const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNodeData);
+      const shipOrderField = (docChildren[0] as FieldNodeData).field;
+      const shipOrderFI = new FieldItem(tree, shipOrderField);
+      tree.children.push(shipOrderFI);
+      shipOrderFI.children.push(new CopyOfSelector(shipOrderFI, copyOfType));
+      return new FieldItemNodeData(targetDocNodeData, shipOrderFI);
+    };
+
+    it('should show copy-of label badge on FieldItemNodeData with inline CopyOfSelector (CONTAINER)', () => {
+      render(<NodeTitle nodeData={createFieldItemNodeData(CopyOfType.CONTAINER)} isDocument={false} rank={0} />);
+
+      const badge = screen.getByTestId('field-copy-of-label');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent('copy');
+    });
+
+    it('should NOT show copy-of label badge when CopyOfSelector has CONTAINER_NODE type', () => {
+      render(<NodeTitle nodeData={createFieldItemNodeData(CopyOfType.CONTAINER_NODE)} isDocument={false} rank={0} />);
+
+      expect(screen.queryByTestId('field-copy-of-label')).not.toBeInTheDocument();
+    });
+
+    it('should NOT show copy-of label on a plain FieldNodeData without mapping', () => {
+      const targetDoc = TestUtil.createTargetOrderDoc();
+      const documentNodeData = new DocumentNodeData(targetDoc);
+      const shipOrderField = targetDoc.fields[0];
+      const fieldNodeData = new FieldNodeData(documentNodeData, shipOrderField);
+
+      render(<NodeTitle nodeData={fieldNodeData} isDocument={false} rank={0} />);
+
+      expect(screen.queryByTestId('field-copy-of-label')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.test.tsx
@@ -698,7 +698,7 @@ describe('TargetDocumentNode', () => {
       expect(nodeContainer).toHaveAttribute('data-selected', 'true');
     });
 
-    it('should call applyValueSelector and handleUpdate on double click', () => {
+    it('should call applyValueOfSelector and handleUpdate on double click', () => {
       const document = new PrimitiveDocument(
         new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
       );
@@ -708,7 +708,7 @@ describe('TargetDocumentNode', () => {
       const getAllowedActionsSpy = vi
         .spyOn(MappingActionRegistryService, 'getAllowedActions')
         .mockReturnValue([MappingActionKind.ValueSelector]);
-      const applyValueSelectorSpy = vi.spyOn(MappingActionService, 'applyValueSelector');
+      const applyValueOfSelectorSpy = vi.spyOn(MappingActionService, 'applyValueOfSelector');
 
       render(<TargetDocumentNode treeNode={tree.root} documentId={documentNodeData.id} rank={0} />, { wrapper });
 
@@ -718,14 +718,14 @@ describe('TargetDocumentNode', () => {
       fireEvent.doubleClick(nodeContainer);
 
       expect(getAllowedActionsSpy).toHaveBeenCalledWith(documentNodeData);
-      expect(applyValueSelectorSpy).toHaveBeenCalledWith(documentNodeData);
-      expect(applyValueSelectorSpy).toHaveBeenCalledTimes(1);
+      expect(applyValueOfSelectorSpy).toHaveBeenCalledWith(documentNodeData);
+      expect(applyValueOfSelectorSpy).toHaveBeenCalledTimes(1);
 
       getAllowedActionsSpy.mockRestore();
-      applyValueSelectorSpy.mockRestore();
+      applyValueOfSelectorSpy.mockRestore();
     });
 
-    it('should not call applyValueSelector when allowValueSelector is false', () => {
+    it('should not call applyValueOfSelector when allowValueSelector is false', () => {
       const document = new PrimitiveDocument(
         new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
       );
@@ -733,7 +733,7 @@ describe('TargetDocumentNode', () => {
       const tree = new DocumentTree(documentNodeData);
 
       const getAllowedActionsSpy = vi.spyOn(MappingActionRegistryService, 'getAllowedActions').mockReturnValue([]);
-      const applyValueSelectorSpy = vi.spyOn(MappingActionService, 'applyValueSelector');
+      const applyValueOfSelectorSpy = vi.spyOn(MappingActionService, 'applyValueOfSelector');
 
       render(<TargetDocumentNode treeNode={tree.root} documentId={documentNodeData.id} rank={0} />, { wrapper });
 
@@ -743,10 +743,10 @@ describe('TargetDocumentNode', () => {
       fireEvent.doubleClick(nodeContainer);
 
       expect(getAllowedActionsSpy).toHaveBeenCalledWith(documentNodeData);
-      expect(applyValueSelectorSpy).not.toHaveBeenCalled();
+      expect(applyValueOfSelectorSpy).not.toHaveBeenCalled();
 
       getAllowedActionsSpy.mockRestore();
-      applyValueSelectorSpy.mockRestore();
+      applyValueOfSelectorSpy.mockRestore();
     });
   });
 

--- a/packages/ui/src/components/Document/TargetDocumentNode.tsx
+++ b/packages/ui/src/components/Document/TargetDocumentNode.tsx
@@ -124,7 +124,7 @@ export const TargetDocumentNode: FunctionComponent<DocumentNodeProps> = memo(
         return;
       }
 
-      MappingActionService.applyValueSelector(nodeData);
+      MappingActionService.applyValueOfSelector(nodeData);
       handleStructuralUpdate();
     }, [nodeData, handleStructuralUpdate]);
 

--- a/packages/ui/src/models/datamapper/mapping.ts
+++ b/packages/ui/src/models/datamapper/mapping.ts
@@ -405,7 +405,7 @@ export class CopyOfSelector extends ValueSelector {
     public parent: MappingParentType,
     public valueType: CopyOfType = CopyOfType.CONTAINER,
   ) {
-    super(parent, 'copy-of');
+    super(parent, 'copy');
   }
   doClone() {
     return new CopyOfSelector(this.parent, this.valueType);

--- a/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
+++ b/packages/ui/src/services/mapping/mapping-serializer.service.test.ts
@@ -426,6 +426,39 @@ describe('MappingSerializerService', () => {
   });
 
   describe('serialize()', () => {
+    it('should preserve copy-of and value-of on the same container through a round trip', () => {
+      const mappingTree = new MappingTree(
+        DocumentType.TARGET_BODY,
+        BODY_DOCUMENT_ID,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      mappingTree.namespaceMap = { ns0: targetDoc.fields[0].namespaceURI };
+      const shipOrderFieldItem = new FieldItem(mappingTree, targetDoc.fields[0]);
+      mappingTree.children.push(shipOrderFieldItem);
+
+      const copyOf = new CopyOfSelector(shipOrderFieldItem, CopyOfType.CONTAINER);
+      copyOf.expression = '/ns0:ShipOrder';
+      const valueOf = new ValueOfSelector(shipOrderFieldItem);
+      valueOf.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      shipOrderFieldItem.children.push(copyOf, valueOf);
+
+      const serialized = MappingSerializerService.serialize(mappingTree, sourceParameterMap);
+      const { mappingTree: reloaded } = MappingSerializerService.deserialize(
+        serialized,
+        targetDoc,
+        new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA),
+        sourceParameterMap,
+      );
+      const reloadedShipOrder = reloaded.children[0] as FieldItem;
+
+      expect(reloadedShipOrder.children.find((child) => child instanceof CopyOfSelector)?.expression).toBe(
+        copyOf.expression,
+      );
+      expect(reloadedShipOrder.children.find((child) => child instanceof ValueOfSelector)?.expression).toBe(
+        valueOf.expression,
+      );
+    });
+
     it('should return an empty XSLT document with empty mappings', () => {
       const empty = MappingSerializerService.serialize(
         new MappingTree(DocumentType.TARGET_BODY, BODY_DOCUMENT_ID, DocumentDefinitionType.XML_SCHEMA),

--- a/packages/ui/src/services/visualization/mapping-action.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.test.ts
@@ -72,17 +72,17 @@ describe('MappingActionService', () => {
       targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
     });
 
-    describe('applyValueSelector()', () => {
-      it('should apply value selector', () => {
+    describe('applyValueOfSelector()', () => {
+      it('should apply value-of selector on a container field', () => {
         expect(tree.children).toHaveLength(0);
         const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
-        MappingActionService.applyValueSelector(docChildren[0] as TargetNodeData);
+        MappingActionService.applyValueOfSelector(docChildren[0] as TargetNodeData);
 
         expect(tree.children).toHaveLength(1);
         expect(tree.children[0].children[0] instanceof ValueSelector).toBeTruthy();
       });
 
-      it('should apply value selector on primitive target body', () => {
+      it('should apply value-of selector on primitive target body', () => {
         const primitiveTargetDoc = new PrimitiveDocument(
           new DocumentDefinition(DocumentType.TARGET_BODY, DocumentDefinitionType.Primitive, BODY_DOCUMENT_ID),
         );
@@ -92,15 +92,30 @@ describe('MappingActionService', () => {
           DocumentDefinitionType.XML_SCHEMA,
         );
         targetDocNode = new TargetDocumentNodeData(primitiveTargetDoc, tree);
-        MappingActionService.applyValueSelector(targetDocNode);
+        MappingActionService.applyValueOfSelector(targetDocNode);
 
         expect(VisualizationService.hasChildren(targetDocNode)).toBeFalsy();
         const targetDocChildren = VisualizationService.generatePrimitiveDocumentChildren(targetDocNode);
         expect(targetDocChildren).toHaveLength(0);
       });
-    });
 
-    describe('applyValueOfSelector()', () => {
+      it('should apply value-of when copy-of already exists', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        MappingActionService.applyCopyOfSelector(docChildren[0] as TargetNodeData);
+
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        MappingActionService.applyValueOfSelector(updatedDocChildren[0] as TargetNodeData);
+
+        const shipOrderFieldItem = tree.children[0] as FieldItem;
+        expect(shipOrderFieldItem.children.filter((child) => child instanceof CopyOfSelector)).toHaveLength(1);
+        expect(shipOrderFieldItem.children.filter((child) => child instanceof ValueOfSelector)).toHaveLength(1);
+        const valueOfSelector = shipOrderFieldItem.children.find(
+          (child) => child instanceof ValueOfSelector,
+        ) as ValueOfSelector;
+        expect(useDocumentTreeStore.getState().targetXPathInputForFocus).toBe(valueOfSelector.nodePath.toString());
+      });
+
       it('should create VALUE ValueSelector for element field', () => {
         expect(tree.children).toHaveLength(0);
         const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
@@ -256,6 +271,22 @@ describe('MappingActionService', () => {
         expect(valueSelectorAction!.isDisabled!(updatedShipOrderChildren[0] as TargetNodeData)).toBe(true);
         const copyOfAction = menuItems.find((item) => item.key === MappingActionKind.CopyOfSelector);
         expect(copyOfAction!.isDisabled).toBeUndefined();
+      });
+
+      it('should NOT disable ValueSelector when only copy-of exists', () => {
+        const docChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const shipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(docChildren[0]);
+        MappingActionService.applyCopyOfSelector(shipOrderChildren[0] as TargetNodeData);
+        targetDocNode = new TargetDocumentNodeData(targetDoc, tree);
+        const updatedDocChildren = VisualizationService.generateStructuredDocumentChildren(targetDocNode);
+        const updatedShipOrderChildren = VisualizationService.generateNonDocumentNodeDataChildren(
+          updatedDocChildren[0],
+        );
+        const menuItems = MappingActionRegistryService.getMappingContextMenuItems(
+          updatedShipOrderChildren[0] as TargetNodeData,
+        );
+        const valueSelectorAction = menuItems.find((item) => item.key === MappingActionKind.ValueSelector);
+        expect(valueSelectorAction!.isDisabled!(updatedShipOrderChildren[0] as TargetNodeData)).toBe(false);
       });
     });
 

--- a/packages/ui/src/services/visualization/mapping-action.service.ts
+++ b/packages/ui/src/services/visualization/mapping-action.service.ts
@@ -11,7 +11,6 @@ import {
   MappingParentType,
   MappingTree,
   ValueOfSelector,
-  ValueOfType,
   ValueSelector,
 } from '../../models/datamapper/mapping';
 import { Types } from '../../models/datamapper/types';
@@ -292,36 +291,28 @@ export class MappingActionService {
   }
 
   /**
-   * Adds a {@link ValueSelector} child to the node's mapping.
+   * Adds a {@link ValueOfSelector} child to the node's mapping.
    * Creates the underlying field item first if the node is a {@link TargetFieldNodeData} without a mapping.
-   * No-op if a `ValueSelector` already exists.
+   * Resolves the value type (VALUE vs ATTRIBUTE) via {@link MappingService.createValueOfSelector}.
+   * No-op if a `ValueOfSelector` already exists.
    * @param nodeData - The target node to add the value selector to.
    */
-  static applyValueSelector(nodeData: TargetNodeData) {
-    const mapping =
-      nodeData instanceof TargetFieldNodeData && !nodeData.mapping
-        ? MappingActionService.getOrCreateFieldItem(nodeData)
-        : nodeData.mapping;
-    if (!mapping) return;
-    if (!mapping.children.some((c: MappingItem) => c instanceof ValueSelector)) {
-      const valueSelector = MappingService.createValueOfSelector(mapping);
-      mapping.children.push(valueSelector);
-      useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
-    }
-  }
-
   static applyValueOfSelector(nodeData: TargetNodeData) {
     const mapping =
       nodeData instanceof TargetFieldNodeData && !nodeData.mapping
         ? MappingActionService.getOrCreateFieldItem(nodeData)
         : nodeData.mapping;
     if (!mapping) return;
-    if (mapping.children.some((c) => c instanceof ValueOfSelector)) return;
-    const valueType =
-      nodeData instanceof TargetFieldNodeData && nodeData.field.isAttribute ? ValueOfType.ATTRIBUTE : ValueOfType.VALUE;
-    const valueSelector = new ValueOfSelector(mapping, valueType);
+    if (mapping.children.some((c: MappingItem) => c instanceof ValueOfSelector)) return;
+    const valueSelector = MappingService.createValueOfSelector(mapping);
     mapping.children.push(valueSelector);
-    useDocumentTreeStore.getState().requestXPathInputFocus(mapping.nodePath.toString());
+    MappingActionService.requestValueOfSelectorFocus(mapping, valueSelector);
+  }
+
+  private static requestValueOfSelectorFocus(mapping: MappingParentType, valueSelector: ValueOfSelector) {
+    const focusTarget =
+      mapping instanceof FieldItem && DocumentService.hasChildren(mapping.field) ? valueSelector : mapping;
+    useDocumentTreeStore.getState().requestXPathInputFocus(focusTarget.nodePath.toString());
   }
 
   static applyCopyOfSelector(nodeData: TargetNodeData) {

--- a/packages/ui/src/services/visualization/mapping-links.service.test.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.test.ts
@@ -853,6 +853,37 @@ describe('MappingLinksService', () => {
       expect(links[0].lineStyle).toBe(MappingLineStyle.COPY_OF);
       expect(links[0].targetNodePath).toContain(vs.id);
     });
+
+    it('should connect mixed container value-of to its node with a regular line', () => {
+      const manualTree = new MappingTree(
+        targetDoc.documentType,
+        targetDoc.documentId,
+        DocumentDefinitionType.XML_SCHEMA,
+      );
+      manualTree.namespaceMap = { ns0: 'io.kaoto.datamapper.poc.test' };
+
+      const targetShipTo = targetRoot.fields.find((f: IField) => f.name === 'ShipTo')!;
+      const rootItem = new FieldItem(manualTree, targetRoot);
+      manualTree.children.push(rootItem);
+      const shipToItem = new FieldItem(rootItem, targetShipTo);
+      rootItem.children.push(shipToItem);
+
+      const copyOf = new CopyOfSelector(shipToItem, CopyOfType.CONTAINER);
+      copyOf.expression = '/ns0:ShipOrder/ShipTo';
+      shipToItem.children.push(copyOf);
+      const valueOf = new ValueOfSelector(shipToItem);
+      valueOf.expression = '/ns0:ShipOrder/ns0:OrderPerson';
+      shipToItem.children.push(valueOf);
+
+      const links = MappingLinksService.extractMappingLinks(manualTree, paramsMap, sourceDoc);
+      const copyOfLink = links.find((link) => link.sourceNodePath.includes('ShipTo'))!;
+      const valueOfLink = links.find((link) => link.sourceNodePath.includes('OrderPerson'))!;
+
+      expect(copyOfLink.targetNodePath).toBe(shipToItem.nodePath.toString());
+      expect(copyOfLink.lineStyle).toBe(MappingLineStyle.COPY_OF);
+      expect(valueOfLink.targetNodePath).toBe(valueOf.nodePath.toString());
+      expect(valueOfLink.lineStyle).toBe(MappingLineStyle.REGULAR);
+    });
   });
 
   describe('variable reference links', () => {

--- a/packages/ui/src/services/visualization/mapping-links.service.ts
+++ b/packages/ui/src/services/visualization/mapping-links.service.ts
@@ -1,7 +1,6 @@
 import {
   BODY_DOCUMENT_ID,
   CopyOfSelector,
-  CopyOfType,
   DocumentNodeData,
   DocumentType,
   FieldItem,
@@ -17,6 +16,7 @@ import {
   MappingTree,
   NodePath,
   PrimitiveDocument,
+  ValueOfSelector,
   ValueSelector,
   VariableItem,
   variableNodePath,
@@ -25,6 +25,7 @@ import {
 import { DocumentService } from '../document/document.service';
 import { MappingService } from '../mapping/mapping.service';
 import { XPathService } from '../xpath/xpath.service';
+import { VisualizationService } from './visualization.service';
 
 /**
  * A collection of the business logic for rendering mapping link lines.
@@ -69,11 +70,12 @@ export class MappingLinksService {
       const effectiveStyle = item instanceof FieldItem ? ownLineStyle : lineStyle;
       const childLineStyle = effectiveStyle === MappingLineStyle.REGULAR ? undefined : effectiveStyle;
       item.children.forEach((child) => {
+        const isInlineValueSelector =
+          child instanceof ValueSelector && VisualizationService.isInlineValueSelector(child);
         if (
           item instanceof FieldItem &&
           !(item.field.ownerDocument instanceof PrimitiveDocument) &&
-          child instanceof ValueSelector &&
-          !(child instanceof CopyOfSelector && child.valueType === CopyOfType.CONTAINER_NODE)
+          isInlineValueSelector
         ) {
           const links = MappingLinksService.doExtractMappingLinks(
             child,
@@ -92,7 +94,7 @@ export class MappingLinksService {
             sourceBody,
             selectedNodePath,
             selectedNodeIsSource,
-            childLineStyle,
+            child instanceof ValueOfSelector ? undefined : childLineStyle,
           );
           answer.push(...links);
         }

--- a/packages/ui/src/services/visualization/visualization-util.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.test.ts
@@ -1,5 +1,5 @@
 import { DocumentDefinitionType, IField } from '../../models/datamapper/document';
-import { FieldItem, MappingTree } from '../../models/datamapper/mapping';
+import { CopyOfSelector, CopyOfType, FieldItem, MappingTree } from '../../models/datamapper/mapping';
 import {
   AbstractFieldNodeData,
   ChoiceFieldNodeData,
@@ -343,6 +343,34 @@ describe('VisualizationUtilService', () => {
       // Use the existing field which has children (complex type)
       const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
       expect(VisualizationUtilService.isTerminalField(fieldNode)).toBe(false);
+    });
+  });
+
+  describe('getInlineContainerCopyOf', () => {
+    const createFieldItemNodeDataWithCopyOf = (copyOfType: CopyOfType) => {
+      const tree = new MappingTree(targetDoc.documentType, targetDoc.documentId, DocumentDefinitionType.XML_SCHEMA);
+      const treeNode = new TargetDocumentNodeData(targetDoc, tree);
+      const shipOrderFI = new FieldItem(tree, targetDoc.fields[0]);
+      tree.children.push(shipOrderFI);
+      shipOrderFI.children.push(new CopyOfSelector(shipOrderFI, copyOfType));
+      return new FieldItemNodeData(treeNode, shipOrderFI);
+    };
+
+    it('should return the CopyOfSelector for a CONTAINER-typed copy-of', () => {
+      const nodeData = createFieldItemNodeDataWithCopyOf(CopyOfType.CONTAINER);
+      const result = VisualizationUtilService.getInlineContainerCopyOf(nodeData);
+      expect(result).toBeInstanceOf(CopyOfSelector);
+      expect(result?.valueType).toBe(CopyOfType.CONTAINER);
+    });
+
+    it('should return undefined for a CONTAINER_NODE-typed copy-of', () => {
+      const nodeData = createFieldItemNodeDataWithCopyOf(CopyOfType.CONTAINER_NODE);
+      expect(VisualizationUtilService.getInlineContainerCopyOf(nodeData)).toBeUndefined();
+    });
+
+    it('should return undefined for a plain FieldNodeData with no mapping', () => {
+      const fieldNode = new FieldNodeData(sourceDocNode, sourceDoc.fields[0]);
+      expect(VisualizationUtilService.getInlineContainerCopyOf(fieldNode)).toBeUndefined();
     });
   });
 });

--- a/packages/ui/src/services/visualization/visualization-util.service.ts
+++ b/packages/ui/src/services/visualization/visualization-util.service.ts
@@ -1,4 +1,5 @@
 import { IField } from '../../models/datamapper/document';
+import { CopyOfSelector, CopyOfType, FieldItem } from '../../models/datamapper/mapping';
 import {
   AbstractFieldNodeData,
   AddMappingNodeData,
@@ -221,5 +222,17 @@ export class VisualizationUtilService {
 
   static isMappingNode(nodeData: NodeData): nodeData is MappingNodeData {
     return nodeData instanceof MappingNodeData;
+  }
+
+  /**
+   * Returns the inline `CONTAINER`-typed {@link CopyOfSelector} for a {@link FieldItemNodeData}
+   * whose mapping is a {@link FieldItem}, or `undefined` if no such selector exists.
+   * Used by {@link FieldNodeTitle} to render the "copy" badge on container fields.
+   */
+  static getInlineContainerCopyOf(nodeData: NodeData): CopyOfSelector | undefined {
+    if (!(nodeData instanceof FieldItemNodeData) || !(nodeData.mapping instanceof FieldItem)) return undefined;
+    return nodeData.mapping.children.find(
+      (c): c is CopyOfSelector => c instanceof CopyOfSelector && c.valueType === CopyOfType.CONTAINER,
+    );
   }
 }

--- a/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.abstract.test.ts
@@ -764,7 +764,9 @@ describe('VisualizationService / abstract fields', () => {
       ) as FieldItem;
 
       const candidateChildren = VisualizationService.generateNonDocumentNodeDataChildren(freshAbstractNode);
-      expect(candidateChildren.map((c) => c.title)).toEqual(['catName']);
+      // The value-of selector on an expandable field (Cat has catName) renders as an explicit 'value' tree node
+      // rather than inline. The schema child catName also appears as a separate field node.
+      expect(candidateChildren.map((c) => c.title)).toEqual(['catName', 'value']);
     });
   });
 

--- a/packages/ui/src/services/visualization/visualization.service.test.ts
+++ b/packages/ui/src/services/visualization/visualization.service.test.ts
@@ -589,10 +589,20 @@ describe('VisualizationService', () => {
   });
 
   describe('isInlineValueSelector()', () => {
-    it('should return true for VALUE ValueOfSelector', () => {
-      const fieldItem = new FieldItem(tree, targetDoc.fields[0]);
-      const vs = new ValueOfSelector(fieldItem, ValueOfType.VALUE);
+    it('should return true for VALUE ValueOfSelector on a leaf field', () => {
+      // targetDoc.fields[0] is ShipOrder (container). Its first child field is a leaf (no children).
+      const shipOrderFI = new FieldItem(tree, targetDoc.fields[0]);
+      const leafField = targetDoc.fields[0].fields[0]; // e.g. OrderId — a leaf field
+      const leafFI = new FieldItem(shipOrderFI, leafField);
+      const vs = new ValueOfSelector(leafFI, ValueOfType.VALUE);
       expect(VisualizationService.isInlineValueSelector(vs)).toBe(true);
+    });
+
+    it('should return false for VALUE ValueOfSelector on an expandable field (has children)', () => {
+      // ShipOrder has child fields, so value-of on it renders as an explicit tree node
+      const shipOrderFI = new FieldItem(tree, targetDoc.fields[0]);
+      const vs = new ValueOfSelector(shipOrderFI, ValueOfType.VALUE);
+      expect(VisualizationService.isInlineValueSelector(vs)).toBe(false);
     });
 
     it('should return true for ATTRIBUTE ValueOfSelector', () => {

--- a/packages/ui/src/services/visualization/visualization.service.ts
+++ b/packages/ui/src/services/visualization/visualization.service.ts
@@ -14,6 +14,7 @@ import {
   MappingTree,
   UnknownMappingItem,
   ValueOfSelector,
+  ValueOfType,
   ValueSelector,
   VariableItem,
 } from '../../models/datamapper/mapping';
@@ -565,7 +566,9 @@ export class VisualizationService {
 
   static isInlineValueSelector(item: MappingItem): item is ValueSelector {
     if (item instanceof CopyOfSelector) return item.valueType !== CopyOfType.CONTAINER_NODE;
-    return item instanceof ValueOfSelector;
+    if (!(item instanceof ValueOfSelector)) return false;
+    if (item.valueType === ValueOfType.ATTRIBUTE) return true;
+    return !(item.parent instanceof FieldItem && DocumentService.hasChildren(item.parent.field));
   }
 
   private static getFieldValueSelector(nodeData: TargetNodeData) {


### PR DESCRIPTION
…ent support

Fixes: https://github.com/KaotoIO/kaoto/issues/3466

Allow adding value-of on a container field that already has copy-of (mixed content). Double-click and context menu now behave identically.

On expandable fields, value-of renders as an explicit (value) child tree node rather than inline, and its mapping link connects to that node with a regular line. Inline copy-of on a container field shows a (copy) label badge next to the field name.


https://github.com/user-attachments/assets/7091fff3-6c59-45bd-b725-a2c9eea48d91



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Field mappings now display a “copy” label when applicable.
  * Value selections on expandable fields appear as distinct tree nodes.
  * Copy and value selections can coexist while preserving their individual targets and expressions.

* **Bug Fixes**
  * Improved focus behavior after applying value selections.
  * Corrected mapping link styles and targets for combined copy and value selections.
  * Improved handling of attribute and field value selections.
  * Preserved copy and value expressions when mappings are serialized and restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->