### PR TITLE
refactor: Migrate `PipeErrorHandler`, `Metadata`, `Beans`, and `BeanField` to the Dynamic catalog

### DIFF
--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.test.tsx
@@ -7,12 +7,12 @@ import { FunctionComponent, ReactElement } from 'react';
 import type { Mock } from 'vitest';
 
 import { useEntityContext } from '../../../../../../hooks/useEntityContext/useEntityContext';
-import { CamelCatalogService, CatalogKind, KaotoSchemaDefinition } from '../../../../../../models';
+import { KaotoSchemaDefinition } from '../../../../../../models';
 import { BeansEntity } from '../../../../../../models/visualization/metadata';
 import { EntitiesContextResult } from '../../../../../../providers';
 import { DocumentationService } from '../../../../../../services/documentation.service';
 import { TestProvidersWrapper } from '../../../../../../stubs';
-import { getFirstCatalogMap } from '../../../../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../../../../stubs/test-load-catalog';
 import { IVisibleFlows, ROOT_PATH } from '../../../../../../utils';
 import { DataSourceBeanField, PrefixedBeanField, UnprefixedBeanField } from './BeanField';
 
@@ -24,10 +24,12 @@ describe('BeanField', () => {
   const refSchema: KaotoSchemaDefinition['schema'] = { title: 'Ref', type: 'string' };
   const beanReferenceSchema: KaotoSchemaDefinition['schema'] = { title: 'Bean Reference', type: 'string' };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
+    setupDynamicCatalogRegistry(catalogsMap);
+  });
 
+  beforeEach(async () => {
     onPropertyChangeSpy = vi.fn();
     cleanup();
   });
@@ -40,15 +42,18 @@ describe('BeanField', () => {
   ) => {
     const { Provider } = await TestProvidersWrapper();
 
-    render(
-      <Provider>
-        <SchemaProvider schema={schema}>
-          <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-            {component}
-          </ModelContextProvider>
-        </SchemaProvider>
-      </Provider>,
-    );
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      render(
+        <Provider>
+          <SchemaProvider schema={schema}>
+            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+              {component}
+            </ModelContextProvider>
+          </SchemaProvider>
+        </Provider>,
+      );
+    });
 
     formPageObject = new KaotoFormPageObject(screen, act);
 
@@ -77,31 +82,39 @@ describe('BeanField', () => {
     it('should render', async () => {
       const { Provider } = await TestProvidersWrapper();
 
-      const { container } = render(
-        <Provider>
-          <ModelContextProvider model="#dataSource" onPropertyChange={vi.fn()}>
-            <PrefixedBeanField propName={ROOT_PATH} />
-          </ModelContextProvider>
-        </Provider>,
-      );
+      let container: HTMLElement;
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        ({ container } = render(
+          <Provider>
+            <ModelContextProvider model="#dataSource" onPropertyChange={vi.fn()}>
+              <PrefixedBeanField propName={ROOT_PATH} />
+            </ModelContextProvider>
+          </Provider>,
+        ));
+      });
 
-      expect(container).toMatchSnapshot();
+      await screen.findByRole('textbox');
+      expect(container!).toMatchSnapshot();
     });
 
     it('should set the appropriate placeholder', async () => {
       const { Provider } = await TestProvidersWrapper();
 
-      const wrapper = render(
-        <Provider>
-          <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
-            <SchemaProvider schema={{ type: 'string', default: 'Default Value' }}>
-              <PrefixedBeanField propName={ROOT_PATH} />
-            </SchemaProvider>
-          </ModelContextProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
+              <SchemaProvider schema={{ type: 'string', default: 'Default Value' }}>
+                <PrefixedBeanField propName={ROOT_PATH} />
+              </SchemaProvider>
+            </ModelContextProvider>
+          </Provider>,
+        );
+      });
 
-      const input = wrapper.getByRole('textbox');
+      const input = screen.getByRole('textbox');
       expect(input).toHaveAttribute('placeholder', 'Default Value');
     });
 
