### PR TITLE
chore: replace getBy* with await findBy*

### DIFF
--- a/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
+++ b/packages/ui/src/components/ComponentMode/ComponentMode.test.tsx
@@ -46,12 +46,12 @@ describe('ComponentMode', () => {
     return node;
   };
 
-  it('renders the three toggle buttons', () => {
+  it('renders the three toggle buttons', async () => {
     const wrapper = render(<ComponentMode vizNode={getMockVizNode('to')} />);
 
-    expect(wrapper.getByText('Static')).toBeInTheDocument();
-    expect(wrapper.getByText('Dynamic')).toBeInTheDocument();
-    expect(wrapper.getByText('Poll')).toBeInTheDocument();
+    expect(await wrapper.findByText('Static')).toBeInTheDocument();
+    expect(await wrapper.findByText('Dynamic')).toBeInTheDocument();
+    expect(await wrapper.findByText('Poll')).toBeInTheDocument();
   });
 
   it('should not call updateSourceCodeFromEntities if there is no VizNode', () => {
@@ -165,7 +165,7 @@ describe('ComponentMode', () => {
     expect(mockUpdateSourceCodeFromEntities).toHaveBeenCalled();
   });
 
-  it('should render buttons even when tooltips are empty', () => {
+  it('should render buttons even when tooltips are empty', async () => {
     // Override tooltips with empty strings for this test
     mockUseProcessorTooltips.mockReturnValue({
       to: '',
@@ -177,9 +177,9 @@ describe('ComponentMode', () => {
     const wrapper = render(<ComponentMode vizNode={vizNode} />);
 
     // Buttons should still render with empty tooltips
-    const toButton = wrapper.getByRole('button', { name: /static/i });
-    const toDButton = wrapper.getByRole('button', { name: /dynamic/i });
-    const pollButton = wrapper.getByRole('button', { name: /poll/i });
+    const toButton = await wrapper.findByRole('button', { name: /static/i });
+    const toDButton = await wrapper.findByRole('button', { name: /dynamic/i });
+    const pollButton = await wrapper.findByRole('button', { name: /poll/i });
 
     expect(toButton).toBeInTheDocument();
     expect(toDButton).toBeInTheDocument();

--- a/packages/ui/src/components/View/SourceTargetView.test.tsx
+++ b/packages/ui/src/components/View/SourceTargetView.test.tsx
@@ -229,8 +229,8 @@ describe('SourceTargetView', () => {
         </BrowserFilePickerMetadataProvider>,
       );
 
-      const zoomInButton = screen.getByLabelText('Zoom in');
-      const zoomOutButton = screen.getByLabelText('Zoom out');
+      const zoomInButton = await screen.findByLabelText('Zoom in');
+      const zoomOutButton = await screen.findByLabelText('Zoom out');
 
       expect(zoomInButton).toBeInTheDocument();
       expect(zoomOutButton).toBeInTheDocument();
@@ -247,7 +247,7 @@ describe('SourceTargetView', () => {
         </BrowserFilePickerMetadataProvider>,
       );
 
-      const zoomInButton = screen.getByLabelText('Zoom in');
+      const zoomInButton = await screen.findByLabelText('Zoom in');
       const sourceTargetView = container.querySelector('.source-target-view') as HTMLElement;
 
       // Initial scale should be 1
@@ -272,7 +272,7 @@ describe('SourceTargetView', () => {
         </BrowserFilePickerMetadataProvider>,
       );
 
-      const zoomOutButton = screen.getByLabelText('Zoom out');
+      const zoomOutButton = await screen.findByLabelText('Zoom out');
       const sourceTargetView = container.querySelector('.source-target-view') as HTMLElement;
 
       // Initial scale should be 1
@@ -297,7 +297,7 @@ describe('SourceTargetView', () => {
         </BrowserFilePickerMetadataProvider>,
       );
 
-      const zoomInButton = screen.getByLabelText('Zoom in');
+      const zoomInButton = await screen.findByLabelText('Zoom in');
       const sourceTargetView = container.querySelector('.source-target-view') as HTMLElement;
 
       // Click zoom in 3 times (1.0 -> 1.1 -> 1.2 -> should stay at 1.2)
@@ -321,7 +321,7 @@ describe('SourceTargetView', () => {
         </BrowserFilePickerMetadataProvider>,
       );
 
-      const zoomOutButton = screen.getByLabelText('Zoom out');
+      const zoomOutButton = await screen.findByLabelText('Zoom out');
       const sourceTargetView = container.querySelector('.source-target-view') as HTMLElement;
 
       // Click zoom out 4 times (1.0 -> 0.9 -> 0.8 -> 0.7 -> should stay at 0.7)

--- a/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/CanvasSideBar.test.tsx
@@ -65,7 +65,7 @@ describe('CanvasSideBar', () => {
       </Provider>,
     );
 
-    const closeButton = wrapper.getByTestId('close-side-bar');
+    const closeButton = await wrapper.findByTestId('close-side-bar');
     fireEvent.click(closeButton);
 
     expect(onCloseSpy).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/Group/CustomGroupExpanded.test.tsx
@@ -123,7 +123,7 @@ describe('CustomGroupExpanded', () => {
 
     await renderInContext(<CustomGroupExpanded element={element} />);
 
-    const group = screen.getByTestId('custom-group__choice-1');
+    const group = await screen.findByTestId('custom-group__choice-1');
     expect(group).toBeInTheDocument();
     expect(group).toHaveAttribute('data-grouplabel', 'Choice');
   });
@@ -152,7 +152,7 @@ describe('CustomGroupExpanded', () => {
 
     await renderInContext(<CustomGroupExpanded element={element} />);
 
-    expect(screen.getByRole('img')).toHaveAttribute('alt', 'Choice icon');
+    expect(await screen.findByRole('img')).toHaveAttribute('alt', 'Choice icon');
   });
 
   it('should render icon placeholder when group has validation warnings', async () => {
@@ -207,7 +207,7 @@ describe('CustomGroupExpanded', () => {
       </SettingsProvider>,
     );
 
-    expect(screen.getByTestId('step-toolbar')).toBeInTheDocument();
+    expect(await screen.findByTestId('step-toolbar')).toBeInTheDocument();
   });
 
   it('calls getNodeDragAndDropDirection when droppable, canDrop and hover are true (line 162)', async () => {


### PR DESCRIPTION
**When it applies:** the component under test starts an async operation on mount (a `useEffect` that calls a promise, a MobX observer that reacts to an observable, a PatternFly Popper that positions itself, etc.). The test's first assertion uses `screen.getBy*` (or `wrapper.getBy*`) synchronously, racing that pending update. React then fires the warning because the state update lands outside any `act()` scope.

**Why `findBy*` fixes it:** `findBy*` is built on `waitFor`, which polls the DOM until the query succeeds (default timeout 1 000 ms). By the time it resolves, all pending async effects have already settled — there is nothing left to trigger the warning. Importantly, `findBy*` does **not** wrap the update in `act()`; it simply waits long enough that the update has already finished.

| Component | Before | After | Fixed? |
|---|---|---|---|
| `MappingLinksContainer` | 74 | 0 | ✅ Fully fixed (`SourceTargetView.test.tsx`) |
| `ComponentMode` | 2 | 0 | ✅ Fully fixed (`ComponentMode.test.tsx`) |
| `CanvasFormBody` | 1 | 0 | ✅ Fully fixed (`CanvasSideBar.test.tsx`) |
| `observerComponent` | 1 | 1 | ⚠️ Still present (`CustomGroupExpanded.test.tsx`) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved UI test reliability by waiting for controls and elements to appear asynchronously before interacting with or asserting them.
  - Updated coverage for component mode toggles, zoom controls, sidebar closing, and expanded custom groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->