### PR TITLE
chore(csimple): Remove csimple references from tests and stubs

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/ExpressionField.test.tsx
@@ -104,7 +104,7 @@ describe('ExpressionField', () => {
     // Wait for the async parseExpressionModel effect to populate the expression field
     await screen.findByTestId(`${ROOT_PATH}__expression-list-typeahead-select-input`);
     await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
-    await formPageObject.selectTypeaheadItem('csimple');
+    await formPageObject.selectTypeaheadItem('constant');
 
     const expressionField = formPageObject.getFieldByDisplayName('Expression');
     expect(expressionField).toBeInTheDocument();
@@ -176,11 +176,11 @@ describe('ExpressionField', () => {
     // Wait for the async parseExpressionModel effect to populate the expression field
     await screen.findByTestId(`${ROOT_PATH}__expression-list-typeahead-select-input`);
     await formPageObject.toggleExpressionFieldForProperty(ROOT_PATH);
-    await formPageObject.selectTypeaheadItem('csimple');
+    await formPageObject.selectTypeaheadItem('constant');
 
     expect(onPropertyChangeSpy).toHaveBeenCalled();
     const lastCall = onPropertyChangeSpy.mock.calls[onPropertyChangeSpy.mock.calls.length - 1];
-    expect(lastCall[1].csimple.expression).toBe(EXPRESSION_STRING);
+    expect(lastCall[1].constant.expression).toBe(EXPRESSION_STRING);
   });
 
   it('should clear the expression when using the clear button', async () => {

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.test.ts
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/ExpressionField/expression.service.test.ts
@@ -44,7 +44,6 @@ describe('ExpressionService', () => {
       const schema: KaotoSchemaDefinition['schema'] = {
         oneOf: [
           { simple: { type: 'string' } },
-          { csimple: { type: 'string' } },
           { constant: { type: 'string' } },
           { expression: { type: 'string' } },
           { groovy: { type: 'string' } },
@@ -62,7 +61,6 @@ describe('ExpressionService', () => {
           {
             oneOf: [
               { simple: { type: 'string' } },
-              { csimple: { type: 'string' } },
               { constant: { type: 'string' } },
               { expression: { type: 'string' } },
               { groovy: { type: 'string' } },
@@ -86,7 +84,6 @@ describe('ExpressionService', () => {
                   {
                     oneOf: [
                       { simple: { type: 'string' } },
-                      { csimple: { type: 'string' } },
                       { constant: { type: 'string' } },
                       { expression: { type: 'string' } },
                       { groovy: { type: 'string' } },
@@ -104,7 +101,6 @@ describe('ExpressionService', () => {
       expect(result).toEqual({
         oneOf: [
           { simple: { type: 'string' } },
-          { csimple: { type: 'string' } },
           { constant: { type: 'string' } },
           { expression: { type: 'string' } },
           { groovy: { type: 'string' } },
@@ -212,11 +208,11 @@ describe('ExpressionService', () => {
 
     it('should update the target model expression if supported', async () => {
       const sourceModel = { simple: { expression: 'sourceExpr' } };
-      const targetModel = { csimple: { expression: undefined } };
+      const targetModel = { constant: { expression: undefined } };
 
       await ExpressionService.updateExpressionFromModel(sourceModel, targetModel);
 
-      expect(targetModel.csimple.expression).toBe('sourceExpr');
+      expect(targetModel.constant.expression).toBe('sourceExpr');
     });
 
     it('should not update the target model if language does not support expression', async () => {

--- a/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.test.ts
+++ b/packages/ui/src/serializers/xml/serializers/expression-xml-serializer.test.ts
@@ -21,7 +21,7 @@ import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/
 import { ExpressionXmlSerializer } from './expression-xml-serializer';
 import { getDocument, testSerializer } from './serializer-test-utils';
 
-const oneOf = ['constant', 'csimple', 'simple', 'datasonnet', 'exchangeProperty', 'groovy', 'header', 'hl7terser'];
+const oneOf = ['constant', 'simple', 'datasonnet', 'exchangeProperty', 'groovy', 'header', 'hl7terser'];
 describe('ExpressionSerialisation tests', () => {
   const doc = getDocument();
   beforeAll(async () => {
@@ -88,12 +88,12 @@ describe('ExpressionSerialisation tests', () => {
 
   it('serialize expression with attributes', async () => {
     const entity = {
-      csimple: {
-        expression: '${body}',
+      constant: {
+        expression: 'a=b',
         resultType: 'String',
       },
     };
-    const expected = `<when><csimple resultType="String">\${body}</csimple></when>`;
+    const expected = `<when><constant resultType="String">a=b</constant></when>`;
     const element = doc.createElement('when');
     await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element);
     testSerializer(expected, element);
@@ -101,12 +101,12 @@ describe('ExpressionSerialisation tests', () => {
 
   it('serialize expression with namespace', async () => {
     const entity = {
-      csimple: {
-        expression: '${body}',
+      constant: {
+        expression: 'a=b',
         namespace: [{ key: 'ns1', value: 'http://example.com/ns1' }],
       },
     };
-    const expected = `<when><csimple>\${body}</csimple></when>`;
+    const expected = `<when><constant>a=b</constant></when>`;
     const element = doc.createElement('when');
     const routeParent = doc.createElement('route');
     await ExpressionXmlSerializer.serialize('expression', entity, oneOf, doc, element, routeParent);

--- a/packages/ui/src/stubs/expression-definition-schema.ts
+++ b/packages/ui/src/stubs/expression-definition-schema.ts
@@ -26,9 +26,6 @@ export const setHeaderDefinitions: KaotoSchemaDefinition['schema']['definitions'
                   required: ['constant'],
                 },
                 {
-                  required: ['csimple'],
-                },
-                {
                   required: ['datasonnet'],
                 },
                 {
@@ -141,7 +138,6 @@ export const setHeaderDefinitions: KaotoSchemaDefinition['schema']['definitions'
           'Name of message header to set a new value The simple language can be used to define a dynamic evaluated header name to be used. Otherwise a constant name will be used.',
       },
       constant: {},
-      csimple: {},
       datasonnet: {},
       exchangeProperty: {},
       groovy: {},
@@ -173,42 +169,6 @@ export const setHeaderDefinitions: KaotoSchemaDefinition['schema']['definitions'
 };
 
 export const expressionDefinitions: KaotoSchemaDefinition['schema']['definitions'] = {
-  'org.apache.camel.model.language.CSimpleExpression': {
-    title: 'CSimple',
-    description: 'Evaluate a compiled simple expression.',
-    oneOf: [
-      {
-        type: 'string',
-      },
-      {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-          expression: {
-            type: 'string',
-            title: 'Expression',
-            description: 'The expression value in your chosen language syntax',
-          },
-          id: {
-            type: 'string',
-            title: 'Id',
-            description: 'Sets the id of this node',
-          },
-          resultType: {
-            type: 'string',
-            title: 'Result Type',
-            description: 'Sets the class of the result type (type from output)',
-          },
-          trim: {
-            type: 'boolean',
-            title: 'Trim',
-            description: 'Whether to trim the value to remove leading and trailing whitespaces and line breaks',
-          },
-        },
-      },
-    ],
-    required: ['expression'],
-  },
   'org.apache.camel.model.language.ConstantExpression': {
     title: 'Constant',
     description: 'A fixed value set only once during the route startup.',
@@ -339,15 +299,6 @@ export const expressionDefinitions: KaotoSchemaDefinition['schema']['definitions
             properties: {
               constant: {
                 $ref: '#/definitions/org.apache.camel.model.language.ConstantExpression',
-              },
-            },
-          },
-          {
-            type: 'object',
-            required: ['csimple'],
-            properties: {
-              csimple: {
-                $ref: '#/definitions/org.apache.camel.model.language.CSimpleExpression',
               },
             },
           },
@@ -572,7 +523,6 @@ export const expressionDefinitions: KaotoSchemaDefinition['schema']['definitions
     ],
     properties: {
       constant: {},
-      csimple: {},
       datasonnet: {},
       exchangeProperty: {},
       groovy: {},
@@ -1650,9 +1600,9 @@ export const setHeaderExpressionSchema: KaotoSchemaDefinition['schema'] = {
   description: 'Test Description',
   default: 'default value',
   definitions: {
-    'org.apache.camel.model.language.CSimpleExpression': {
-      title: 'CSimple',
-      description: 'Evaluate a compiled simple expression.',
+    'org.apache.camel.model.language.ConstantExpression': {
+      title: 'Constant',
+      description: 'A fixed value set only once during the route startup.',
       required: ['expression'],
       type: 'object',
       additionalProperties: false,
@@ -1727,10 +1677,10 @@ export const setHeaderExpressionSchema: KaotoSchemaDefinition['schema'] = {
           oneOf: [
             {
               type: 'object',
-              required: ['csimple'],
+              required: ['constant'],
               properties: {
-                csimple: {
-                  $ref: '#/definitions/org.apache.camel.model.language.CSimpleExpression',
+                constant: {
+                  $ref: '#/definitions/org.apache.camel.model.language.ConstantExpression',
                 },
               },
             },
@@ -1784,7 +1734,6 @@ export const setHeaderExpressionSchema: KaotoSchemaDefinition['schema'] = {
       ],
       properties: {
         constant: {},
-        csimple: {},
         datasonnet: {},
         exchangeProperty: {},
         groovy: {},
@@ -1819,9 +1768,6 @@ export const setHeaderExpressionSchema: KaotoSchemaDefinition['schema'] = {
           },
           {
             required: ['constant'],
-          },
-          {
-            required: ['csimple'],
           },
           {
             required: ['datasonnet'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated expression configuration to use the `constant` expression type in place of the obsolete `csimple` type.
  * Removed `csimple` from supported expression definitions and XML serialization scenarios.
  * Updated expression validation and serialization behavior to preserve constant expressions and their attributes correctly.
* **Tests**
  * Refreshed coverage for expression selection, schema validation, and XML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->