### PR TITLE
refactor(ExpressionField): `ExpressionField` now resolves language catalog promise with use() hook

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.test.tsx
@@ -70,7 +70,7 @@ describe('MultiValuePropertyEditor', () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
     });
   };
 
@@ -201,7 +201,21 @@ describe('MultiValuePropertyEditor', () => {
     await renderComponent({ schema: {} });
 
     expect(getMultiValuePropertiesSpy).toHaveBeenCalledWith(undefined, undefined);
-    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
+  });
+
+  it('should show the error boundary fallback when getMultiValueProperties rejects', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    getMultiValuePropertiesSpy.mockRejectedValue(new Error('catalog unavailable'));
+
+    await renderComponent();
+
+    expect(await screen.findByText('Field editor is unavailable')).toBeInTheDocument();
+    const expandableButton = await screen.findByLabelText('Show more');
+    expect(expandableButton).toBeInTheDocument();
+
+    fireEvent.click(expandableButton);
+    expect(await screen.findByText('catalog unavailable')).toBeInTheDocument();
   });
 
   it('should pass standard properties through unmodified when the schema has no catalog extension fields', async () => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/EndpointPropertiesField/MultiValuePropertyEditor.tsx
@@ -3,6 +3,7 @@ import { cloneDeep } from 'lodash';
 import { FunctionComponent, Suspense, use, useContext, useMemo } from 'react';
 
 import { ParsedParameters } from '../../../../../../utils';
+import { ErrorBoundary } from '../../../../../ErrorBoundary';
 import { Loading } from '../../../../../Loading';
 import { MultiValuePropertyService } from './MultiValueProperty.service';
 
@@ -16,9 +17,11 @@ export const MultiValuePropertyEditor: FunctionComponent<FieldProps> = ({ propNa
   }, [catalogKind, componentName]);
 
   return (
-    <Suspense fallback={<Loading />}>
-      <MultiValuePropertyEditorInner propName={propName} required={required} promise={multiValuePromise} />
-    </Suspense>
+    <ErrorBoundary fallback={<p>Field editor is unavailable</p>}>
+      <Suspense fallback={<Loading />}>
+        <MultiValuePropertyEditorInner propName={propName} required={required} promise={multiValuePromise} />
+      </Suspense>
+    </ErrorBoundary>
   );
 };
 

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
@@ -12,17 +12,27 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CamelLanguageProvider } from '../../../../../../dynamic-catalog/providers/camel-components.provider';
-import { CamelCatalogService, CatalogKind } from '../../../../../../models';
+import { CatalogKind } from '../../../../../../models';
 import { setHeaderExpressionSchema } from '../../../../../../stubs/expression-definition-schema';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
 import { ROOT_PATH } from '../../../../../../utils';
 import { ExpressionService } from './expression.service';
 import { ExpressionField } from './ExpressionField';
 
