### PR TITLE
refactor(DataMapper): remove unused field from IDataMapperContext

### DIFF
--- a/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/DebugLayout.test.tsx
@@ -40,7 +40,7 @@ describe('DebugLayout', () => {
     const LoadMappings: FunctionComponent<PropsWithChildren> = ({ children }) => {
       const {
         mappingTree,
-        setMappingTree,
+        refreshMappingTree,
         sourceParameterMap,
         setSourceBodyDocument,
         setTargetBodyDocument,
@@ -52,7 +52,7 @@ describe('DebugLayout', () => {
         const targetDoc = TestUtil.createTargetOrderDoc();
         setTargetBodyDocument(targetDoc);
         MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, mappingTree, sourceParameterMap);
-        setMappingTree(mappingTree);
+        refreshMappingTree({ structural: true });
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
       useEffect(() => {
@@ -83,7 +83,7 @@ describe('DebugLayout', () => {
   // Skipped: JSDOM cannot render the full DataMapperControl layout (expansion panels require real dimensions)
   it.skip('should update store selection when clicking a node', async () => {
     const LoadMappings: FunctionComponent<PropsWithChildren> = ({ children }) => {
-      const { mappingTree, setMappingTree, sourceParameterMap, setSourceBodyDocument, setTargetBodyDocument } =
+      const { mappingTree, refreshMappingTree, sourceParameterMap, setSourceBodyDocument, setTargetBodyDocument } =
         useDataMapper();
       useEffect(() => {
         const sourceDoc = TestUtil.createSourceOrderDoc();
@@ -91,7 +91,7 @@ describe('DebugLayout', () => {
         const targetDoc = TestUtil.createTargetOrderDoc();
         setTargetBodyDocument(targetDoc);
         MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, mappingTree, sourceParameterMap);
-        setMappingTree(mappingTree);
+        refreshMappingTree({ structural: true });
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
       return <>{children}</>;
@@ -180,7 +180,7 @@ describe('DebugLayout', () => {
         const {
           setDebug,
           mappingTree,
-          setMappingTree,
+          refreshMappingTree,
           sourceParameterMap,
           setSourceBodyDocument,
           setTargetBodyDocument,
@@ -197,7 +197,7 @@ describe('DebugLayout', () => {
             mappingTree,
             sourceParameterMap,
           );
-          setMappingTree(mappingTree);
+          refreshMappingTree({ structural: true });
           // eslint-disable-next-line react-hooks/exhaustive-deps
         }, []);
         return <>{children}</>;

--- a/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
+++ b/packages/ui/src/components/DataMapper/debug/ExportMappingFileModal.test.tsx
@@ -155,7 +155,7 @@ describe('ExportMappingFileModal', () => {
 
   it('should serialize and display mappings when mappings exist', async () => {
     const TestLoader: FunctionComponent<PropsWithChildren> = ({ children }) => {
-      const { mappingTree, setMappingTree, sourceParameterMap, setSourceBodyDocument, setTargetBodyDocument } =
+      const { mappingTree, refreshMappingTree, sourceParameterMap, setSourceBodyDocument, setTargetBodyDocument } =
         useDataMapper();
       useEffect(() => {
         const sourceDoc = TestUtil.createSourceOrderDoc();
@@ -163,7 +163,7 @@ describe('ExportMappingFileModal', () => {
         const targetDoc = TestUtil.createTargetOrderDoc();
         setTargetBodyDocument(targetDoc);
         MappingSerializerService.deserialize(getShipOrderToShipOrderXslt(), targetDoc, mappingTree, sourceParameterMap);
-        setMappingTree(mappingTree);
+        refreshMappingTree({ structural: true });
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
       return <>{children}</>;
@@ -209,14 +209,14 @@ describe('ExportMappingFileModal', () => {
 
   it('should update serialized mappings when mappingTree changes', async () => {
     const TestLoader: FunctionComponent<PropsWithChildren> = ({ children }) => {
-      const { mappingTree, setMappingTree, setSourceBodyDocument, setTargetBodyDocument } = useDataMapper();
+      const { refreshMappingTree, setSourceBodyDocument, setTargetBodyDocument } = useDataMapper();
       useEffect(() => {
         const sourceDoc = TestUtil.createSourceOrderDoc();
         setSourceBodyDocument(sourceDoc);
         const targetDoc = TestUtil.createTargetOrderDoc();
         setTargetBodyDocument(targetDoc);
         // Initially no mappings
-        setMappingTree(mappingTree);
+        refreshMappingTree({ structural: true });
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, []);
       return <>{children}</>;

--- a/packages/ui/src/providers/datamapper.provider.tsx
+++ b/packages/ui/src/providers/datamapper.provider.tsx
@@ -73,7 +73,6 @@ export interface IDataMapperContext {
   structuralMappingTree: MappingTree;
   refreshMappingTree(options?: { structural?: boolean }): void;
   resetMappingTree(): void;
-  setMappingTree(mappings: MappingTree): void;
   variables: VariableItem[];
 
   alerts: SendAlertProps[];
@@ -427,7 +426,6 @@ export const DataMapperProvider: FunctionComponent<DataMapperProviderProps> = ({
       structuralMappingTree,
       refreshMappingTree,
       resetMappingTree,
-      setMappingTree,
       variables,
       alerts,
       sendAlert,


### PR DESCRIPTION
Resolves: [#3835](https://github.com/KaotoIO/kaoto/issues/3835)

Drop the field that was declared in IDataMapperContext but never consumed by any component or hook. Update DebugLayout and ExportMappingFileModal tests to stop destructuring the removed field from the useDataMapper() hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mapping refresh behavior after importing or deserializing mappings.
  * Mapping updates now trigger structural refreshes to keep the mapping tree synchronized more reliably.
  * Updated mapping-related workflows to ensure refreshed data is reflected consistently after loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->