### PR TITLE
e2e(DataMapper): XPath Editor: Create e2e coverage

### DIFF
--- a/packages/ui-tests/cypress/e2e/datamapper/xpath-editor.cy.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/xpath-editor.cy.ts
@@ -1,0 +1,154 @@
+// Coverage: DataMapper XPath Editor — open/close, manual typing, DnD field, DnD function, operators, whitespace
+
+describe('Test for DataMapper : XPath Editor', () => {
+  beforeEach(() => {
+    cy.openHomePage();
+    cy.openDataMapper();
+    // Use ShipOrder → ShipOrder as a symmetric source/target so all fields are available
+    cy.attachSourceBodySchema('datamapper/xsd/ShipOrder.xsd');
+    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
+    // Import an existing XSLT mapping so fields already have XPath expressions to edit
+    cy.importMappings('datamapper/xslt/ShipOrderToShipOrder.xsl');
+  });
+
+  it('open XPath Editor via fx button and close it → modal opens and closes correctly', () => {
+    cy.openXPathEditor(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson']);
+
+    // Verify all major editor UI elements are present
+    cy.get('[data-testid="xpath-editor-modal"]').should('be.visible');
+    cy.get('[data-testid="xpath-editor"]').should('be.visible');
+    cy.get('[data-testid="xpath-editor-tab-field"]').should('be.visible');
+    cy.get('[data-testid="xpath-editor-tab-function"]').should('be.visible');
+    cy.get('[data-testid="close-xpath-editor-btn"]').should('be.visible');
+    cy.get('[data-testid="xpath-editor-hint"]').should('be.visible');
+
+    cy.closeXPathEditor();
+  });
+
+  it('type a field path manually → inline XPath input reflects the expression', () => {
+    cy.openXPathEditor(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson']);
+    cy.typeInXPathEditor('/ns0:ShipOrder/ns0:OrderPerson');
+    cy.closeXPathEditor();
+    // Verify the inline input reflects the edited expression
+    cy.verifyXPathEditorOutput(
+      ['document-doc-targetBody-Body', 'node-target-fx-OrderPerson'],
+      '/ns0:ShipOrder/ns0:OrderPerson',
+    );
+    // Verify the generated XSLT contains the edited expression
+    cy.exportMappings();
+    cy.getMonacoValue().then(({ sourceCode }) => {
+      expect(sourceCode).to.include('/ns0:ShipOrder/ns0:OrderPerson');
+    });
+    cy.closeExportMappingsModal();
+  });
+
+  it('type a function call manually → inline XPath input reflects the expression', () => {
+    cy.openXPathEditor(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson']);
+    cy.typeInXPathEditor('string-length(/ns0:ShipOrder/ns0:OrderPerson)');
+    cy.closeXPathEditor();
+    // Verify the inline input reflects the edited expression
+    cy.verifyXPathEditorOutput(
+      ['document-doc-targetBody-Body', 'node-target-fx-OrderPerson'],
+      'string-length(/ns0:ShipOrder/ns0:OrderPerson)',
+    );
+    // Verify the generated XSLT contains the edited expression
+    cy.exportMappings();
+    cy.getMonacoValue().then(({ sourceCode }) => {
+      expect(sourceCode).to.include('string-length(/ns0:ShipOrder/ns0:OrderPerson)');
+    });
+    cy.closeExportMappingsModal();
+  });
+
+  it('type arithmetic operators (+, -, *, /) → inline XPath input reflects the expression', () => {
+    cy.openXPathEditor(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson']);
+    cy.typeInXPathEditor('1 + 2 - 1 * 3 / 2');
+    cy.closeXPathEditor();
+    cy.verifyXPathEditorOutput(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson'], '1 + 2 - 1 * 3 / 2');
+  });
+
+  it('type space and Enter (newline) → expression is preserved after close', () => {
+    cy.openXPathEditor(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson']);
+    // Monaco keeps the raw multi-line value; the inline input will contain the full string.
+    cy.typeInXPathEditor('/ns0:ShipOrder/\nns0:OrderPerson');
+    cy.closeXPathEditor();
+    // Value is multi-line so check parts separately
+    cy.getDataMapperTargetNode(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson'])
+      .find('[data-testid="transformation-xpath-input"]')
+      .invoke('val')
+      .should('include', '/ns0:ShipOrder/')
+      .and('include', 'ns0:OrderPerson');
+  });
+
+  it(
+    'DnD a field from Field tab into editor → inline XPath input reflects the dropped field path',
+    { browser: '!firefox' },
+    () => {
+      cy.openXPathEditor(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson']);
+
+      // The Field tab is active by default — the SourcePanel is rendered inside it
+      cy.get('[data-testid="xpath-editor-tab-field"]').should('have.attr', 'aria-selected', 'true');
+
+      // Clear the existing expression so the drop is the sole contributor
+      cy.typeInXPathEditor('');
+
+      // Drag the OrderPerson source field from the read-only SourcePanel into the editor drop zone
+      cy.get('.xpath-editor .source-panel')
+        .find('[data-testid^="node-source-fx-OrderPerson"]')
+        .find('[id^="draggable-"]')
+        .first()
+        .invoke('attr', 'id')
+        .then((id) => cy.dragToXPathEditor(`[id="${id}"]`));
+
+      // Wait for the model to contain the dropped path before closing
+      cy.verifyXPathEditorModelIncludes('OrderPerson');
+
+      cy.closeXPathEditor();
+      // The dropped OrderPerson field resolves to an absolute path with the ns0 prefix
+      // that was already registered by the imported XSLT
+      cy.getDataMapperTargetNode(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson'])
+        .find('[data-testid="transformation-xpath-input"]')
+        .invoke('val')
+        .should('include', 'OrderPerson');
+    },
+  );
+
+  it(
+    'DnD a function from Function tab into editor → inline XPath input wraps expression with function',
+    { browser: '!firefox' },
+    () => {
+      cy.openXPathEditor(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson']);
+
+      // Switch to Function tab — the String group is expanded by default
+      cy.openXPathFunctionTab();
+
+      // Draggable ID pattern: draggable-${FunctionGroup}-${func.name} → draggable-String-concat
+      cy.dragToXPathEditor('[id="draggable-String-concat"]');
+
+      // Wait for the model to contain the dropped function before closing
+      cy.verifyXPathEditorModelIncludes('concat(');
+
+      cy.closeXPathEditor();
+      // Verify the expression now contains the function wrapper
+      cy.getDataMapperTargetNode(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson'])
+        .find('[data-testid="transformation-xpath-input"]')
+        .invoke('val')
+        .should('include', 'concat(');
+    },
+  );
+
+  it('type in Function tab search filter → list is filtered to matching functions', () => {
+    cy.openXPathEditor(['document-doc-targetBody-Body', 'node-target-fx-OrderPerson']);
+
+    cy.openXPathFunctionTab();
+
+    // Type in the search to narrow down to string-length
+    cy.get('[data-testid="functions-menu-search-input"]').find('input').type('String Length');
+
+    // Only string-length related items should be visible; verify by text presence
+    cy.contains('String Length').should('be.visible');
+    // Other unrelated functions should not be rendered
+    cy.contains('Concatenate').should('not.exist');
+
+    cy.closeXPathEditor();
+  });
+});

--- a/packages/ui-tests/cypress/support/cypress.d.ts
+++ b/packages/ui-tests/cypress/support/cypress.d.ts
@@ -187,13 +187,22 @@ declare global {
       ): Chainable<JQuery<Element>>;
       checkMappingLineSelected(selected: boolean): Chainable<JQuery<Element>>;
       countMappingLines(num: number): Chainable<JQuery<Element>>;
-      getDataMapperNode(nodePath: string[]): Chainable<JQuery<HTMLElement>>;
+      getDataMapperNode(nodePath: string[], panelClass?: string): Chainable<JQuery<HTMLElement>>;
+      getDataMapperSourceNode(nodePath: string[]): Chainable<JQuery<HTMLElement>>;
+      getDataMapperTargetNode(nodePath: string[]): Chainable<JQuery<HTMLElement>>;
       engageMapping(sourceNodePath: string[], targetNodePath: string[], testXPath: string): Chainable<JQuery<Element>>;
       engageForEachMapping(
         sourceNodePath: string[],
         targetNodePath: string[],
         testXPath: string,
       ): Chainable<JQuery<Element>>;
+      openXPathEditor(targetNodePath: string[]): Chainable<JQuery<Element>>;
+      typeInXPathEditor(text: string): Chainable<JQuery<Element>>;
+      dragToXPathEditor(draggableSelector: string): Chainable<void>;
+      verifyXPathEditorModelIncludes(expected: string): Chainable<void>;
+      verifyXPathEditorOutput(targetNodePath: string[], expectedValue: string): Chainable<void>;
+      closeXPathEditor(): Chainable<void>;
+      openXPathFunctionTab(): Chainable<void>;
     }
   }
 }

--- a/packages/ui-tests/cypress/support/next-commands/datamapper.ts
+++ b/packages/ui-tests/cypress/support/next-commands/datamapper.ts
@@ -198,3 +198,148 @@ Cypress.Commands.add(
     cy.engageMapping(sourceNodePath, updatedTargetNodePath, testXPath);
   },
 );
+
+/**
+ * Opens the XPath Editor modal for the given target node.
+ * Clicks the edit-xpath-button on the target field and waits for the modal and Monaco editor to appear.
+ */
+Cypress.Commands.add('openXPathEditor', (targetNodePath: string[]) => {
+  cy.getDataMapperTargetNode(targetNodePath).find('[data-testid^="edit-xpath-button-"]').first().click({ force: true });
+  cy.get('[data-testid="xpath-editor-modal"]').should('be.visible');
+  cy.get('[data-testid="xpath-editor"]').should('be.visible');
+});
+
+/**
+ * Sets text in the Monaco-based XPath editor inside the XPath Editor modal,
+ * replacing any existing content.
+ * The editor must already be open before calling this command.
+ */
+Cypress.Commands.add('typeInXPathEditor', (text: string) => {
+  cy.get('[data-testid="xpath-editor"]').should('be.visible');
+  // Clear the Monaco model via the API before typing.  Using the API is more
+  // reliable than {selectAll}{del} on the hidden textarea, which does not work
+  // consistently in Firefox because the synthesised selection is not established
+  // before the delete keystroke fires.
+  cy.window().then((win) => {
+    const container = Cypress.$('[data-testid="xpath-editor"]')[0];
+    const xpathEditor = win.monaco.editor.getEditors().find((e) => container.contains(e.getDomNode()!));
+    xpathEditor?.getModel()?.setValue('');
+  });
+
+  if (text) {
+    // Locate Monaco's hidden textarea — the real keyboard input sink.
+    // force: true is required because the textarea is visually hidden.
+    const textarea = '[data-testid="xpath-editor"] .monaco-editor textarea';
+    // Split on newlines so we can type each line with special-sequence parsing
+    // disabled (preventing Cypress from misinterpreting literal `{` / `}` in
+    // XPath), while still sending a real Enter keystroke between lines.
+    const lines = text.split('\n');
+    lines.forEach((line, index) => {
+      cy.get(textarea).type(line, { force: true, parseSpecialCharSequences: false });
+      if (index < lines.length - 1) {
+        cy.get(textarea).type('{enter}', { force: true });
+      }
+    });
+  }
+  // Confirm the model value was stored correctly by reading it back — avoids
+  // false failures caused by Monaco's tokenised DOM rendering (invisible spans,
+  // non-breaking spaces, etc.) that make contain.text unreliable.
+  cy.window().should((win) => {
+    const container = Cypress.$('[data-testid="xpath-editor"]')[0];
+    const xpathEditor = win.monaco.editor.getEditors().find((e) => container.contains(e.getDomNode()!));
+    const value = xpathEditor?.getModel()?.getValue();
+    expect(value).to.equal(text);
+  });
+});
+
+/**
+ * Drags an element (identified by `draggableSelector`) into the XPath Editor
+ * drop zone and releases it.
+ *
+ * The XPath Editor modal must already be open.
+ */
+Cypress.Commands.add('dragToXPathEditor', (draggableSelector: string) => {
+  const dataTransfer = new DataTransfer();
+
+  // Scope all queries to the modal to avoid matching duplicate nodes outside it.
+  const modal = () => cy.get('[data-testid="xpath-editor-modal"]');
+
+  // Initiate the drag on the source element
+  modal()
+    .find(draggableSelector)
+    .first()
+    .trigger('mouseenter', { dataTransfer })
+    .trigger('mouseover', { dataTransfer })
+    .trigger('mousedown', { dataTransfer });
+
+  // Move toward the drop zone so the DnD layer activates
+  modal().find('[id^="droppable-xpath-editor"]').trigger('mousemove', { dataTransfer });
+
+  // Verify the draggable side became active
+  modal().find(draggableSelector).first().should('have.attr', 'data-dnd-draggable');
+
+  // Hover over the drop zone to activate the droppable side
+  modal()
+    .find('[id^="droppable-xpath-editor"]')
+    .trigger('mouseenter', { dataTransfer })
+    .trigger('mouseover', { dataTransfer })
+    .trigger('mousemove', { dataTransfer });
+
+  // Verify the drop zone became active
+  modal().find('[id^="droppable-xpath-editor"]').should('have.attr', 'data-dnd-droppable');
+
+  // Release — complete the drop
+  modal().find('[id^="droppable-xpath-editor"]').trigger('mouseup', { dataTransfer, force: true });
+
+  // Wait for the drop handler to settle before returning. The DnD handler updates
+  // the Monaco model asynchronously; asserting the editor is still visible ensures
+  // React has flushed the state update and the modal is stable before the caller
+  // attempts to close it.
+  modal().find('[data-testid="xpath-editor"]').should('be.visible');
+});
+
+/**
+ * Retries until the Monaco model inside the open XPath Editor contains the
+ * expected substring. Use this after `dragToXPathEditor` to wait for the
+ * asynchronous DnD handler to finish writing the dropped value into the model
+ * before closing the editor.
+ */
+Cypress.Commands.add('verifyXPathEditorModelIncludes', (expected: string) => {
+  cy.window().should((win) => {
+    const container = Cypress.$('[data-testid="xpath-editor"]')[0];
+    const xpathEditor = win.monaco.editor.getEditors().find((e) => container.contains(e.getDomNode()!));
+    const value = xpathEditor?.getModel()?.getValue() ?? '';
+    expect(value).to.include(expected);
+  });
+});
+
+/**
+ * Asserts that the inline transformation-xpath-input for the given target node
+ * has exactly the expected value. Call this before or after closing the editor.
+ */
+Cypress.Commands.add('verifyXPathEditorOutput', (targetNodePath: string[], expectedValue: string) => {
+  cy.getDataMapperTargetNode(targetNodePath)
+    .find('[data-testid="transformation-xpath-input"]')
+    .should('have.value', expectedValue);
+});
+
+/**
+ * Closes the XPath Editor modal and waits for it to disappear.
+ * Use `verifyXPathEditorOutput` separately to assert the resulting expression.
+ */
+Cypress.Commands.add('closeXPathEditor', () => {
+  cy.get('[data-testid="close-xpath-editor-btn"]').click();
+  cy.get('[data-testid="xpath-editor-modal"]').should('not.exist');
+});
+
+/**
+ * Switches the XPath Editor sidebar to the Function tab and waits for
+ * both the search input and the String function group to be visible —
+ * the minimum readiness signal before interacting with the function list.
+ * The editor modal must already be open before calling this command.
+ */
+Cypress.Commands.add('openXPathFunctionTab', () => {
+  cy.get('[data-testid="xpath-editor-tab-function"]').click();
+  cy.get('[data-testid="functions-menu-search-input"]').should('be.visible');
+  cy.get('[data-testid="function-group-toggle-String"]').should('be.visible');
+});

--- a/packages/ui/src/components/XPath/XPathEditor.tsx
+++ b/packages/ui/src/components/XPath/XPathEditor.tsx
@@ -7,6 +7,12 @@ import { IExpressionHolder } from '../../models/datamapper';
 import { XPathService } from '../../services/xpath/xpath.service';
 import { xpathEditorConstrufctionOption, xpathEditorTheme } from './monaco-options';
 
+// Expose monaco on window so Cypress helpers can reach editor instances through
+// the standard win.monaco.editor.getEditors() API
+if (typeof window !== 'undefined' && 'Cypress' in window) {
+  (globalThis as typeof globalThis & { monaco: typeof monaco }).monaco = monaco;
+}
+
 type XPathEditorProps = {
   mapping: IExpressionHolder;
   onChange: (expression: string | undefined) => void;
@@ -14,7 +20,7 @@ type XPathEditorProps = {
 
 export const XPathEditor: FunctionComponent<XPathEditorProps> = ({ mapping, onChange }) => {
   const [editor, setEditor] = useState<monaco.editor.IStandaloneCodeEditor | null>(null);
-  const monacoEl = useRef(null);
+  const monacoEl = useRef<HTMLDivElement>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
   const xpathLanguage = XPathService.getMonacoXPathLanguageMetadata();


### PR DESCRIPTION
fixes: https://github.com/KaotoIO/kaoto/issues/3602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for the DataMapper XPath Editor, including:
    * Opening and closing the editor
    * Entering XPath expressions, functions, operators, and multiline content
    * Dragging fields and functions into the editor
    * Searching available functions
    * Verifying generated XPath output and mappings across supported browsers
  * Added coverage for editor interactions and function selection to help ensure reliable XPath editing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->