### PR TITLE
Extract processor steps logic into ProcessorStepsService

### DIFF
--- a/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.ts
+++ b/packages/ui/src/components/Visualization/Custom/Node/CustomNodeUtils.ts
@@ -5,7 +5,7 @@ import { ElementModel, GraphElement, Node } from '@patternfly/react-topology';
 import { PlaceholderType } from '../../../../models/placeholder.constants';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { IClipboardContent } from '../../../../models/visualization/clipboard';
-import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
+import { ProcessorStepsService } from '../../../../models/visualization/flows/support/processor-steps.service';
 import { EntitiesContextResult } from '../../../../providers/entities.provider';
 import {
   IInteractionType,
@@ -194,13 +194,12 @@ export const getVizNodeChildrenInfo = (vizNode: IVisualizationNode | undefined):
   const hasGroupChildren = vizNodeChildren.some((child) => {
     const childProcessorName = child.data.primaryNodeId?.name;
     return childProcessorName
-      ? CamelComponentSchemaService.getProcessorStepsProperties(childProcessorName as keyof ProcessorDefinition)
-          .length > 0
+      ? ProcessorStepsService.getProcessorStepsProperties(childProcessorName as keyof ProcessorDefinition).length > 0
       : false;
   });
   const isContainerType =
     !!processorName &&
-    CamelComponentSchemaService.getProcessorStepsProperties(processorName as keyof ProcessorDefinition).length > 0;
+    ProcessorStepsService.getProcessorStepsProperties(processorName as keyof ProcessorDefinition).length > 0;
   const isCollapsedGroup = isContainerType && childCount > 0;
   return { childCount, hasGroupChildren, isCollapsedGroup };
 };

--- a/packages/ui/src/components/Visualization/Custom/customComponentUtils.test.ts
+++ b/packages/ui/src/components/Visualization/Custom/customComponentUtils.test.ts
@@ -7,7 +7,6 @@ import {
   IVisualizationNode,
   IVisualizationNodeData,
 } from '../../../models/visualization/base-visual-entity';
-import { CamelComponentSchemaService } from '../../../models/visualization/flows/support/camel-component-schema.service';
 import { EntitiesContextResult } from '../../../providers';
 import { canDragGroup, canDropOnEdge, getDropTargetContainerClassNames } from './customComponentUtils';
 
@@ -252,37 +251,23 @@ describe('canDragGroup', () => {
     } as unknown as IVisualizationNode;
   };
 