+/**
+ * Renders the component inside `await act(async () => ...)` so that the
+ * microtask queue drains and the internal <Suspense> boundary (wrapping the
+ * `use(promise)` call for language names) resolves before the first assertion.
+ * Plain `render()` uses a synchronous act internally and exits before the
+ * already-settled promise microtask fires, leaving the component suspended.
+ * The eslint rule cannot detect Suspense inside the tree, so we suppress it.
+ */
+// eslint-disable-next-line testing-library/no-unnecessary-act
+const renderWithSuspense = async (ui: React.ReactElement) => act(async () => render(ui));
+
 describe('ExpressionField', () => {
   beforeEach(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Language, catalogsMap.languageCatalog);
     DynamicCatalogRegistry.get().setCatalog(
       CatalogKind.Language,
       new DynamicCatalog(new CamelLanguageProvider(catalogsMap.languageCatalog)),
@@ -34,7 +44,7 @@ describe('ExpressionField', () => {
   });
 
   it('renders empty expression field with schema', async () => {
-    const { container } = render(
+    const { container } = await renderWithSuspense(
       <ModelContextProvider model={{ id: 'setHeader-1361' }} onPropertyChange={vi.fn()}>
         <SchemaProvider schema={setHeaderExpressionSchema}>
           <ExpressionField propName={ROOT_PATH} required />
@@ -42,16 +52,15 @@ describe('ExpressionField', () => {
       </ModelContextProvider>,
     );
 
-    // Wait for the async parseExpressionModel effect to resolve
     await waitFor(() => {
-      expect(container.firstChild).not.toBeNull();
+      expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
     });
 
     expect(container).toMatchSnapshot();
   });
 
   it('renders expression field with selection', async () => {
-    const { container } = render(
+    const { container } = await renderWithSuspense(
       <FormComponentFactoryProvider>
         <ModelContextProvider
           model={{
@@ -71,16 +80,15 @@ describe('ExpressionField', () => {
       </FormComponentFactoryProvider>,
     );
 
-    // Wait for the async parseExpressionModel effect to resolve
     await waitFor(() => {
-      expect(container.firstChild).not.toBeNull();
+      expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
     });
 
     expect(container).toMatchSnapshot();
   });
 
   it('should be able to change the selection', async () => {
-    render(
+    await renderWithSuspense(
       <FormComponentFactoryProvider>
         <ModelContextProvider
           model={{
@@ -101,7 +109,6 @@ describe('ExpressionField', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
-    // Wait for the async parseExpressionModel effect to populate the expression field
     await screen.findByTestId(`${ROOT_PATH}__expression-list-typeahead-select-input`);
     await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
     await formPageObject.selectTypeaheadItem('constant');
@@ -114,7 +121,7 @@ describe('ExpressionField', () => {
     const onPropertyChangeSpy = vi.fn();
     const EXPRESSION_STRING = 'Test';
 
-    render(
+    await renderWithSuspense(
       <FormComponentFactoryProvider>
         <ModelContextProvider
           model={{
@@ -137,7 +144,6 @@ describe('ExpressionField', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
-    // Wait for the async parseExpressionModel effect to populate the expression field
     await waitFor(() => formPageObject.getFieldByDisplayName('Expression'));
     await formPageObject.inputText('Expression', '');
 
@@ -150,7 +156,7 @@ describe('ExpressionField', () => {
     const onPropertyChangeSpy = vi.fn();
     const EXPRESSION_STRING = 'Test';
 
-    render(
+    await renderWithSuspense(
       <FormComponentFactoryProvider>
         <ModelContextProvider
           model={{
@@ -173,7 +179,6 @@ describe('ExpressionField', () => {
     );
 
     const formPageObject = new KaotoFormPageObject(screen, act);
-    // Wait for the async parseExpressionModel effect to populate the expression field
     await screen.findByTestId(`${ROOT_PATH}__expression-list-typeahead-select-input`);
     await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
     await formPageObject.selectTypeaheadItem('constant');
@@ -186,7 +191,7 @@ describe('ExpressionField', () => {
   it('should clear the expression when using the clear button', async () => {
     const onPropertyChangeSpy = vi.fn();
 
-    render(
+    await renderWithSuspense(
       <ModelContextProvider
         model={{
           id: 'setHeader-1891',
@@ -202,9 +207,7 @@ describe('ExpressionField', () => {
       </ModelContextProvider>,
     );
 
-    // Wait for the async parseExpressionModel effect to populate the expression list
     const clearButton = await screen.findByTestId(`#__expression-list__clear`);
-    // Use act to flush the async onExpressionChange handler
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(async () => {
       fireEvent.click(clearButton);
@@ -217,7 +220,7 @@ describe('ExpressionField', () => {
   it('should update the model with `undefined` when the model is empty after clearing the expression', async () => {
     const onPropertyChangeSpy = vi.fn();
 
-    const { findByTestId } = render(
+    const { findByTestId } = await renderWithSuspense(
       <ModelContextProvider
         model={{
           expression: {
@@ -232,10 +235,8 @@ describe('ExpressionField', () => {
       </ModelContextProvider>,
     );
 
-    // Wait for the async parseExpressionModel effect to populate the expression list
     const clearButton = await findByTestId(`#__expression-list__clear`);
 
-    // Use act to flush the async onExpressionChange handler
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(async () => {
       fireEvent.click(clearButton);
@@ -245,11 +246,11 @@ describe('ExpressionField', () => {
     expect(onPropertyChangeSpy).toHaveBeenCalledWith(ROOT_PATH, undefined);
   });
 
-  it('should show the error boundary fallback when parseExpressionModel rejects', async () => {
+  it('should show the error boundary fallback when getLanguageNames rejects', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.spyOn(ExpressionService, 'parseExpressionModel').mockRejectedValue(new Error('catalog unavailable'));
+    vi.spyOn(ExpressionService, 'getLanguageNames').mockRejectedValue(new Error('catalog unavailable'));
 
-    render(
+    await renderWithSuspense(
       <ModelContextProvider model={{ id: 'setHeader-1361' }} onPropertyChange={vi.fn()}>
         <SchemaProvider schema={setHeaderExpressionSchema}>
           <ExpressionField propName={ROOT_PATH} required />

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.tsx
@@ -1,4 +1,3 @@
-import { ExpressionDefinition } from '@kaoto/camel-catalog/types';
 import {
   FieldProps,
   FieldWrapper,
@@ -8,10 +7,11 @@ import {
   useFieldValue,
 } from '@kaoto/forms';
 import { isEmpty } from 'lodash';
-import { FunctionComponent, useContext, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, Suspense, use, useContext, useMemo } from 'react';
 
 import { ROOT_PATH, setValue } from '../../../../../../utils';
 import { ErrorBoundary } from '../../../../../ErrorBoundary';
+import { Loading } from '../../../../../Loading';
 import { ExpressionService } from './expression.service';
 import { ExpressionFieldInner } from './ExpressionFieldInner';
 
@@ -31,52 +31,23 @@ import { ExpressionFieldInner } from './ExpressionFieldInner';
  * - ObjectField -> property resolution -> FormComponentFactoryProvider -> ExpressionField
  * this brings an entire schema with a `anyOf` array where the languages are specified.
  */
-const ExpressionFieldImpl: FunctionComponent<FieldProps> = ({ propName, required }) => {
+const ExpressionFieldImpl: FunctionComponent<FieldProps & { promise: Promise<string[]> }> = ({
+  propName,
+  required,
+  promise,
+}) => {
   const { schema } = useContext(SchemaContext);
   const { value: originalModel, onChange } = useFieldValue<Record<string, unknown>>(propName);
+  const languageNames = use(promise);
 
   const isRootExpression = schema.format === 'expression';
-  const [parseError, setParseError] = useState<Error | undefined>(undefined);
-  const [parsedModel, setParsedModel] = useState<ExpressionDefinition | undefined>(undefined);
-  /**
-   * Whether the first async `parseExpressionModel` has resolved. `ExpressionFieldInner` relies on
-   * `useOneOfField`, which latches its selected schema from the model on its mount render only.
-   * Mounting it before the model is parsed would latch an empty selection that never recovers, so
-   * we hold rendering until the initial parse completes. The flag stays `true` afterwards so later
-   * `originalModel` changes re-parse without remounting (and thus without dropping the selection).
-   */
-  const [isModelParsed, setIsModelParsed] = useState(false);
+  const parsedModel = ExpressionService.parseExpressionModel(languageNames, originalModel);
   const expressionsSchema = useMemo(() => ExpressionService.getExpressionsSchema(schema), [schema]);
-
-  useEffect(() => {
-    let cancelled = false;
-    ExpressionService.parseExpressionModel(originalModel)
-      .then((model) => {
-        if (!cancelled) {
-          setParsedModel(model);
-          setIsModelParsed(true);
-        }
-      })
-      .catch((error: Error) => {
-        if (!cancelled) setParseError(error);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [originalModel]);
-
-  if (parseError) {
-    throw parseError;
-  }
-
-  if (!isModelParsed) {
-    return null;
-  }
 
   const onExpressionChange = async (propName: string, model: unknown) => {
     let localValue = parsedModel ?? {};
 
-    await ExpressionService.updateExpressionFromModel(parsedModel, model as Record<string, unknown>);
+    await ExpressionService.updateExpressionFromModel(parsedModel, model as Record<string, unknown>, languageNames);
     let updatedValue = model;
     if (typeof model === 'string' && model.trim() === '') {
       updatedValue = undefined;
@@ -118,8 +89,16 @@ const ExpressionFieldImpl: FunctionComponent<FieldProps> = ({ propName, required
   );
 };
 
-export const ExpressionField: FunctionComponent<FieldProps> = (props) => (
-  <ErrorBoundary fallback={<p>Expression editor is unavailable</p>}>
-    <ExpressionFieldImpl {...props} />
-  </ErrorBoundary>
-);
+export const ExpressionField: FunctionComponent<FieldProps> = (props) => {
+  const languageNamesPromise = useMemo(() => {
+    return ExpressionService.getLanguageNames();
+  }, []);
+
+  return (
+    <ErrorBoundary fallback={<p>Expression editor is unavailable</p>}>
+      <Suspense fallback={<Loading />}>
+        <ExpressionFieldImpl {...props} promise={languageNamesPromise} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+};

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.test.ts
@@ -3,11 +3,13 @@ import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 
 import { DynamicCatalog } from '../../../../../../dynamic-catalog/dynamic-catalog';
 import { DynamicCatalogRegistry } from '../../../../../../dynamic-catalog/dynamic-catalog-registry';
-import { CamelCatalogService, CatalogKind, KaotoSchemaDefinition } from '../../../../../../models';
+import { CatalogKind, KaotoSchemaDefinition } from '../../../../../../models';
 import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
 import { ExpressionService } from './expression.service';
 
 describe('ExpressionService', () => {
+  let languageNames: string[];
+
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
     const languageCatalog = catalogsMap.languageCatalog;
@@ -19,6 +21,8 @@ describe('ExpressionService', () => {
       fetchAll: async () => languageCatalog,
     };
     DynamicCatalogRegistry.get().setCatalog(CatalogKind.Language, new DynamicCatalog(mockProvider));
+
+    languageNames = await ExpressionService.getLanguageNames();
   });
 
   describe('getExpressionsSchema', () => {
@@ -109,108 +113,127 @@ describe('ExpressionService', () => {
     });
   });
 
-  const expressionsArray: [Record<string, unknown>, Record<string, unknown>][] = [
-    [
-      {
-        name: 'MY_HEADER',
-        expression: {
+  describe('getLanguageNames', () => {
+    it('should return a non-empty list of language names from the catalog', async () => {
+      const result = await ExpressionService.getLanguageNames();
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('should include known language names such as simple and constant', async () => {
+      const result = await ExpressionService.getLanguageNames();
+
+      expect(result).toContain('simple');
+      expect(result).toContain('constant');
+    });
+  });
+
+  describe('parseExpressionModel', () => {
+    it('should return undefined when parentModel is undefined', () => {
+      const result = ExpressionService.parseExpressionModel(languageNames, undefined);
+
+      expect(result).toBeUndefined();
+    });
+
+    const expressionsArray: [Record<string, unknown>, Record<string, unknown>][] = [
+      [
+        {
+          name: 'MY_HEADER',
+          expression: {
+            simple: {
+              expression: '${body}',
+              trim: true,
+            },
+          },
+        },
+        {
+          name: 'MY_HEADER',
           simple: {
             expression: '${body}',
             trim: true,
           },
         },
-      },
-      {
-        name: 'MY_HEADER',
-        simple: {
-          expression: '${body}',
-          trim: true,
+      ],
+      [
+        {
+          name: 'MY_HEADER',
+          expression: {
+            simple: '${body}',
+          },
         },
-      },
-    ],
-    [
-      {
-        name: 'MY_HEADER',
-        expression: {
+        {
+          name: 'MY_HEADER',
+          simple: {
+            expression: '${body}',
+          },
+        },
+      ],
+      [
+        {
+          name: 'MY_HEADER',
+          simple: {
+            id: 'simple',
+            expression: '${body}',
+          },
+        },
+        {
+          name: 'MY_HEADER',
+          simple: {
+            id: 'simple',
+            expression: '${body}',
+          },
+        },
+      ],
+      [
+        {
+          name: 'MY_HEADER',
           simple: '${body}',
         },
-      },
-      {
-        name: 'MY_HEADER',
-        simple: {
-          expression: '${body}',
+        {
+          name: 'MY_HEADER',
+          simple: {
+            expression: '${body}',
+          },
         },
-      },
-    ],
-    [
-      {
-        name: 'MY_HEADER',
-        simple: {
-          id: 'simple',
-          expression: '${body}',
+      ],
+      [
+        {
+          simple: {
+            expression: '${body}',
+            trim: true,
+          },
         },
-      },
-      {
-        name: 'MY_HEADER',
-        simple: {
-          id: 'simple',
-          expression: '${body}',
+        {
+          simple: {
+            expression: '${body}',
+            trim: true,
+          },
         },
-      },
-    ],
-    [
-      {
-        name: 'MY_HEADER',
-        simple: '${body}',
-      },
-      {
-        name: 'MY_HEADER',
-        simple: {
-          expression: '${body}',
+      ],
+      [
+        { simple: '${body}' },
+        {
+          simple: {
+            expression: '${body}',
+          },
         },
-      },
-    ],
-    [
-      {
-        simple: {
-          expression: '${body}',
-          trim: true,
-        },
-      },
-      {
-        simple: {
-          expression: '${body}',
-          trim: true,
-        },
-      },
-    ],
-    [
-      { simple: '${body}' },
-      {
-        simple: {
-          expression: '${body}',
-        },
-      },
-    ],
-  ];
+      ],
+    ];
 
-  it.each(expressionsArray)('should parse %s', async (parentModel, expected) => {
-    const result = await ExpressionService.parseExpressionModel(parentModel);
+    it.each(expressionsArray)('should parse %s', (parentModel, expected) => {
+      const result = ExpressionService.parseExpressionModel(languageNames, parentModel);
 
-    expect(result).toEqual(expected);
-  });
-  describe('updateExpressionFromModel', () => {
-    beforeAll(async () => {
-      const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-      const languageCatalog = catalogsMap.languageCatalog;
-      CamelCatalogService.setCatalogKey(CatalogKind.Language, languageCatalog);
+      expect(result).toEqual(expected);
     });
+  });
 
+  describe('updateExpressionFromModel', () => {
     it('should update the target model expression if supported', async () => {
       const sourceModel = { simple: { expression: 'sourceExpr' } };
       const targetModel = { constant: { expression: undefined } };
 
-      await ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
+      await ExpressionService.updateExpressionFromModel(sourceModel, targetModel, languageNames);
 
       expect(targetModel.constant.expression).toBe('sourceExpr');
     });
@@ -219,9 +242,17 @@ describe('ExpressionService', () => {
       const sourceModel = { simple: { expression: 'sourceExpr' } };
       const targetModel = { bean: { expression: undefined } };
 
-      await ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
+      await ExpressionService.updateExpressionFromModel(sourceModel, targetModel, languageNames);
 
       expect(targetModel.bean.expression).toBeUndefined();
+    });
+
+    it('should do nothing if sourceModel is undefined', async () => {
+      const targetModel = { csimple: { expression: undefined } };
+
+      await ExpressionService.updateExpressionFromModel(undefined, targetModel, languageNames);
+
+      expect(targetModel.csimple.expression).toBeUndefined();
     });
   });
 });

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.ts
@@ -64,7 +64,10 @@ export class ExpressionService {
    * </ul>
    * @param parentModel The parent step model object which has expression as its parameter. For example `setBody` contents.
    * */
-  static async parseExpressionModel(parentModel?: Record<string, unknown>): Promise<ExpressionDefinition | undefined> {
+  static parseExpressionModel(
+    languageNames: string[],
+    parentModel?: Record<string, unknown>,
+  ): ExpressionDefinition | undefined {
     if (!isDefined(parentModel)) {
       return undefined;
     }
@@ -78,7 +81,6 @@ export class ExpressionService {
       return { ...model, ...parsedModel };
     }
 
-    const languageNames = await this.getLanguageNames();
     return Object.entries(parentModel).reduce((acc, [key, value]) => {
       if (languageNames.includes(key)) {
         acc[key] = this.parseLanguageModel({ [key]: value }, key)[key];
@@ -90,7 +92,7 @@ export class ExpressionService {
     }, {} as ExpressionDefinition);
   }
 
-  private static async getLanguageNames(): Promise<string[]> {
+  static async getLanguageNames(): Promise<string[]> {
     const languageCatalogMap = (await DynamicCatalogRegistry.get().getCatalog(CatalogKind.Language)?.getAll()) ?? {};
 
     return Object.values(languageCatalogMap).map((lang) => lang.model.name);
@@ -117,11 +119,11 @@ export class ExpressionService {
   static async updateExpressionFromModel(
     sourceModel: Record<string, unknown> | undefined,
     targetModel: Record<string, unknown>,
+    languageNames: string[],
   ): Promise<void> {
     if (!isDefined(sourceModel) || !isDefined(targetModel)) {
       return;
     }
-    const languageNames = await this.getLanguageNames();
     const sourceKey = Object.keys(sourceModel).find((key) => languageNames.includes(key));
     const sourceExpressionString = sourceKey
       ? (sourceModel[sourceKey] as Record<string, unknown>)?.expression

--- a/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/validators/model-validation.service.ts
@@ -95,9 +95,10 @@ export class ModelValidationService {
 
     const answer: IValidationResult[] = [];
     let parsedModel = model;
+    const languageNames = await ExpressionService.getLanguageNames();
     for (const anyOfSchema of schema.anyOf) {
       if (isDefined(anyOfSchema.format) && anyOfSchema.format === 'expression') {
-        parsedModel = await ExpressionService.parseExpressionModel(model);
+        parsedModel = ExpressionService.parseExpressionModel(languageNames, model);
       }
       answer.push(...(await this.validateRequiredProperties(anyOfSchema, parsedModel, parentPath, definitions)));
     }


### PR DESCRIPTION
fix https://github.com/KaotoIO/kaoto/issues/3442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Expression fields now load available expression languages before displaying and processing expressions.
* A visible loading state appears while expression language information is retrieved.
* Multi-value property editors provide an error fallback with an option to view additional details.

## Bug Fixes
* Improved expression validation and updates provide more reliable behavior while editing expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->