### PR TITLE
refactor(ExpressionField): ExpressionField now resolvse language cata…

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
@@ -1,4 +1,3 @@
-import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
 import {
   FieldProps,
   FieldWrapper,
@@ -8,12 +7,13 @@ import {
   useFieldValue,
 } from '@kaoto/forms';
 import { isEmpty } from 'lodash';
-import { FunctionComponent, useContext, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, Suspense, use, useContext, useMemo } from 'react';
 
 import { ROOT_PATH, setValue } from '../../../../../../utils';
-import { ErrorBoundary } from '../../../../../ErrorBoundary';
 import { ExpressionService } from './expression.service';
 import { ExpressionFieldInner } from './ExpressionFieldInner';
+import { Loading } from '../../../../../Loading';
+import { ICamelLanguageDefinition } from '../../../../../../models/camel/camel-languages-catalog';
 
 /**
  * ExpressionField component.
@@ -31,52 +31,20 @@ import { ExpressionFieldInner } from './ExpressionFieldInner';
  * - ObjectField -> property resolution -> FormComponentFactoryProvider -> ExpressionField
  * this brings an entire schema with a `anyOf` array where the languages are specified.
  */
-const ExpressionFieldImpl: FunctionComponent<FieldProps> = ({ propName, required }) => {
+const ExpressionFieldImpl: FunctionComponent<FieldProps & { promise: Promise<Record<string, ICamelLanguageDefinition>> }> = ({ propName, required, promise }) => {
   const { schema } = useContext(SchemaContext);
   const { value: originalModel, onChange } = useFieldValue<Record<string, unknown>>(propName);
+  const languageCatalogMap = use(promise);
+  const languageNames = new Set(Object.values(languageCatalogMap).map((lang) => lang.model.name));
 
   const isRootExpression = schema.format === 'expression';
-  const [parseError, setParseError] = useState<Error | undefined>(undefined);
-  const [parsedModel, setParsedModel] = useState<ExpressionDefinition | undefined>(undefined);
-  /**
-   * Whether the first async `parseExpressionModel` has resolved. `ExpressionFieldInner` relies on
-   * `useOneOfField`, which latches its selected schema from the model on its mount render only.
-   * Mounting it before the model is parsed would latch an empty selection that never recovers, so
-   * we hold rendering until the initial parse completes. The flag stays `true` afterwards so later
-   * `originalModel` changes re-parse without remounting (and thus without dropping the selection).
-   */
-  const [isModelParsed, setIsModelParsed] = useState(false);
+  const parsedModel = ExpressionService.parseExpressionModel(languageNames, originalModel);
   const expressionsSchema = useMemo(() => ExpressionService.getExpressionsSchema(schema), [schema]);
 
-  useEffect(() => {
-    let cancelled = false;
-    ExpressionService.parseExpressionModel(originalModel)
-      .then((model) => {
-        if (!cancelled) {
-          setParsedModel(model);
-          setIsModelParsed(true);
-        }
-      })
-      .catch((error: Error) => {
-        if (!cancelled) setParseError(error);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [originalModel]);
-
-  if (parseError) {
-    throw parseError;
-  }
-
-  if (!isModelParsed) {
-    return null;
-  }
-
-  const onExpressionChange = async (propName: string, model: unknown) => {
+  const onExpressionChange = (propName: string, model: unknown) => {
     let localValue = parsedModel ?? {};
 
-    await ExpressionService.updateExpressionFromModel(parsedModel, model as Record<string, unknown>);
+    ExpressionService.updateExpressionFromModel(parsedModel, model as Record<string, unknown>, languageCatalogMap);
     let updatedValue = model;
     if (typeof model === 'string' && model.trim() === '') {
       updatedValue = undefined;
@@ -118,8 +86,14 @@ const ExpressionFieldImpl: FunctionComponent<FieldProps> = ({ propName, required
   );
 };
 
-export const ExpressionField: FunctionComponent<FieldProps> = (props) => (
-  <ErrorBoundary fallback={<p>Expression editor is unavailable</p>}>
-    <ExpressionFieldImpl {...props} />
-  </ErrorBoundary>
-);
+export const ExpressionField: FunctionComponent<FieldProps> = (props) => {
+  const languageNamesPromise = useMemo(() => {
+    return ExpressionService.getLanguages();
+  }, [] );
+
+  return (
+  <Suspense fallback={<Loading />}>
+    <ExpressionFieldImpl {...props} promise={languageNamesPromise} />
+  </Suspense>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
@@ -4,6 +4,7 @@ import { isDefined } from '@kaoto/forms';
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../../../../../models/catalog-kind';
 import { KaotoSchemaDefinition } from '../../../../../../models/kaoto-schema';
+import { ICamelLanguageDefinition } from '../../../../../../models/camel/camel-languages-catalog';
 
 export class ExpressionService {
   static getExpressionsSchema(schema: KaotoSchemaDefinition['schema']): KaotoSchemaDefinition['schema'] {
@@ -64,7 +65,7 @@ export class ExpressionService {
    * </ul>
    * @param parentModel The parent step model object which has expression as its parameter. For example `setBody` contents.
    * */
-  static async parseExpressionModel(parentModel?: Record<string, unknown>): Promise<ExpressionDefinition | undefined> {
+  static parseExpressionModel(languageNames: Set<string>, parentModel?: Record<string, unknown>): ExpressionDefinition | undefined {
     if (!isDefined(parentModel)) {
       return undefined;
     }
@@ -78,9 +79,8 @@ export class ExpressionService {
       return { ...model, ...parsedModel };
     }
 
-    const languageNames = await this.getLanguageNames();
     return Object.entries(parentModel).reduce((acc, [key, value]) => {
-      if (languageNames.includes(key)) {
+      if (languageNames.has(key)) {
         acc[key] = this.parseLanguageModel({ [key]: value }, key)[key];
       } else {
         acc[key] = value;
@@ -90,10 +90,10 @@ export class ExpressionService {
     }, {} as ExpressionDefinition);
   }
 
-  private static async getLanguageNames(): Promise<string[]> {
+  static async getLanguages(): Promise<Record<string, ICamelLanguageDefinition>> {
     const languageCatalogMap = (await DynamicCatalogRegistry.get().getCatalog(CatalogKind.Language)?.getAll()) ?? {};
 
-    return Object.values(languageCatalogMap).map((lang) => lang.model.name);
+    return languageCatalogMap;
   }
 
   /**
@@ -114,24 +114,25 @@ export class ExpressionService {
     }
   }
 
-  static async updateExpressionFromModel(
+  static updateExpressionFromModel(
     sourceModel: Record<string, unknown> | undefined,
     targetModel: Record<string, unknown>,
-  ): Promise<void> {
+    languageCatalogMap: Record<string, ICamelLanguageDefinition>,
+  ): void {
     if (!isDefined(sourceModel) || !isDefined(targetModel)) {
       return;
     }
-    const languageNames = await this.getLanguageNames();
-    const sourceKey = Object.keys(sourceModel).find((key) => languageNames.includes(key));
+
+    const languageNames = new Set(Object.values(languageCatalogMap).map((lang) => lang.model.name));
+    const sourceKey = Object.keys(sourceModel).find((key) => languageNames.has(key));
     const sourceExpressionString = sourceKey
       ? (sourceModel[sourceKey] as Record<string, unknown>)?.expression
       : undefined;
 
     if (typeof sourceExpressionString === 'string') {
-      const targetKey = Object.keys(targetModel).find((key) => languageNames.includes(key));
+      const targetKey = Object.keys(targetModel).find((key) => languageNames.has(key));
       if (targetKey) {
-        const exprModel =
-          (await DynamicCatalogRegistry.get().getEntity(CatalogKind.Language, targetKey))?.properties ?? {};
+        const exprModel = languageCatalogMap[targetKey].properties ?? {};
         if (isDefined(exprModel) && 'expression' in exprModel) {
           (targetModel[targetKey] as Record<string, unknown>).expression = sourceExpressionString;
         }


### PR DESCRIPTION
…log promise with use() hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Expression fields now display a loading state while language information is being retrieved.
  - Expression parsing and updates use the loaded language catalog for more consistent handling of language-specific expressions.
  - Expression editing no longer relies on separate asynchronous parsing and error-state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->