-  beforeEach(() => {
-    vi.spyOn(CamelComponentSchemaService, 'getProcessorStepsProperties').mockReturnValue([]);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('should return false when groupVizNode is undefined', () => {
     expect(canDragGroup()).toBe(false);
-    expect(CamelComponentSchemaService.getProcessorStepsProperties).not.toHaveBeenCalled();
   });
 
   it('should return false when path is top-level (single segment)', () => {
     const groupVizNode = getMockGroupVizNode('Route', 'route');
 
     expect(canDragGroup(groupVizNode)).toBe(false);
-    expect(CamelComponentSchemaService.getProcessorStepsProperties).not.toHaveBeenCalled();
   });
 
-  it('should return true when group is otherwise(single-clause)', () => {
+  it('should return true when group has a multi-segment path', () => {
     const groupVizNode = getMockGroupVizNode('route.from.steps.0.choice.otherwise', 'otherwise', 'choice');
 
     expect(canDragGroup(groupVizNode)).toBe(true);
   });
 
-  it('should return true when group does not match single-clause property', () => {
-    (CamelComponentSchemaService.getProcessorStepsProperties as Mock).mockReturnValue([
-      { name: 'otherwise', type: 'single-clause' },
-      { name: 'when', type: 'array-clause' },
-    ]);
+  it('should return true when group has a multi-segment path (when clause)', () => {
     const groupVizNode = getMockGroupVizNode('route.from.steps.0.choice.when', 'when', 'choice');
 
     expect(canDragGroup(groupVizNode)).toBe(true);

--- a/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/duplicate-step.hook.tsx
@@ -8,7 +8,7 @@ import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.p
 import { SourceSchemaType } from '../../../../models/camel/source-schema-type';
 import { EntityType } from '../../../../models/entities';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
-import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
+import { ProcessorStepsService } from '../../../../models/visualization/flows/support/processor-steps.service';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { VisibleFlowsContext } from '../../../../providers/visible-flows.provider';
 import { updateIds } from '../../../../utils/update-ids';
@@ -108,7 +108,7 @@ export const useDuplicateStep = (vizNode: IVisualizationNode) => {
 
       // Set an empty model to clear the graph, Fixes an issue rendering child nodes incorrectly
       if (parentVizNode?.getNodeInteraction().canHaveSpecialChildren) {
-        const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+        const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
           parentVizNode.data.primaryNodeId?.name as keyof ProcessorDefinition,
         );
         if (

--- a/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.test.tsx
@@ -6,7 +6,7 @@ import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.p
 import { CatalogKind } from '../../../../models';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
-import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
+import { ProcessorStepsService } from '../../../../models/visualization/flows/support/processor-steps.service';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { createMockEntitiesContext } from '../../../../stubs';
@@ -42,7 +42,7 @@ describe('useInsertStep', () => {
   };
 
   const mockCompatibleComponents = (item: ITile) => ['log', 'to'].includes(item.type);
-  const getProcessorStepsPropertiesMock = vi.spyOn(CamelComponentSchemaService, 'getProcessorStepsProperties');
+  const getProcessorStepsPropertiesMock = vi.spyOn(ProcessorStepsService, 'getProcessorStepsProperties');
 
   beforeEach(() => {
     mockVizNode = createVisualizationNode('test', {

--- a/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/insert-step.hook.tsx
@@ -6,7 +6,7 @@ import { useCallback, useContext, useMemo } from 'react';
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { DefinedComponent } from '../../../../models';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
-import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
+import { ProcessorStepsService } from '../../../../models/visualization/flows/support/processor-steps.service';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 
 export interface UseInsertStepOptions {
@@ -45,7 +45,7 @@ export const useInsertStep = (
 
     // Set an empty model to clear the graph, Fixes an issue rendering child nodes incorrectly
     if (mode === AddStepMode.InsertSpecialChildStep) {
-      const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+      const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
         vizNode.data.primaryNodeId?.name as keyof ProcessorDefinition,
       );
       if (

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.test.tsx
@@ -7,7 +7,7 @@ import { CatalogKind } from '../../../../models';
 import { CamelRouteResource } from '../../../../models/camel/camel-route-resource';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { IClipboardContent } from '../../../../models/visualization/clipboard';
-import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
+import { ProcessorStepsService } from '../../../../models/visualization/flows/support/processor-steps.service';
 import { createVisualizationNode } from '../../../../models/visualization/visualization-node';
 import { EntitiesContext, EntitiesContextResult } from '../../../../providers/entities.provider';
 import { ClipboardService } from '../../../../services/visualization/clipboard.service';
@@ -181,7 +181,7 @@ describe('usePasteStep', () => {
     });
     mockChoiceVizNode.pasteBaseEntityStep = vi.fn();
 
-    const getProcessorStepsPropertiesMock = vi.spyOn(CamelComponentSchemaService, 'getProcessorStepsProperties');
+    const getProcessorStepsPropertiesMock = vi.spyOn(ProcessorStepsService, 'getProcessorStepsProperties');
 
     const whenContent = {
       name: 'when',

--- a/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.tsx
+++ b/packages/ui/src/components/Visualization/Custom/hooks/paste-step.hook.tsx
@@ -7,7 +7,7 @@ import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'r
 import { CatalogModalContext } from '../../../../dynamic-catalog/catalog-modal.provider';
 import { AddStepMode, IVisualizationNode } from '../../../../models/visualization/base-visual-entity';
 import { IClipboardContent } from '../../../../models/visualization/clipboard';
-import { CamelComponentSchemaService } from '../../../../models/visualization/flows/support/camel-component-schema.service';
+import { ProcessorStepsService } from '../../../../models/visualization/flows/support/processor-steps.service';
 import { ActionConfirmationModalContext } from '../../../../providers/action-confirmation-modal.provider';
 import { EntitiesContext } from '../../../../providers/entities.provider';
 import { ClipboardService } from '../../../../services/visualization/clipboard.service';
@@ -98,7 +98,7 @@ export const usePasteStep = (vizNode: IVisualizationNode, mode: AddStepMode) => 
 
     // Set an empty model to clear the graph, Fixes an issue rendering child nodes incorrectly
     if (mode === AddStepMode.InsertSpecialChildStep) {
-      const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+      const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
         vizNode.data.primaryNodeId?.name as keyof ProcessorDefinition,
       );
       if (

--- a/packages/ui/src/models/special-processors.constants.ts
+++ b/packages/ui/src/models/special-processors.constants.ts
@@ -49,3 +49,16 @@ export const SPECIAL_PROCESSORS_PARENTS_MAP = {
 export const SPECIAL_CHILD_PROCESSORS = Object.entries(SPECIAL_PROCESSORS_PARENTS_MAP)
   .filter(([key]) => key !== 'routeConfiguration')
   .flatMap(([, values]) => values);
+
+/**
+ * Processors that cannot have a sibling step in the canvas.
+ * Includes flow-level nodes and all special clause children.
+ */
+export const DISABLED_SIBLING_STEPS = [
+  'route',
+  'from',
+  'onWhen',
+  ...Object.values(SPECIAL_PROCESSORS_PARENTS_MAP)
+    .flat()
+    .filter((v) => v !== 'onFallback'),
+] as const;

--- a/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/abstract-camel-visual-entity.ts
@@ -28,6 +28,7 @@ import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentDefaultService } from './support/camel-component-default.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
 import { CamelProcessorStepsProperties } from './support/camel-component-types';
+import { ProcessorStepsService } from './support/processor-steps.service';
 import { ModelValidationService } from './support/validators/model-validation.service';
 
 export abstract class AbstractCamelVisualEntity<T extends object> implements BaseVisualEntity {
@@ -294,11 +295,11 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
     const processorName = data.primaryNodeId?.name as keyof ProcessorDefinition;
-    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(processorName);
-    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(processorName);
+    const canHavePreviousStep = ProcessorStepsService.canHavePreviousStep(processorName);
+    const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(processorName);
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');
     const canHaveSpecialChildren = Object.keys(stepsProperties).length > 1;
-    const canReplaceStep = CamelComponentSchemaService.canReplaceStep(processorName);
+    const canReplaceStep = ProcessorStepsService.canReplaceStep(processorName);
     const canRemoveFlow = data.path === this.getRootPath();
     const canRemoveStep = !canRemoveFlow && !CamelComponentSchemaService.DISABLED_REMOVE_STEPS.includes(processorName);
     const canBeDisabled = CamelComponentSchemaService.canBeDisabled(processorName);
@@ -402,7 +403,7 @@ export abstract class AbstractCamelVisualEntity<T extends object> implements Bas
     insertAtStart?: boolean,
   ) {
     if (data.path === undefined) return;
-    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+    const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
 

--- a/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-from-visual-entity.ts
@@ -10,6 +10,7 @@ import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { ProcessorStepsService } from './support/processor-steps.service';
 
 export class CamelInterceptFromVisualEntity
   extends AbstractCamelVisualEntity<{ interceptFrom: InterceptFrom }>
@@ -67,10 +68,10 @@ export class CamelInterceptFromVisualEntity
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
-    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+    const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
-    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
+    const canHavePreviousStep = ProcessorStepsService.canHavePreviousStep(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');

--- a/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-send-to-endpoint-visual-entity.ts
@@ -10,6 +10,7 @@ import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { ProcessorStepsService } from './support/processor-steps.service';
 
 export class CamelInterceptSendToEndpointVisualEntity
   extends AbstractCamelVisualEntity<{ interceptSendToEndpoint: InterceptSendToEndpoint }>
@@ -79,10 +80,10 @@ export class CamelInterceptSendToEndpointVisualEntity
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
-    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+    const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
-    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
+    const canHavePreviousStep = ProcessorStepsService.canHavePreviousStep(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');

--- a/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-intercept-visual-entity.ts
@@ -10,6 +10,7 @@ import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { ProcessorStepsService } from './support/processor-steps.service';
 
 export class CamelInterceptVisualEntity
   extends AbstractCamelVisualEntity<{ intercept: Intercept }>
@@ -50,10 +51,10 @@ export class CamelInterceptVisualEntity
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
-    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+    const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
-    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
+    const canHavePreviousStep = ProcessorStepsService.canHavePreviousStep(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');

--- a/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-completion-visual-entity.ts
@@ -10,6 +10,7 @@ import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { ProcessorStepsService } from './support/processor-steps.service';
 
 export class CamelOnCompletionVisualEntity
   extends AbstractCamelVisualEntity<{ onCompletion: OnCompletion }>
@@ -52,10 +53,10 @@ export class CamelOnCompletionVisualEntity
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
-    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+    const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
-    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
+    const canHavePreviousStep = ProcessorStepsService.canHavePreviousStep(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');

--- a/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/camel-on-exception-visual-entity.ts
@@ -10,6 +10,7 @@ import { AbstractCamelVisualEntity } from './abstract-camel-visual-entity';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { NodeMapperService } from './nodes/node-mapper.service';
 import { CamelComponentSchemaService } from './support/camel-component-schema.service';
+import { ProcessorStepsService } from './support/processor-steps.service';
 
 export class CamelOnExceptionVisualEntity
   extends AbstractCamelVisualEntity<{ onException: OnException }>
@@ -52,10 +53,10 @@ export class CamelOnExceptionVisualEntity
   }
 
   getNodeInteraction(data: IVisualizationNodeData): NodeInteraction {
-    const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+    const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
-    const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
+    const canHavePreviousStep = ProcessorStepsService.canHavePreviousStep(
       data.primaryNodeId?.name as keyof ProcessorDefinition,
     );
     const canHaveChildren = stepsProperties.some((property) => property.type === 'branch');

--- a/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
+++ b/packages/ui/src/models/visualization/flows/nodes/mappers/base-node-mapper.ts
@@ -8,8 +8,8 @@ import { SPECIAL_PROCESSORS_PARENTS_MAP } from '../../../../special-processors.c
 import { IVisualizationNode, IVisualizationNodeData, IVisualizationNodeIds } from '../../../base-visual-entity';
 import { NodeIdentity } from '../../../node-identity';
 import { createVisualizationNode } from '../../../visualization-node';
-import { CamelComponentSchemaService } from '../../support/camel-component-schema.service';
 import { CamelProcessorStepsProperties } from '../../support/camel-component-types';
+import { ProcessorStepsService } from '../../support/processor-steps.service';
 import { INodeMapper } from '../node-mapper';
 
 const URI_PROCESSORS = new Set<string>(['to', 'toD', 'poll']);
@@ -58,7 +58,7 @@ export class BaseNodeMapper implements INodeMapper {
 
     const vizNode = createVisualizationNode(path, data);
 
-    const childrenStepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
+    const childrenStepsProperties = ProcessorStepsService.getProcessorStepsProperties(
       componentLookup.primaryNodeId?.name as keyof ProcessorDefinition,
     );
 

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.test.ts
@@ -6,7 +6,6 @@ import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
 import { CamelCatalogService } from '../camel-catalog.service';
 import { CamelComponentSchemaService } from './camel-component-schema.service';
-import { CamelProcessorStepsProperties } from './camel-component-types';
 
 describe('CamelComponentSchemaService', () => {
   beforeAll(async () => {
@@ -24,126 +23,6 @@ describe('CamelComponentSchemaService', () => {
 
   afterAll(() => {
     CamelCatalogService.clearCatalogs();
-  });
-
-  describe('canHavePreviousStep', () => {
-    it.each([
-      ['from', false],
-      ['when', false],
-      ['otherwise', false],
-      ['doCatch', false],
-      ['doFinally', false],
-      ['aggregate', true],
-      ['onFallback', true],
-      ['saga', true],
-    ])('should return whether the %s processor could have a previous step', (processorName, result) => {
-      const canHavePreviousStep = CamelComponentSchemaService.canHavePreviousStep(
-        processorName as keyof ProcessorDefinition,
-      );
-
-      expect(canHavePreviousStep).toEqual(result);
-    });
-  });
-
-  describe('canReplaceStep', () => {
-    it.each([
-      ['from', true],
-      ['when', false],
-      ['otherwise', false],
-      ['doCatch', false],
-      ['doFinally', false],
-      ['intercept', false],
-      ['interceptFrom', false],
-      ['interceptSendToEndpoint', false],
-      ['onException', false],
-      ['onCompletion', false],
-      ['aggregate', true],
-      ['onFallback', true],
-      ['saga', true],
-    ])('should return whether the %s processor could be replaced', (processorName, result) => {
-      const canBeReplaced = CamelComponentSchemaService.canReplaceStep(processorName as keyof ProcessorDefinition);
-
-      expect(canBeReplaced).toEqual(result);
-    });
-  });
-
-  describe('getProcessorStepsProperties', () => {
-    it.each([
-      ['from', [{ name: 'steps', type: 'branch' }]],
-      ['when', [{ name: 'steps', type: 'branch' }]],
-      ['otherwise', [{ name: 'steps', type: 'branch' }]],
-      ['doCatch', [{ name: 'steps', type: 'branch' }]],
-      ['doFinally', [{ name: 'steps', type: 'branch' }]],
-      ['aggregate', [{ name: 'steps', type: 'branch' }]],
-      [
-        'circuitBreaker',
-        [
-          { name: 'steps', type: 'branch' },
-          { name: 'onFallback', type: 'single-clause' },
-        ],
-      ],
-      ['onFallback', [{ name: 'steps', type: 'branch' }]],
-      ['saga', [{ name: 'steps', type: 'branch' }]],
-      [
-        'choice',
-        [
-          { name: 'when', type: 'array-clause' },
-          { name: 'otherwise', type: 'single-clause' },
-        ],
-      ],
-      [
-        'doTry',
-        [
-          { name: 'steps', type: 'branch' },
-          { name: 'doCatch', type: 'array-clause' },
-          { name: 'doFinally', type: 'single-clause' },
-        ],
-      ],
-      ['to', []],
-      ['toD', []],
-      ['log', []],
-      [
-        'routeConfiguration',
-        [
-          { name: 'intercept', type: 'array-clause' },
-          { name: 'interceptFrom', type: 'array-clause' },
-          { name: 'interceptSendToEndpoint', type: 'array-clause' },
-          { name: 'onException', type: 'array-clause' },
-          { name: 'onCompletion', type: 'array-clause' },
-        ],
-      ],
-      ['intercept', [{ name: 'steps', type: 'branch' }]],
-      ['interceptFrom', [{ name: 'steps', type: 'branch' }]],
-      ['interceptSendToEndpoint', [{ name: 'steps', type: 'branch' }]],
-      ['onException', [{ name: 'steps', type: 'branch' }]],
-      ['onCompletion', [{ name: 'steps', type: 'branch' }]],
-      [
-        'rest',
-        [
-          { name: 'get', type: 'array-clause' },
-          { name: 'post', type: 'array-clause' },
-          { name: 'put', type: 'array-clause' },
-          { name: 'delete', type: 'array-clause' },
-          { name: 'patch', type: 'array-clause' },
-          { name: 'head', type: 'array-clause' },
-        ],
-      ],
-      ['get', [{ name: 'to', type: 'single-clause' }]],
-      ['post', [{ name: 'to', type: 'single-clause' }]],
-      ['put', [{ name: 'to', type: 'single-clause' }]],
-      ['delete', [{ name: 'to', type: 'single-clause' }]],
-      ['patch', [{ name: 'to', type: 'single-clause' }]],
-      ['head', [{ name: 'to', type: 'single-clause' }]],
-    ] as [string, CamelProcessorStepsProperties[]][])(
-      `should return the steps properties for '%s'`,
-      (processorName, result) => {
-        const stepsProperties = CamelComponentSchemaService.getProcessorStepsProperties(
-          processorName as keyof ProcessorDefinition,
-        );
-
-        expect(stepsProperties).toEqual(result);
-      },
-    );
   });
 
   describe('canBeDisabled', () => {

--- a/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/camel-component-schema.service.ts
@@ -2,53 +2,9 @@ import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
 
 import { DATAMAPPER_ID_PREFIX } from '../../../../utils';
 import { CatalogKind } from '../../../catalog-kind';
-import { REST_DSL_VERBS } from '../../../special-processors.constants';
 import { CamelCatalogService } from '../camel-catalog.service';
-import { CamelProcessorStepsProperties } from './camel-component-types';
-
-const CAMEL_EIP_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [{ name: 'steps', type: 'branch' }];
-const CAMEL_CIRCUIT_BREAK_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [
-  { name: 'steps', type: 'branch' },
-  { name: 'onFallback', type: 'single-clause' },
-];
-const CAMEL_CHOICE_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [
-  { name: 'when', type: 'array-clause' },
-  { name: 'otherwise', type: 'single-clause' },
-];
-const CAMEL_DO_TRY_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [
-  { name: 'steps', type: 'branch' },
-  { name: 'doCatch', type: 'array-clause' },
-  { name: 'doFinally', type: 'single-clause' },
-];
-const CAMEL_ROUTE_CONFIGURATION_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [
-  { name: 'intercept', type: 'array-clause' },
-  { name: 'interceptFrom', type: 'array-clause' },
-  { name: 'interceptSendToEndpoint', type: 'array-clause' },
-  { name: 'onException', type: 'array-clause' },
-  { name: 'onCompletion', type: 'array-clause' },
-];
-const CAMEL_REST_DSL_STEP_PROPERTIES: CamelProcessorStepsProperties[] = REST_DSL_VERBS.map((method) => ({
-  name: method,
-  type: 'array-clause',
-}));
-const CAMEL_REST_VERB_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [{ name: 'to', type: 'single-clause' }];
 
 export class CamelComponentSchemaService {
-  static readonly DISABLED_SIBLING_STEPS = [
-    'route',
-    'from',
-    'onWhen',
-    'when',
-    'otherwise',
-    'doCatch',
-    'doFinally',
-    'intercept',
-    'interceptFrom',
-    'interceptSendToEndpoint',
-    'onException',
-    'onCompletion',
-    ...REST_DSL_VERBS,
-  ];
   static readonly DISABLED_REMOVE_STEPS = ['from', 'route'] as unknown as (keyof ProcessorDefinition)[];
   static readonly PROCESSOR_STRING_DEFINITIONS: Record<string, string> = {
     to: 'uri',
@@ -67,68 +23,6 @@ export class CamelComponentSchemaService {
     removeHeaders: 'pattern',
     kamelet: 'name',
   };
-
-  static canHavePreviousStep(processorName: keyof ProcessorDefinition): boolean {
-    return !this.DISABLED_SIBLING_STEPS.includes(processorName);
-  }
-
-  static canReplaceStep(processorName: keyof ProcessorDefinition): boolean {
-    return (
-      processorName === ('from' as keyof ProcessorDefinition) || !this.DISABLED_SIBLING_STEPS.includes(processorName)
-    );
-  }
-
-  static getProcessorStepsProperties(processorName: keyof ProcessorDefinition): CamelProcessorStepsProperties[] {
-    switch (processorName) {
-      /** choice */ case 'when' as keyof ProcessorDefinition:
-      /** choice */ case 'otherwise' as keyof ProcessorDefinition:
-      /** doTry */ case 'doCatch':
-      /** doTry */ case 'doFinally':
-      case 'aggregate':
-      case 'filter':
-      case 'loadBalance':
-      case 'loop':
-      case 'multicast':
-      case 'onFallback' as keyof ProcessorDefinition:
-      case 'pipeline':
-      case 'resequence':
-      case 'saga':
-      case 'split':
-      case 'step':
-      case 'whenSkipSendToEndpoint' as keyof ProcessorDefinition:
-      case 'from' as keyof ProcessorDefinition:
-      case /** routeConfiguration */ 'intercept' as keyof ProcessorDefinition:
-      case /** routeConfiguration */ 'interceptFrom' as keyof ProcessorDefinition:
-      case /** routeConfiguration */ 'interceptSendToEndpoint' as keyof ProcessorDefinition:
-      case /** routeConfiguration */ 'onException' as keyof ProcessorDefinition:
-      case /** routeConfiguration */ 'onCompletion' as keyof ProcessorDefinition:
-        return CAMEL_EIP_STEP_PROPERTIES;
-
-      case 'circuitBreaker':
-        return CAMEL_CIRCUIT_BREAK_STEP_PROPERTIES;
-
-      case 'choice':
-        return CAMEL_CHOICE_STEP_PROPERTIES;
-
-      case 'doTry':
-        return CAMEL_DO_TRY_STEP_PROPERTIES;
-
-      case 'routeConfiguration' as keyof ProcessorDefinition:
-        return CAMEL_ROUTE_CONFIGURATION_STEP_PROPERTIES;
-
-      case 'rest' as keyof ProcessorDefinition:
-        return CAMEL_REST_DSL_STEP_PROPERTIES;
-      case /** rest */ 'get' as keyof ProcessorDefinition:
-      case /** rest */ 'post' as keyof ProcessorDefinition:
-      case /** rest */ 'put' as keyof ProcessorDefinition:
-      case /** rest */ 'delete' as keyof ProcessorDefinition:
-      case /** rest */ 'patch' as keyof ProcessorDefinition:
-      case /** rest */ 'head' as keyof ProcessorDefinition:
-        return CAMEL_REST_VERB_STEP_PROPERTIES;
-      default:
-        return [];
-    }
-  }
 
   static canBeDisabled(processorName: keyof ProcessorDefinition): boolean {
     if (processorName == DATAMAPPER_ID_PREFIX) {

--- a/packages/ui/src/models/visualization/flows/support/processor-steps.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/processor-steps.service.test.ts
@@ -1,0 +1,124 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+
+import { CamelProcessorStepsProperties } from './camel-component-types';
+import { ProcessorStepsService } from './processor-steps.service';
+
+describe('ProcessorStepsService', () => {
+  describe('canHavePreviousStep', () => {
+    it.each([
+      ['from', false],
+      ['when', false],
+      ['otherwise', false],
+      ['doCatch', false],
+      ['doFinally', false],
+      ['aggregate', true],
+      ['onFallback', true],
+      ['saga', true],
+    ])('should return whether the %s processor could have a previous step', (processorName, result) => {
+      const canHavePreviousStep = ProcessorStepsService.canHavePreviousStep(processorName as keyof ProcessorDefinition);
+
+      expect(canHavePreviousStep).toEqual(result);
+    });
+  });
+
+  describe('canReplaceStep', () => {
+    it.each([
+      ['from', true],
+      ['when', false],
+      ['otherwise', false],
+      ['doCatch', false],
+      ['doFinally', false],
+      ['intercept', false],
+      ['interceptFrom', false],
+      ['interceptSendToEndpoint', false],
+      ['onException', false],
+      ['onCompletion', false],
+      ['aggregate', true],
+      ['onFallback', true],
+      ['saga', true],
+    ])('should return whether the %s processor could be replaced', (processorName, result) => {
+      const canBeReplaced = ProcessorStepsService.canReplaceStep(processorName as keyof ProcessorDefinition);
+
+      expect(canBeReplaced).toEqual(result);
+    });
+  });
+
+  describe('getProcessorStepsProperties', () => {
+    it.each([
+      ['from', [{ name: 'steps', type: 'branch' }]],
+      ['when', [{ name: 'steps', type: 'branch' }]],
+      ['otherwise', [{ name: 'steps', type: 'branch' }]],
+      ['doCatch', [{ name: 'steps', type: 'branch' }]],
+      ['doFinally', [{ name: 'steps', type: 'branch' }]],
+      ['aggregate', [{ name: 'steps', type: 'branch' }]],
+      [
+        'circuitBreaker',
+        [
+          { name: 'steps', type: 'branch' },
+          { name: 'onFallback', type: 'single-clause' },
+        ],
+      ],
+      ['onFallback', [{ name: 'steps', type: 'branch' }]],
+      ['saga', [{ name: 'steps', type: 'branch' }]],
+      [
+        'choice',
+        [
+          { name: 'when', type: 'array-clause' },
+          { name: 'otherwise', type: 'single-clause' },
+        ],
+      ],
+      [
+        'doTry',
+        [
+          { name: 'steps', type: 'branch' },
+          { name: 'doCatch', type: 'array-clause' },
+          { name: 'doFinally', type: 'single-clause' },
+        ],
+      ],
+      ['to', []],
+      ['toD', []],
+      ['log', []],
+      [
+        'routeConfiguration',
+        [
+          { name: 'intercept', type: 'array-clause' },
+          { name: 'interceptFrom', type: 'array-clause' },
+          { name: 'interceptSendToEndpoint', type: 'array-clause' },
+          { name: 'onException', type: 'array-clause' },
+          { name: 'onCompletion', type: 'array-clause' },
+        ],
+      ],
+      ['intercept', [{ name: 'steps', type: 'branch' }]],
+      ['interceptFrom', [{ name: 'steps', type: 'branch' }]],
+      ['interceptSendToEndpoint', [{ name: 'steps', type: 'branch' }]],
+      ['onException', [{ name: 'steps', type: 'branch' }]],
+      ['onCompletion', [{ name: 'steps', type: 'branch' }]],
+      [
+        'rest',
+        [
+          { name: 'get', type: 'array-clause' },
+          { name: 'post', type: 'array-clause' },
+          { name: 'put', type: 'array-clause' },
+          { name: 'delete', type: 'array-clause' },
+          { name: 'patch', type: 'array-clause' },
+          { name: 'head', type: 'array-clause' },
+        ],
+      ],
+      ['get', [{ name: 'to', type: 'single-clause' }]],
+      ['post', [{ name: 'to', type: 'single-clause' }]],
+      ['put', [{ name: 'to', type: 'single-clause' }]],
+      ['delete', [{ name: 'to', type: 'single-clause' }]],
+      ['patch', [{ name: 'to', type: 'single-clause' }]],
+      ['head', [{ name: 'to', type: 'single-clause' }]],
+    ] as [string, CamelProcessorStepsProperties[]][])(
+      `should return the steps properties for '%s'`,
+      (processorName, result) => {
+        const stepsProperties = ProcessorStepsService.getProcessorStepsProperties(
+          processorName as keyof ProcessorDefinition,
+        );
+
+        expect(stepsProperties).toEqual(result);
+      },
+    );
+  });
+});

--- a/packages/ui/src/models/visualization/flows/support/processor-steps.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/processor-steps.service.ts
@@ -1,0 +1,93 @@
+import { ProcessorDefinition } from '@kaoto/camel-catalog/types';
+
+import {
+  DISABLED_SIBLING_STEPS,
+  SPECIAL_PROCESSORS_PARENTS_MAP,
+} from '../../../../models/special-processors.constants';
+import { CamelProcessorStepsProperties } from './camel-component-types';
+
+const CAMEL_EIP_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [{ name: 'steps', type: 'branch' }];
+const CAMEL_CIRCUIT_BREAK_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [
+  { name: 'steps', type: 'branch' },
+  { name: 'onFallback', type: 'single-clause' },
+];
+const CAMEL_CHOICE_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [
+  { name: 'when', type: 'array-clause' },
+  { name: 'otherwise', type: 'single-clause' },
+];
+const CAMEL_DO_TRY_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [
+  { name: 'steps', type: 'branch' },
+  { name: 'doCatch', type: 'array-clause' },
+  { name: 'doFinally', type: 'single-clause' },
+];
+const CAMEL_ROUTE_CONFIGURATION_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [
+  { name: 'intercept', type: 'array-clause' },
+  { name: 'interceptFrom', type: 'array-clause' },
+  { name: 'interceptSendToEndpoint', type: 'array-clause' },
+  { name: 'onException', type: 'array-clause' },
+  { name: 'onCompletion', type: 'array-clause' },
+];
+const CAMEL_REST_VERB_STEP_PROPERTIES: CamelProcessorStepsProperties[] = [{ name: 'to', type: 'single-clause' }];
+
+export class ProcessorStepsService {
+  static canHavePreviousStep(processorName: keyof ProcessorDefinition): boolean {
+    return !(DISABLED_SIBLING_STEPS as readonly string[]).includes(processorName as string);
+  }
+
+  static canReplaceStep(processorName: keyof ProcessorDefinition): boolean {
+    return (
+      processorName === ('from' as keyof ProcessorDefinition) ||
+      !(DISABLED_SIBLING_STEPS as readonly string[]).includes(processorName as string)
+    );
+  }
+
+  static getProcessorStepsProperties(processorName: keyof ProcessorDefinition): CamelProcessorStepsProperties[] {
+    if ((SPECIAL_PROCESSORS_PARENTS_MAP.rest as readonly string[]).includes(processorName as string)) {
+      return CAMEL_REST_VERB_STEP_PROPERTIES;
+    }
+
+    switch (processorName) {
+      /** choice */ case 'when' as keyof ProcessorDefinition:
+      /** choice */ case 'otherwise' as keyof ProcessorDefinition:
+      /** doTry */ case 'doCatch':
+      /** doTry */ case 'doFinally':
+      case 'aggregate':
+      case 'filter':
+      case 'loadBalance':
+      case 'loop':
+      case 'multicast':
+      case 'onFallback' as keyof ProcessorDefinition:
+      case 'pipeline':
+      case 'resequence':
+      case 'saga':
+      case 'split':
+      case 'step':
+      case 'whenSkipSendToEndpoint' as keyof ProcessorDefinition:
+      case 'from' as keyof ProcessorDefinition:
+      case /** routeConfiguration */ 'intercept' as keyof ProcessorDefinition:
+      case /** routeConfiguration */ 'interceptFrom' as keyof ProcessorDefinition:
+      case /** routeConfiguration */ 'interceptSendToEndpoint' as keyof ProcessorDefinition:
+      case /** routeConfiguration */ 'onException' as keyof ProcessorDefinition:
+      case /** routeConfiguration */ 'onCompletion' as keyof ProcessorDefinition:
+        return CAMEL_EIP_STEP_PROPERTIES;
+
+      case 'circuitBreaker':
+        return CAMEL_CIRCUIT_BREAK_STEP_PROPERTIES;
+
+      case 'choice':
+        return CAMEL_CHOICE_STEP_PROPERTIES;
+
+      case 'doTry':
+        return CAMEL_DO_TRY_STEP_PROPERTIES;
+
+      case 'routeConfiguration' as keyof ProcessorDefinition:
+        return CAMEL_ROUTE_CONFIGURATION_STEP_PROPERTIES;
+
+      case 'rest' as keyof ProcessorDefinition:
+        return SPECIAL_PROCESSORS_PARENTS_MAP.rest.map((method) => ({ name: method, type: 'array-clause' as const }));
+
+      default:
+        return [];
+    }
+  }
+}


### PR DESCRIPTION
Closes #3868

## Summary

Move `canHavePreviousStep`, `canReplaceStep`, `getProcessorStepsProperties`, `DISABLED_SIBLING_STEPS`, and related step-property constants out of `CamelComponentSchemaService` into a new dedicated `ProcessorStepsService`.

Consolidate the disabled-sibling and special-processor constants in `special-processors.constants.ts` and update all callers accordingly.

## Changes

- **New file**: `processor-steps.service.ts` — dedicated service for processor step logic
- **New file**: `processor-steps.service.test.ts` — full test coverage for the new service
- **Updated**: `special-processors.constants.ts` — consolidates `DISABLED_SIBLING_STEPS` and related constants
- **Updated**: `camel-component-schema.service.ts` — removes extracted logic (~100 lines removed)
- **Updated**: all callers (`CustomNodeUtils`, hooks, visual entities, mappers) to import from the new service

## Motivation

`CamelComponentSchemaService` had grown to include responsibilities beyond schema handling — specifically the logic for determining valid processor step positions. Extracting this into `ProcessorStepsService` improves single-responsibility adherence and makes the step logic easier to find, test, and maintain independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved step interaction handling in the visual editor, including adding, inserting, duplicating, pasting, replacing, and navigating between processor steps.
  * Prevented unsupported sibling steps from being added to restricted flow and clause nodes.
  * Preserved processor-specific branching and clause behavior across supported Camel processors.

* **Tests**
  * Added coverage for processor step capabilities and property handling across common processor types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->