@@ -109,13 +122,16 @@ describe('BeanField', () => {
       const onPropertyChangeSpy = vi.fn();
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <ModelContextProvider model="#dataSource" onPropertyChange={onPropertyChangeSpy}>
-            <PrefixedBeanField propName={ROOT_PATH} />
-          </ModelContextProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <ModelContextProvider model="#dataSource" onPropertyChange={onPropertyChangeSpy}>
+              <PrefixedBeanField propName={ROOT_PATH} />
+            </ModelContextProvider>
+          </Provider>,
+        );
+      });
 
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.clearForProperty(ROOT_PATH);
@@ -128,15 +144,18 @@ describe('BeanField', () => {
       const onPropertyChangeSpy = vi.fn();
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <SchemaProvider schema={beanSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <PrefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={beanSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <PrefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -155,15 +174,18 @@ describe('BeanField', () => {
 
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <SchemaProvider schema={beanSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <PrefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={beanSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <PrefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
     });
@@ -238,15 +260,18 @@ describe('BeanField', () => {
 
       const { Provider } = await TestProvidersWrapper();
       cleanup();
-      render(
-        <Provider>
-          <SchemaProvider schema={beanSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <CaptureEntitiesWrapper />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={beanSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <CaptureEntitiesWrapper />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
       formPageObject = new KaotoFormPageObject(screen, act);
 
       await createBean('myNewBean', 'Bean');
@@ -270,31 +295,39 @@ describe('BeanField', () => {
     it('should render', async () => {
       const { Provider } = await TestProvidersWrapper();
 
-      const { container } = render(
-        <Provider>
-          <ModelContextProvider model="dataSource" onPropertyChange={vi.fn()}>
-            <UnprefixedBeanField propName={ROOT_PATH} />
-          </ModelContextProvider>
-        </Provider>,
-      );
+      let container: HTMLElement;
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        ({ container } = render(
+          <Provider>
+            <ModelContextProvider model="dataSource" onPropertyChange={vi.fn()}>
+              <UnprefixedBeanField propName={ROOT_PATH} />
+            </ModelContextProvider>
+          </Provider>,
+        ));
+      });
 
-      expect(container).toMatchSnapshot();
+      await screen.findByRole('textbox');
+      expect(container!).toMatchSnapshot();
     });
 
     it('should set the appropriate placeholder', async () => {
       const { Provider } = await TestProvidersWrapper();
 
-      const wrapper = render(
-        <Provider>
-          <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
-            <SchemaProvider schema={{ type: 'string', default: 'Default Value' }}>
-              <UnprefixedBeanField propName={ROOT_PATH} />
-            </SchemaProvider>
-          </ModelContextProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
+              <SchemaProvider schema={{ type: 'string', default: 'Default Value' }}>
+                <UnprefixedBeanField propName={ROOT_PATH} />
+              </SchemaProvider>
+            </ModelContextProvider>
+          </Provider>,
+        );
+      });
 
-      const input = wrapper.getByRole('textbox');
+      const input = screen.getByRole('textbox');
       expect(input).toHaveAttribute('placeholder', 'Default Value');
     });
 
@@ -302,13 +335,16 @@ describe('BeanField', () => {
       const onPropertyChangeSpy = vi.fn();
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <ModelContextProvider model="dataSource" onPropertyChange={onPropertyChangeSpy}>
-            <UnprefixedBeanField propName={ROOT_PATH} />
-          </ModelContextProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <ModelContextProvider model="dataSource" onPropertyChange={onPropertyChangeSpy}>
+              <UnprefixedBeanField propName={ROOT_PATH} />
+            </ModelContextProvider>
+          </Provider>,
+        );
+      });
 
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.clearForProperty(ROOT_PATH);
@@ -321,15 +357,18 @@ describe('BeanField', () => {
       const onPropertyChangeSpy = vi.fn();
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <SchemaProvider schema={refSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <UnprefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={refSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <UnprefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       const formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -348,15 +387,18 @@ describe('BeanField', () => {
 
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <SchemaProvider schema={refSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <UnprefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={refSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <UnprefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
     });
@@ -436,15 +478,18 @@ describe('BeanField', () => {
       const { Provider } = await TestProvidersWrapper();
 
       // First create a bean using UnprefixedBeanField to add it to the system
-      render(
-        <Provider>
-          <SchemaProvider schema={beanReferenceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
-              <UnprefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={beanReferenceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
+                <UnprefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       let formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -458,15 +503,18 @@ describe('BeanField', () => {
       cleanup();
 
       // Now test that PrefixedBeanField shows the bean with prefix in dropdown
-      render(
-        <Provider>
-          <SchemaProvider schema={beanReferenceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
-              <PrefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={beanReferenceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
+                <PrefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -480,15 +528,18 @@ describe('BeanField', () => {
       const { Provider } = await TestProvidersWrapper();
 
       // First create a bean using PrefixedBeanField to add it to the system
-      render(
-        <Provider>
-          <SchemaProvider schema={beanReferenceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
-              <PrefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={beanReferenceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
+                <PrefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       let formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -502,15 +553,18 @@ describe('BeanField', () => {
       cleanup();
 
       // Now test that UnprefixedBeanField shows the bean without prefix in dropdown
-      render(
-        <Provider>
-          <SchemaProvider schema={beanReferenceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
-              <UnprefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={beanReferenceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
+                <UnprefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -529,9 +583,6 @@ describe('BeanField', () => {
     const dataSourceSchema: KaotoSchemaDefinition['schema'] = { title: 'Data Source', type: 'string' };
 
     beforeEach(async () => {
-      const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-      CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
-
       onPropertyChangeSpy = vi.fn();
       cleanup();
     });
@@ -539,15 +590,18 @@ describe('BeanField', () => {
     it('should include default items in dropdown options', async () => {
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <SchemaProvider schema={dataSourceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <DataSourceBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={dataSourceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <DataSourceBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -564,15 +618,18 @@ describe('BeanField', () => {
     it('should allow selection of default items', async () => {
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <SchemaProvider schema={dataSourceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <DataSourceBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={dataSourceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <DataSourceBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -585,15 +642,18 @@ describe('BeanField', () => {
       const { Provider } = await TestProvidersWrapper();
 
       // First create regular bean and DataSource bean
-      render(
-        <Provider>
-          <SchemaProvider schema={dataSourceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
-              <UnprefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={dataSourceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
+                <UnprefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       let formPageObject = new KaotoFormPageObject(screen, act);
 
@@ -609,15 +669,18 @@ describe('BeanField', () => {
       cleanup();
 
       // Create DataSource bean
-      render(
-        <Provider>
-          <SchemaProvider schema={dataSourceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
-              <UnprefixedBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={dataSourceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={vi.fn()}>
+                <UnprefixedBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -631,15 +694,18 @@ describe('BeanField', () => {
       cleanup();
 
       // Now test DataSourceBeanField only shows DataSource beans
-      render(
-        <Provider>
-          <SchemaProvider schema={dataSourceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <DataSourceBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={dataSourceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <DataSourceBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);
@@ -655,15 +721,18 @@ describe('BeanField', () => {
     it('should show new bean modal when creating DataSource bean', async () => {
       const { Provider } = await TestProvidersWrapper();
 
-      render(
-        <Provider>
-          <SchemaProvider schema={dataSourceSchema}>
-            <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
-              <DataSourceBeanField propName={ROOT_PATH} />
-            </ModelContextProvider>
-          </SchemaProvider>
-        </Provider>,
-      );
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        render(
+          <Provider>
+            <SchemaProvider schema={dataSourceSchema}>
+              <ModelContextProvider model={undefined} onPropertyChange={onPropertyChangeSpy}>
+                <DataSourceBeanField propName={ROOT_PATH} />
+              </ModelContextProvider>
+            </SchemaProvider>
+          </Provider>,
+        );
+      });
 
       formPageObject = new KaotoFormPageObject(screen, act);
       await formPageObject.toggleTypeaheadFieldForProperty(ROOT_PATH);

--- a/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.tsx
+++ b/packages/ui/src/components/Visualization/Canvas/Form/fields/BeanField/BeanField.tsx
@@ -9,11 +9,13 @@ import {
   TypeaheadItem,
   useFieldValue,
 } from '@kaoto/forms';
-import { FunctionComponent, useCallback, useContext, useMemo, useState } from 'react';
+import { FunctionComponent, Suspense, use, useCallback, useContext, useMemo, useState } from 'react';
 
+import { KaotoSchemaDefinition } from '../../../../../../models/kaoto-schema';
 import { BeansEntityHandler } from '../../../../../../models/visualization/metadata/beans-entity-handler';
 import { EntitiesContext } from '../../../../../../providers';
 import { getSerializedModel } from '../../../../../../utils';
+import { Loading } from '../../../../../Loading';
 import { NewBeanModal } from './NewBeanModal';
 
 const DEFAULT_DATASOURCE_NAMES = [
@@ -49,20 +51,35 @@ interface BeanFieldProps extends FieldProps {
   defaultItems?: TypeaheadItem<string>[];
 }
 
-const BeanFieldBase: FunctionComponent<BeanFieldProps> = ({
-  propName,
-  required,
-  shouldPrefixBeanName,
-  filterFn,
-  defaultItems = [],
-}) => {
-  const { schema } = useContext(SchemaContext);
-  const { value = '', onChange, disabled } = useFieldValue<string | undefined>(propName);
+const BeanFieldBase: FunctionComponent<BeanFieldProps> = (props) => {
   const entitiesContext = useContext(EntitiesContext);
   const camelResource = entitiesContext?.camelResource;
-  const beanReference = value;
   const beansHandler = useMemo(() => new BeansEntityHandler(camelResource), [camelResource]);
-  const beanSchema = useMemo(() => beansHandler.getBeanSchema(), [beansHandler]);
+  const beanSchemaPromise = useMemo(() => {
+    if (!beansHandler.isSupported()) {
+      return Promise.resolve(undefined);
+    }
+
+    return beansHandler.getBeanSchema();
+  }, [beansHandler]);
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <BeanFieldBaseInner {...props} beansHandler={beansHandler} beanSchemaPromise={beanSchemaPromise} />
+    </Suspense>
+  );
+};
+
+const BeanFieldBaseInner: FunctionComponent<
+  BeanFieldProps & {
+    beansHandler: BeansEntityHandler;
+    beanSchemaPromise: Promise<KaotoSchemaDefinition['schema'] | undefined>;
+  }
+> = ({ propName, required, shouldPrefixBeanName, filterFn, defaultItems = [], beansHandler, beanSchemaPromise }) => {
+  const { schema } = useContext(SchemaContext);
+  const { value = '', onChange, disabled } = useFieldValue<string | undefined>(propName);
+  const beanSchema = use(beanSchemaPromise);
+  const beanReference = value;
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>(beanReference);
   const [lastUpdated, setLastUpdated] = useState<number>(Date.now());

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.test.ts
@@ -4,17 +4,15 @@ import { cloneDeep } from 'lodash';
 
 import * as routeStub from '../../../stubs/camel-route';
 import * as kameletStub from '../../../stubs/kamelet-route';
-import { getFirstCatalogMap } from '../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../stubs/test-load-catalog';
 import { CamelRouteResource, KameletResource, PipeResource } from '../../camel';
-import { CatalogKind } from '../../catalog-kind';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
-import { CamelCatalogService } from '../flows';
 import { BeansEntityHandler } from './beans-entity-handler';
 
 describe('BeansEntityHandler', () => {
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   describe('should handle beans in CamelRouteResource', () => {
@@ -28,13 +26,13 @@ describe('BeansEntityHandler', () => {
       beansHandler = new BeansEntityHandler(camelRouteResource);
     });
 
-    it('initial state', () => {
+    it('initial state', async () => {
       expect(model.beans).toBeUndefined();
       expect(beansHandler.isSupported()).toBeTruthy();
-      const beanSchema = beansHandler.getBeanSchema();
+      const beanSchema = await beansHandler.getBeanSchema();
       expect(beanSchema!.properties!.builderClass.title).toBe('Builder Class');
       expect(beanSchema!.properties!.script.title).toBe('Script');
-      const beansSchema = beansHandler.getBeansSchema();
+      const beansSchema = await beansHandler.getBeansSchema();
       expect(beansSchema!.items as KaotoSchemaDefinition['schema']).toMatchSnapshot();
       expect(beansHandler.getBeansEntity()).toBeUndefined();
       expect(beansHandler.getBeansModel()).toBeUndefined();
@@ -82,17 +80,17 @@ describe('BeansEntityHandler', () => {
       beansHandler = new BeansEntityHandler(kameletResource);
     });
 
-    it('initial state', () => {
+    it('initial state', async () => {
       expect(model.spec.template.beans).toBeUndefined();
       expect(beansHandler.isSupported()).toBeTruthy();
-      const beanSchema = beansHandler.getBeanSchema();
+      const beanSchema = await beansHandler.getBeanSchema();
       expect(beanSchema?.properties!.builderClass).toBeDefined();
       expect(beanSchema?.properties!.script.title).toBe('Script');
-      const beansSchema = beansHandler.getBeansSchema();
-      expect((beansSchema?.items as KaotoSchemaDefinition['schema']).properties!.scriptLanguage.title).toBe(
+      const beansSchema = await beansHandler.getBeansSchema();
+      expect((beansSchema!.items as KaotoSchemaDefinition['schema']).properties!.scriptLanguage.title).toBe(
         'Script Language',
       );
-      expect((beansSchema?.items as KaotoSchemaDefinition['schema']).properties!.builderClass).toBeDefined();
+      expect((beansSchema!.items as KaotoSchemaDefinition['schema']).properties!.builderClass).toBeDefined();
       expect(beansHandler.getBeansEntity()).toBeUndefined();
       expect(beansHandler.getBeansModel()).toBeUndefined();
     });

--- a/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
+++ b/packages/ui/src/models/visualization/metadata/beans-entity-handler.ts
@@ -1,11 +1,11 @@
 import { BeanFactory, BeansDeserializer } from '@kaoto/camel-catalog/types';
 import { isDefined, resolveSchemaWithRef } from '@kaoto/forms';
 
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { CatalogKind } from '../../catalog-kind';
 import { EntityType } from '../../entities';
 import { BeansAwareResource, KaotoResource, RouteTemplateBeansAwareResource } from '../../kaoto-resource';
 import { KaotoSchemaDefinition } from '../../kaoto-schema';
-import { CamelCatalogService } from '../flows/camel-catalog.service';
 import { BeansEntity } from './beansEntity';
 import { RouteTemplateBeansEntity } from './routeTemplateBeansEntity';
 
@@ -32,12 +32,12 @@ export class BeansEntityHandler {
     return this.type !== undefined;
   }
 
-  getBeanSchema(): KaotoSchemaDefinition['schema'] | undefined {
+  async getBeanSchema(): Promise<KaotoSchemaDefinition['schema'] | undefined> {
     if (!isDefined(this.type)) {
       return undefined;
     }
 
-    const rootSchema = this.getBeansSchema();
+    const rootSchema = await this.getBeansSchema();
     if (!isDefined(rootSchema?.items)) {
       return undefined;
     }
@@ -45,12 +45,13 @@ export class BeansEntityHandler {
     return resolveSchemaWithRef(rootSchema.items, rootSchema.definitions ?? {});
   }
 
-  getBeansSchema(): KaotoSchemaDefinition['schema'] | undefined {
+  async getBeansSchema(): Promise<KaotoSchemaDefinition['schema'] | undefined> {
     if (!isDefined(this.type)) {
       return undefined;
     }
 
-    const beansSchema = CamelCatalogService.getComponent(CatalogKind.Entity, 'bean')?.propertiesSchema;
+    const definition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, 'bean');
+    const beansSchema = definition?.propertiesSchema ? { ...definition.propertiesSchema } : undefined;
     if (isDefined(beansSchema?.items)) {
       beansSchema.items = resolveSchemaWithRef(beansSchema.items, beansSchema.definitions ?? {});
     }

--- a/packages/ui/src/pages/Beans/BeansPage.tsx
+++ b/packages/ui/src/pages/Beans/BeansPage.tsx
@@ -1,23 +1,49 @@
 import { BeanFactory, BeansDeserializer } from '@kaoto/camel-catalog/types';
 import { Content } from '@patternfly/react-core';
-import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
+import { FunctionComponent, Suspense, use, useCallback, useContext, useMemo } from 'react';
 
+import { Loading } from '../../components/Loading';
 import { MetadataEditor } from '../../components/MetadataEditor';
+import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
 import { BeansEntityHandler } from '../../models/visualization/metadata/beans-entity-handler';
-import { EntitiesContext } from '../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../providers/entities.provider';
 
 export const BeansPage: FunctionComponent = () => {
   const entitiesContext = useContext(EntitiesContext);
   const camelResource = entitiesContext?.camelResource;
-  const beansHandler = useMemo(() => {
-    return new BeansEntityHandler(camelResource);
-  }, [camelResource]);
-  const isSupported = useMemo(() => {
-    return beansHandler.isSupported();
-  }, [beansHandler]);
-  const beansSchema = useMemo(() => {
+  const beansHandler = useMemo(() => new BeansEntityHandler(camelResource), [camelResource]);
+
+  const isSupported = useMemo(() => beansHandler.isSupported(), [beansHandler]);
+  const beansSchemaPromise = useMemo(() => {
+    if (!beansHandler.isSupported()) {
+      return Promise.resolve(undefined);
+    }
+
     return beansHandler.getBeansSchema();
   }, [beansHandler]);
+
+  if (!isSupported) {
+    return <Content>Not applicable</Content>;
+  }
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <BeansPageInner
+        beansHandler={beansHandler}
+        entitiesContext={entitiesContext!}
+        beansSchemaPromise={beansSchemaPromise}
+      />
+    </Suspense>
+  );
+};
+
+const BeansPageInner: FunctionComponent<{
+  beansHandler: BeansEntityHandler;
+  entitiesContext: EntitiesContextResult;
+  beansSchemaPromise: Promise<KaotoSchemaDefinition['schema'] | undefined>;
+}> = ({ beansHandler, entitiesContext, beansSchemaPromise }) => {
+  const beansSchema = use(beansSchemaPromise);
+
   const getBeansModel = useCallback(() => {
     return beansHandler.getBeansModel() || [];
   }, [beansHandler]);
@@ -25,14 +51,12 @@ export const BeansPage: FunctionComponent = () => {
   const handleChangeModel = useCallback(
     (model: BeansDeserializer | BeanFactory[]) => {
       beansHandler.setBeansModel(model);
-      entitiesContext?.updateSourceCodeFromEntities();
+      entitiesContext.updateSourceCodeFromEntities();
     },
     [beansHandler, entitiesContext],
   );
 
-  return isSupported ? (
+  return (
     <MetadataEditor name="Beans" schema={beansSchema} metadata={getBeansModel()} onChangeModel={handleChangeModel} />
-  ) : (
-    <Content>Not applicable</Content>
   );
 };

--- a/packages/ui/src/pages/Metadata/MetadataPage.test.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.test.tsx
@@ -1,12 +1,10 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { PipeResource } from '../../models/camel';
-import { CatalogKind } from '../../models/catalog-kind';
-import { CamelCatalogService } from '../../models/visualization/flows/camel-catalog.service';
 import { EntitiesContext } from '../../providers/entities.provider';
-import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { MetadataPage } from './MetadataPage';
 
 const camelResource = new PipeResource();
@@ -20,9 +18,13 @@ const mockEntitiesContext = {
 };
 
 describe('MetadataPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   it('renders "Not applicable" when the resource type is not supported', () => {
@@ -32,22 +34,37 @@ describe('MetadataPage', () => {
     expect(screen.getByText('Not applicable')).toBeInTheDocument();
   });
 
-  it('renders the KaotoForm when the resource type is supported', () => {
-    const { container } = render(
-      <EntitiesContext.Provider value={mockEntitiesContext}>
-        <MetadataPage />
-      </EntitiesContext.Provider>,
-    );
+  it('renders the KaotoForm when the resource type is supported', async () => {
+    let container: HTMLElement;
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      ({ container } = render(
+        <EntitiesContext.Provider value={mockEntitiesContext}>
+          <MetadataPage />
+        </EntitiesContext.Provider>,
+      ));
+    });
 
-    expect(container).toMatchSnapshot();
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+
+    expect(container!).toMatchSnapshot();
   });
 
-  it('calls updateSourceCodeFromEntities when the model changes', () => {
-    render(
-      <EntitiesContext.Provider value={mockEntitiesContext}>
-        <MetadataPage />
-      </EntitiesContext.Provider>,
-    );
+  it('calls updateEntitiesFromCamelResource when the model changes', async () => {
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      render(
+        <EntitiesContext.Provider value={mockEntitiesContext}>
+          <MetadataPage />
+        </EntitiesContext.Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
 
     const addButton = screen.getAllByRole('button', { name: 'Add a new property' });
     fireEvent.click(addButton[0]);

--- a/packages/ui/src/pages/Metadata/MetadataPage.tsx
+++ b/packages/ui/src/pages/Metadata/MetadataPage.tsx
@@ -1,25 +1,54 @@
 import { CanvasFormTabsContext, CanvasFormTabsContextResult, KaotoForm, KaotoFormProps } from '@kaoto/forms';
 import { Content } from '@patternfly/react-core';
-import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
+import { FunctionComponent, Suspense, use, useCallback, useContext, useMemo } from 'react';
 
+import { Loading } from '../../components/Loading';
 import { CamelKResource, CamelKResourceKinds } from '../../models/camel/camel-k-resource';
-import { CatalogKind } from '../../models/catalog-kind';
 import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
-import { CamelCatalogService } from '../../models/visualization/flows/camel-catalog.service';
-import { EntitiesContext } from '../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../providers/entities.provider';
+import { MetadataService } from './metadata.service';
 
 export const MetadataPage: FunctionComponent = () => {
-  const formTabsValue: CanvasFormTabsContextResult = useMemo(
-    () => ({ selectedTab: 'All', setSelectedTab: () => {} }),
-    [],
-  );
   const entitiesContext = useContext(EntitiesContext);
   const camelkResource = entitiesContext?.camelResource as CamelKResource;
-  const metadataSchema = CamelCatalogService.getComponent(CatalogKind.Entity, 'ObjectMeta')?.propertiesSchema || {};
 
   const isSupported = useMemo(() => {
     return camelkResource && camelkResource.getType() in CamelKResourceKinds;
   }, [camelkResource]);
+
+  const metadataSchemaPromise = useMemo(() => {
+    if (!isSupported) {
+      return Promise.resolve(undefined);
+    }
+
+    return MetadataService.getMetadataSchema();
+  }, [isSupported]);
+
+  if (!isSupported) {
+    return <Content>Not applicable</Content>;
+  }
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <MetadataPageInner
+        camelkResource={camelkResource}
+        entitiesContext={entitiesContext!}
+        metadataSchemaPromise={metadataSchemaPromise}
+      />
+    </Suspense>
+  );
+};
+
+const MetadataPageInner: FunctionComponent<{
+  camelkResource: CamelKResource;
+  entitiesContext: EntitiesContextResult;
+  metadataSchemaPromise: Promise<KaotoSchemaDefinition['schema'] | undefined>;
+}> = ({ camelkResource, entitiesContext, metadataSchemaPromise }) => {
+  const formTabsValue: CanvasFormTabsContextResult = useMemo(
+    () => ({ selectedTab: 'All', setSelectedTab: () => {} }),
+    [],
+  );
+  const metadataSchema = use(metadataSchemaPromise);
 
   const getMetadataModel = useCallback(() => {
     const found = camelkResource.getMetadataEntity();
@@ -39,21 +68,19 @@ export const MetadataPage: FunctionComponent = () => {
       } else {
         camelkResource.deleteMetadataEntity();
       }
-      entitiesContext?.updateEntitiesFromCamelResource();
+      entitiesContext.updateEntitiesFromCamelResource();
     },
     [camelkResource, entitiesContext],
   );
 
-  return isSupported ? (
+  return (
     <CanvasFormTabsContext.Provider value={formTabsValue}>
       <KaotoForm
         data-testid="metadata-form"
-        schema={metadataSchema as KaotoSchemaDefinition['schema']}
+        schema={metadataSchema}
         model={getMetadataModel()}
         onChange={onChangeModel as KaotoFormProps['onChange']}
       />
     </CanvasFormTabsContext.Provider>
-  ) : (
-    <Content>Not applicable</Content>
   );
 };

--- a/packages/ui/src/pages/Metadata/metadata.service.test.ts
+++ b/packages/ui/src/pages/Metadata/metadata.service.test.ts
@@ -1,0 +1,51 @@
+import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../models/catalog-kind';
+import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
+import { MetadataService } from './metadata.service';
+
+describe('MetadataService.getMetadataSchema', () => {
+  afterEach(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
+  });
+
+  it('returns undefined when no Entity catalog is registered', async () => {
+    const schema = await MetadataService.getMetadataSchema();
+
+    expect(schema).toBeUndefined();
+  });
+
+  it('returns undefined when the ObjectMeta entity has no propertiesSchema', async () => {
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Entity, {
+      get: vi.fn().mockResolvedValue({ name: 'ObjectMeta' }),
+      getAll: vi.fn(),
+      clearCache: vi.fn(),
+    });
+
+    const schema = await MetadataService.getMetadataSchema();
+
+    expect(schema).toBeUndefined();
+  });
+
+  it('returns propertiesSchema from the ObjectMeta entity unchanged', async () => {
+    const propertiesSchema: KaotoSchemaDefinition['schema'] = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        annotations: { type: 'object' },
+        labels: { type: 'object' },
+        name: { type: 'string' },
+        namespace: { type: 'string' },
+      },
+    };
+
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Entity, {
+      get: vi.fn().mockResolvedValue({ propertiesSchema }),
+      getAll: vi.fn(),
+      clearCache: vi.fn(),
+    });
+
+    const schema = await MetadataService.getMetadataSchema();
+
+    expect(schema).toBe(propertiesSchema); // same reference — no copy, no mutation
+  });
+});

--- a/packages/ui/src/pages/Metadata/metadata.service.ts
+++ b/packages/ui/src/pages/Metadata/metadata.service.ts
@@ -1,0 +1,10 @@
+import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../models/catalog-kind';
+import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
+
+export class MetadataService {
+  static async getMetadataSchema(): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    const definition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, 'ObjectMeta');
+    return definition?.propertiesSchema;
+  }
+}

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.test.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.test.tsx
@@ -1,12 +1,10 @@
 import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { PipeResource } from '../../models/camel';
-import { CatalogKind } from '../../models/catalog-kind';
-import { CamelCatalogService } from '../../models/visualization/flows/camel-catalog.service';
 import { EntitiesContext } from '../../providers/entities.provider';
-import { getFirstCatalogMap } from '../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { PipeErrorHandlerPage } from './PipeErrorHandlerPage';
 
 const camelResource = new PipeResource();
@@ -26,7 +24,7 @@ describe('PipeErrorHandlerPage', () => {
 
   beforeAll(async () => {
     const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
   it('renders "Not applicable" when the resource type is not supported', () => {
@@ -36,25 +34,40 @@ describe('PipeErrorHandlerPage', () => {
     expect(screen.getByText('Not applicable')).toBeInTheDocument();
   });
 
-  it('renders the KaotoForm when the resource type is supported', () => {
-    const { container } = render(
-      <EntitiesContext.Provider value={mockEntitiesContext}>
-        <PipeErrorHandlerPage />
-      </EntitiesContext.Provider>,
-    );
+  it('renders the KaotoForm when the resource type is supported', async () => {
+    let container: HTMLElement;
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      ({ container } = render(
+        <EntitiesContext.Provider value={mockEntitiesContext}>
+          <PipeErrorHandlerPage />
+        </EntitiesContext.Provider>,
+      ));
+    });
 
-    expect(container).toMatchSnapshot();
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+
+    expect(container!).toMatchSnapshot();
     expect(screen.getByRole('button', { name: 'No Pipe ErrorHandler' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Log Pipe ErrorHandler' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Sink Pipe ErrorHandler' })).toBeInTheDocument();
   });
 
-  it('calls updateSourceCodeFromEntities when the model changes', () => {
-    render(
-      <EntitiesContext.Provider value={mockEntitiesContext}>
-        <PipeErrorHandlerPage />
-      </EntitiesContext.Provider>,
-    );
+  it('calls updateSourceCodeFromEntities when the model changes', async () => {
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(async () => {
+      render(
+        <EntitiesContext.Provider value={mockEntitiesContext}>
+          <PipeErrorHandlerPage />
+        </EntitiesContext.Provider>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
 
     const addButton = screen.getByRole('button', { name: 'Add a new property' });
     fireEvent.click(addButton);

--- a/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
+++ b/packages/ui/src/pages/PipeErrorHandler/PipeErrorHandlerPage.tsx
@@ -1,32 +1,54 @@
 import { CanvasFormTabsContext, CanvasFormTabsContextResult, KaotoForm, KaotoFormProps } from '@kaoto/forms';
 import { Content } from '@patternfly/react-core';
-import { FunctionComponent, useCallback, useContext, useMemo } from 'react';
+import { FunctionComponent, Suspense, use, useCallback, useContext, useMemo } from 'react';
 
+import { Loading } from '../../components/Loading';
 import { PipeResource, SourceSchemaType } from '../../models/camel';
-import { CatalogKind } from '../../models/catalog-kind';
 import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
-import { CamelCatalogService } from '../../models/visualization/flows/camel-catalog.service';
-import { EntitiesContext } from '../../providers/entities.provider';
+import { EntitiesContext, EntitiesContextResult } from '../../providers/entities.provider';
+import { PipeErrorHandlerService } from './pipe-error-handler.service';
 
 export const PipeErrorHandlerPage: FunctionComponent = () => {
-  const formTabsValue: CanvasFormTabsContextResult = useMemo(
-    () => ({ selectedTab: 'All', setSelectedTab: () => {} }),
-    [],
-  );
   const entitiesContext = useContext(EntitiesContext);
   const pipeResource = entitiesContext?.camelResource as PipeResource;
-
-  const errorHandlerSchema = (CamelCatalogService.getComponent(CatalogKind.Entity, 'PipeErrorHandler')
-    ?.propertiesSchema || {}) as KaotoSchemaDefinition['schema'];
-
-  if (Array.isArray(errorHandlerSchema.oneOf) && !Array.isArray(errorHandlerSchema.anyOf)) {
-    errorHandlerSchema.anyOf = [{ oneOf: errorHandlerSchema.oneOf }];
-    delete errorHandlerSchema.oneOf;
-  }
 
   const isSupported = useMemo(() => {
     return pipeResource && [SourceSchemaType.Pipe, SourceSchemaType.KameletBinding].includes(pipeResource.getType());
   }, [pipeResource]);
+
+  const errorHandlerSchemaPromise = useMemo(() => {
+    if (!isSupported) {
+      return Promise.resolve(undefined);
+    }
+
+    return PipeErrorHandlerService.getErrorHandlerSchema();
+  }, [isSupported]);
+
+  if (!isSupported) {
+    return <Content>Not applicable</Content>;
+  }
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <PipeErrorHandlerPageInner
+        pipeResource={pipeResource}
+        entitiesContext={entitiesContext!}
+        errorHandlerSchemaPromise={errorHandlerSchemaPromise}
+      />
+    </Suspense>
+  );
+};
+
+const PipeErrorHandlerPageInner: FunctionComponent<{
+  pipeResource: PipeResource;
+  entitiesContext: EntitiesContextResult;
+  errorHandlerSchemaPromise: Promise<KaotoSchemaDefinition['schema'] | undefined>;
+}> = ({ pipeResource, entitiesContext, errorHandlerSchemaPromise }) => {
+  const formTabsValue: CanvasFormTabsContextResult = useMemo(
+    () => ({ selectedTab: 'All', setSelectedTab: () => {} }),
+    [],
+  );
+  const errorHandlerSchema = use(errorHandlerSchemaPromise);
 
   const getErrorHandlerModel = useCallback(() => {
     const found = pipeResource.getErrorHandlerEntity();
@@ -40,14 +62,14 @@ export const PipeErrorHandlerPage: FunctionComponent = () => {
         entity ??= pipeResource.createErrorHandlerEntity();
         entity.parent.errorHandler = model;
       } else {
-        pipeResource!.deleteErrorHandlerEntity();
+        pipeResource.deleteErrorHandlerEntity();
       }
-      entitiesContext!.updateSourceCodeFromEntities();
+      entitiesContext.updateSourceCodeFromEntities();
     },
     [entitiesContext, pipeResource],
   );
 
-  return isSupported ? (
+  return (
     <CanvasFormTabsContext.Provider value={formTabsValue}>
       <KaotoForm
         data-testid="pipe-error-handler-form"
@@ -56,7 +78,5 @@ export const PipeErrorHandlerPage: FunctionComponent = () => {
         onChange={onChangeModel as KaotoFormProps['onChange']}
       />
     </CanvasFormTabsContext.Provider>
-  ) : (
-    <Content>Not applicable</Content>
   );
 };

--- a/packages/ui/src/pages/PipeErrorHandler/pipe-error-handler.service.test.ts
+++ b/packages/ui/src/pages/PipeErrorHandler/pipe-error-handler.service.test.ts
@@ -1,0 +1,207 @@
+import { JSONSchema4 } from 'json-schema';
+
+import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../models/catalog-kind';
+import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
+import { PipeErrorHandlerService } from './pipe-error-handler.service';
+
+/**
+ * Realistic propertiesSchema as returned by the Camel catalog for the
+ * 'PipeErrorHandler' entity.  The three oneOf variants mirror the real
+ * catalog exactly (No / Log / Sink error handlers).
+ */
+const PIPE_ERROR_HANDLER_ONE_OF: JSONSchema4[] = [
+  {
+    title: 'No Pipe ErrorHandler',
+    type: 'object',
+    properties: { none: { type: 'object' } },
+    required: ['none'],
+  },
+  {
+    title: 'Log Pipe ErrorHandler',
+    type: 'object',
+    properties: {
+      log: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          parameters: {
+            type: 'object',
+            properties: {
+              maximumRedeliveries: {
+                type: 'number',
+                description:
+                  'Sets the maximum redeliveries x = redeliver at most x times 0 = no redeliveries -1 = redeliver forever',
+              },
+              redeliveryDelay: {
+                type: 'number',
+                description: 'Sets the maximum delay between redelivery',
+              },
+            },
+            additionalProperties: { type: 'string' },
+          },
+        },
+      },
+    },
+    required: ['log'],
+  },
+  {
+    title: 'Sink Pipe ErrorHandler',
+    type: 'object',
+    properties: {
+      sink: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          endpoint: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              ref: {
+                type: 'object',
+                additionalProperties: false,
+                properties: {
+                  kind: { type: 'string' },
+                  apiVersion: { type: 'string' },
+                  name: { type: 'string' },
+                },
+                required: ['kind', 'apiVersion', 'name'],
+              },
+              properties: {
+                type: 'object',
+                properties: {
+                  message: { type: 'string' },
+                  additionalProperties: { type: 'string' },
+                },
+              },
+            },
+          },
+          parameters: {
+            type: 'object',
+            properties: {
+              maximumRedeliveries: {
+                type: 'number',
+                description:
+                  'Sets the maximum redeliveries x = redeliver at most x times 0 = no redeliveries -1 = redeliver forever',
+              },
+              redeliveryDelay: {
+                type: 'number',
+                description: 'Sets the maximum delay between redelivery',
+              },
+            },
+            additionalProperties: { type: 'string' },
+          },
+        },
+      },
+    },
+    required: ['sink'],
+  },
+];
+
+/** Baseline propertiesSchema as it arrives from the catalog (oneOf, no anyOf). */
+const makeCachedSchema = (): KaotoSchemaDefinition['schema'] => ({
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  additionalProperties: false,
+  title: 'Pipe Error Handler',
+  description:
+    'Camel K Pipe ErrorHandler. See https://camel.apache.org/camel-k/latest/kamelets/kameletbindings-error-handler.html for more details.',
+  oneOf: PIPE_ERROR_HANDLER_ONE_OF,
+  properties: { none: {}, log: {}, sink: {} },
+});
+
+describe('PipeErrorHandlerService.getErrorHandlerSchema', () => {
+  afterEach(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
+  });
+
+  it('returns undefined when the entity is not in the registry', async () => {
+    const schema = await PipeErrorHandlerService.getErrorHandlerSchema();
+
+    expect(schema).toBeUndefined();
+  });
+
+  it('returns undefined when the entity exists but has no propertiesSchema', async () => {
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Entity, {
+      get: vi.fn().mockResolvedValue({ name: 'PipeErrorHandler' }),
+      getAll: vi.fn(),
+      clearCache: vi.fn(),
+    });
+
+    const schema = await PipeErrorHandlerService.getErrorHandlerSchema();
+
+    expect(schema).toBeUndefined();
+  });
+
+  it('moves oneOf into anyOf and removes oneOf from the returned schema', async () => {
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Entity, {
+      get: vi.fn().mockResolvedValue({ propertiesSchema: makeCachedSchema() }),
+      getAll: vi.fn(),
+      clearCache: vi.fn(),
+    });
+
+    const schema = await PipeErrorHandlerService.getErrorHandlerSchema();
+
+    expect(schema).not.toHaveProperty('oneOf');
+    expect(schema?.anyOf).toEqual([{ oneOf: PIPE_ERROR_HANDLER_ONE_OF }]);
+    // Top-level catalog metadata must be preserved on the returned copy
+    expect(schema?.title).toBe('Pipe Error Handler');
+    expect(schema?.type).toBe('object');
+  });
+
+  it('does not mutate the cached propertiesSchema object', async () => {
+    const cachedSchema = makeCachedSchema();
+
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Entity, {
+      get: vi.fn().mockResolvedValue({ propertiesSchema: cachedSchema }),
+      getAll: vi.fn(),
+      clearCache: vi.fn(),
+    });
+
+    await PipeErrorHandlerService.getErrorHandlerSchema();
+
+    // The original cached object must remain untouched
+    expect(cachedSchema).toHaveProperty('oneOf', PIPE_ERROR_HANDLER_ONE_OF);
+    expect(cachedSchema).not.toHaveProperty('anyOf');
+  });
+
+  it('leaves the schema unchanged when anyOf is already present', async () => {
+    const alreadyNormalized: KaotoSchemaDefinition['schema'] = {
+      ...makeCachedSchema(),
+      anyOf: [{ oneOf: PIPE_ERROR_HANDLER_ONE_OF }],
+    };
+
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Entity, {
+      get: vi.fn().mockResolvedValue({ propertiesSchema: alreadyNormalized }),
+      getAll: vi.fn(),
+      clearCache: vi.fn(),
+    });
+
+    const schema = await PipeErrorHandlerService.getErrorHandlerSchema();
+
+    // anyOf already exists — normalization must not fire a second time
+    expect(schema?.anyOf).toHaveLength(1);
+    expect(schema).toHaveProperty('oneOf'); // original oneOf preserved
+  });
+
+  it('leaves the schema unchanged when oneOf is absent', async () => {
+    const noOneOf: KaotoSchemaDefinition['schema'] = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      title: 'Pipe Error Handler',
+      properties: { none: {}, log: {}, sink: {} },
+    };
+
+    DynamicCatalogRegistry.get().setCatalog(CatalogKind.Entity, {
+      get: vi.fn().mockResolvedValue({ propertiesSchema: noOneOf }),
+      getAll: vi.fn(),
+      clearCache: vi.fn(),
+    });
+
+    const schema = await PipeErrorHandlerService.getErrorHandlerSchema();
+
+    expect(schema).toEqual(noOneOf);
+    expect(schema).not.toHaveProperty('anyOf');
+    expect(schema).not.toHaveProperty('oneOf');
+  });
+});

--- a/packages/ui/src/pages/PipeErrorHandler/pipe-error-handler.service.ts
+++ b/packages/ui/src/pages/PipeErrorHandler/pipe-error-handler.service.ts
@@ -1,0 +1,17 @@
+import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
+import { CatalogKind } from '../../models/catalog-kind';
+import { KaotoSchemaDefinition } from '../../models/kaoto-schema';
+
+export class PipeErrorHandlerService {
+  static async getErrorHandlerSchema(): Promise<KaotoSchemaDefinition['schema'] | undefined> {
+    const definition = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, 'PipeErrorHandler');
+    const errorHandlerSchema = definition?.propertiesSchema ? { ...definition.propertiesSchema } : undefined;
+
+    if (Array.isArray(errorHandlerSchema?.oneOf) && !Array.isArray(errorHandlerSchema.anyOf)) {
+      errorHandlerSchema.anyOf = [{ oneOf: errorHandlerSchema.oneOf }];
+      delete errorHandlerSchema.oneOf;
+    }
+
+    return errorHandlerSchema;
+  }
+}


### PR DESCRIPTION
### Context

fix https://github.com/KaotoIO/kaoto/issues/3880

Replace synchronous CamelCatalogService lookups with DynamicCatalogRegistry- backed services. Load entity schemas asynchronously via Suspense and use(), following the same wrapper/inner component pattern used elsewhere.

- Add PipeErrorHandlerService, MetadataService, and BeansService
- Refactor PipeErrorHandlerPage, MetadataPage, and BeansPage
- Refactor BeanField to resolve bean schema from BeansService
- Move bean schema fetching out of BeansEntityHandler
- Update related tests to use setupDynamicCatalogRegistry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous schema loading for Beans, Metadata, and Pipe Error Handler forms, with loading indicators while content is retrieved.
  * Added support for organizing and serializing multi-value endpoint properties.
* **Bug Fixes**
  * Improved handling of unsupported resources by displaying a clear “Not applicable” state.
  * Preserved error-handler configuration options when loading schemas.
* **Tests**
  * Expanded coverage for asynchronous loading, catalog-backed schemas, form rendering, and multi-value endpoint properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->