### PR TITLE
Remove dead KameletSchemaService.getKameletCatalogEntry method

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.test.ts
@@ -1,31 +1,6 @@
-import catalogLibrary from '@kaoto/camel-catalog/index.json';
-import { CatalogLibrary } from '@kaoto/camel-catalog/types';
-
-import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
-import { CatalogKind } from '../../../catalog-kind';
-import { CamelCatalogService } from '../camel-catalog.service';
 import { KameletSchemaService } from './kamelet-schema.service';
 
 describe('KameletSchemaService', () => {
-  let kameletCatalogMap: Record<string, unknown>;
-
-  beforeEach(async () => {
-    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    kameletCatalogMap = catalogsMap.kameletsCatalogMap;
-
-    CamelCatalogService.setCatalogKey(CatalogKind.Kamelet, {
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
-      'log-action': (kameletCatalogMap as any)['log-action'],
-      /* eslint-disable  @typescript-eslint/no-explicit-any */
-      'xj-template-action': (kameletCatalogMap as any)['xj-template-action'],
-    });
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
-    CamelCatalogService.clearCatalogs();
-  });
-
   describe('getNodeLabel', () => {
     it.each([
       ['source', 'source', undefined],

--- a/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/kamelet-schema.service.ts
@@ -1,15 +1,6 @@
-import { IKameletDefinition } from '../../../camel/kamelets-catalog';
-import { CatalogKind } from '../../../catalog-kind';
-import { KameletBindingStep, PipeStep } from '../../../entities';
-import { CamelCatalogService } from '../camel-catalog.service';
+import { PipeStep } from '../../../entities';
 
 export class KameletSchemaService {
-  static getKameletCatalogEntry(step?: KameletBindingStep): IKameletDefinition | undefined {
-    const stepName = step?.ref?.name;
-
-    return CamelCatalogService.getComponent(CatalogKind.Kamelet, stepName);
-  }
-
   static getNodeLabel(step: PipeStep, path: string): string {
     const kameletName = step?.ref?.name;
 


### PR DESCRIPTION
## Summary

`KameletSchemaService.getKameletCatalogEntry()` had no callers anywhere in the codebase. Rather than migrating dead code to the async `DynamicCatalogRegistry`, this PR removes the method entirely and cleans up the now-unnecessary catalog setup scaffolding from its test file.

## Changes

- Removed `getKameletCatalogEntry()` from `KameletSchemaService`
- Removed the three imports that were exclusively used by it (`IKameletDefinition`, `CatalogKind`, `KameletBindingStep`, `CamelCatalogService`)
- Stripped the `beforeEach`/`afterEach` catalog population from `kamelet-schema.service.test.ts` — it was scaffolding for the deleted method only; the `getNodeLabel` tests are unaffected

## Verification

- All 4 tests in `kamelet-schema.service.test.ts` pass
- `yarn workspace @kaoto/kaoto build` (typecheck + build) passes clean

Closes https://github.com/KaotoIO/kaoto/issues/3886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed Kamelet catalog lookup support from the visualization flow schema service.
  - Removed the associated catalog setup and teardown from automated tests.
  - Existing node-label behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->