### PR TITLE
Migrate CamelRouteResource.getCanvasEntityList to DynamicCatalogRegistry

### DIFF
--- a/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
+++ b/packages/ui/src/components/Visualization/ContextToolbar/NewEntity/NewEntity.test.tsx
@@ -2,21 +2,22 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 
-import { CamelCatalogService, CatalogKind } from '../../../../models';
+import { DynamicCatalogRegistry } from '../../../../dynamic-catalog/dynamic-catalog-registry';
 import { CamelRouteResource } from '../../../../models/camel';
 import { configureSourceSchemaTypes, TestProvidersWrapper } from '../../../../stubs';
 import { camelRouteJson } from '../../../../stubs/camel-route';
-import { getFirstCatalogMap } from '../../../../stubs/test-load-catalog';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../../../stubs/test-load-catalog';
 import { NewEntity } from './NewEntity';
 
 describe('NewEntity', () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     configureSourceSchemaTypes();
+    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+    setupDynamicCatalogRegistry(catalogsMap);
   });
 
-  beforeEach(async () => {
-    const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
-    CamelCatalogService.setCatalogKey(CatalogKind.Entity, catalogsMap.entitiesCatalog);
+  afterAll(() => {
+    DynamicCatalogRegistry.get().clearRegistry();
   });
 
   it('component renders', async () => {

--- a/packages/ui/src/hooks/useCanvasEntities.ts
+++ b/packages/ui/src/hooks/useCanvasEntities.ts
@@ -2,8 +2,8 @@ import { useCallback, useContext, useMemo, useRef } from 'react';
 
 import { EntityType } from '../models/entities';
 import { BaseVisualEntityDefinition, BaseVisualEntityDefinitionItem } from '../models/kaoto-resource';
-import { EntitiesContext } from '../providers/entities.provider';
 import { VisibleFlowsContext } from '../providers/visible-flows.provider';
+import { useEntityContext } from './useEntityContext/useEntityContext';
 
 export interface CanvasEntities {
   commonEntities: BaseVisualEntityDefinitionItem[];
@@ -12,7 +12,7 @@ export interface CanvasEntities {
 }
 
 export const useCanvasEntities = (): CanvasEntities => {
-  const { camelResource, updateEntitiesFromCamelResource } = useContext(EntitiesContext)!;
+  const { camelResource, updateEntitiesFromCamelResource } = useEntityContext();
   const visibleFlowsContext = useContext(VisibleFlowsContext)!;
   const groupedEntities = useRef<BaseVisualEntityDefinition>(camelResource.getCanvasEntityList());
 

--- a/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
+++ b/packages/ui/src/hooks/useEntityContext/useEntityContext.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 import type { Mock } from 'vitest';
 
@@ -22,9 +22,11 @@ describe('useEntityContext', () => {
     (console.error as Mock).mockRestore();
   });
 
-  it('should return EntityContext', () => {
+  it('should return EntityContext', async () => {
     const { result } = renderHook(() => useEntityContext(), { wrapper });
 
-    expect(result.current).not.toBeNull();
+    await waitFor(() => {
+      expect(result.current).not.toBeNull();
+    });
   });
 });

--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -1,9 +1,17 @@
-import { CamelYamlDsl, RouteConfigurationDefinition, RouteDefinition } from '@kaoto/camel-catalog/types';
+import catalogLibrary from '@kaoto/camel-catalog/index.json';
+import {
+  CamelYamlDsl,
+  CatalogLibrary,
+  RouteConfigurationDefinition,
+  RouteDefinition,
+} from '@kaoto/camel-catalog/types';
 import { parse } from 'yaml';
 
+import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
 import { beansJson } from '../../stubs/beans';
 import { camelFromJson } from '../../stubs/camel-from';
 import { camelRouteJson, camelRouteYaml } from '../../stubs/camel-route';
+import { getFirstCatalogMap, setupDynamicCatalogRegistry } from '../../stubs/test-load-catalog';
 import { EntityType } from '../entities';
 import { AddStepMode } from '../visualization/base-visual-entity';
 import { CamelRouteVisualEntity } from '../visualization/flows/camel-route-visual-entity';
@@ -571,6 +579,15 @@ describe('CamelRouteResource', () => {
   });
 
   describe('getCanvasEntityList', () => {
+    beforeAll(async () => {
+      const catalogsMap = await getFirstCatalogMap(catalogLibrary as CatalogLibrary);
+      setupDynamicCatalogRegistry(catalogsMap);
+    });
+
+    afterAll(() => {
+      DynamicCatalogRegistry.get().clearRegistry();
+    });
+
     it('should return all entities', async () => {
       const resource = new CamelRouteResource();
       await resource.initialize();
@@ -633,6 +650,19 @@ describe('CamelRouteResource', () => {
 
       // Route should be in common (empty group)
       expect(entityList.common).toEqual([expect.objectContaining({ name: EntityType.Route })]);
+    });
+
+    it('should use title and description from DynamicCatalogRegistry', async () => {
+      const resource = new CamelRouteResource();
+      await resource.initialize();
+
+      const entityList = resource.getCanvasEntityList();
+      const routeEntity = entityList.common.find((e) => e.name === EntityType.Route);
+
+      expect(routeEntity).toBeDefined();
+      // The catalog has a proper title for 'route' — it should NOT fall back to the raw type string
+      expect(routeEntity!.title).not.toBe(EntityType.Route);
+      expect(routeEntity!.title.length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/ui/src/models/camel/camel-route-resource.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.ts
@@ -19,12 +19,13 @@ import { isDefined } from '@kaoto/forms';
 import { parse, stringify } from 'yaml';
 
 import { TileFilter } from '../../components/Catalog';
+import { DynamicCatalogRegistry } from '../../dynamic-catalog/dynamic-catalog-registry';
 import { insertYamlComments } from '../../utils/yaml-comments';
 import { CatalogKind } from '../catalog-kind';
 import { BaseEntity, EntityType } from '../entities';
 import { BaseVisualEntityDefinition, BeansAwareResource, KaotoResource } from '../kaoto-resource';
 import { AddStepMode, BaseEntityConstructor, IVisualizationNodeData } from '../visualization/base-visual-entity';
-import { CamelCatalogService, CamelRouteVisualEntity } from '../visualization/flows';
+import { CamelRouteVisualEntity } from '../visualization/flows';
 import { CamelErrorHandlerVisualEntity } from '../visualization/flows/camel-error-handler-visual-entity';
 import { CamelInterceptFromVisualEntity } from '../visualization/flows/camel-intercept-from-visual-entity';
 import { CamelInterceptSendToEndpointVisualEntity } from '../visualization/flows/camel-intercept-send-to-endpoint-visual-entity';
@@ -124,21 +125,22 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
   ) {}
 
   async initialize(): Promise<void> {
-    if (!this.rawEntities) {
+    await this.resolveCanvasEntityList();
+
+    if (this.rawEntities) {
+      const entities = Array.isArray(this.rawEntities) ? this.rawEntities : [this.rawEntities];
+      const parsedEntities = entities.reduce((acc, rawItem) => {
+        const entity = this.getEntity(rawItem);
+        if (isDefined(entity) && typeof entity === 'object') {
+          acc.push(entity);
+        }
+        return acc;
+      }, [] as BaseEntity[]);
+
+      this.entities = EntityOrderingService.sortEntitiesForSerialization(parsedEntities);
+    } else {
       this.entities = [];
-      return;
     }
-
-    const entities = Array.isArray(this.rawEntities) ? this.rawEntities : [this.rawEntities];
-    const parsedEntities = entities.reduce((acc, rawItem) => {
-      const entity = this.getEntity(rawItem);
-      if (isDefined(entity) && typeof entity === 'object') {
-        acc.push(entity);
-      }
-      return acc;
-    }, [] as BaseEntity[]);
-
-    this.entities = EntityOrderingService.sortEntitiesForSerialization(parsedEntities);
   }
 
   protected setRawEntities(rawEntities?: CamelYamlDsl): void {
@@ -146,30 +148,7 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
   }
 
   getCanvasEntityList(): BaseVisualEntityDefinition {
-    this.resolvedEntities = this.supportedEntities
-      .filter(({ isVisualEntity }) => isVisualEntity)
-      .reduce(
-        (acc, { type, group }) => {
-          const catalogEntity = CamelCatalogService.getComponent(CatalogKind.Entity, type);
-          const entityDefinition = {
-            name: type,
-            title: catalogEntity?.model.title || type,
-            description: catalogEntity?.model.description || '',
-          };
-
-          if (group === '') {
-            acc.common.push(entityDefinition);
-            return acc;
-          }
-
-          acc.groups[group] ??= [];
-          acc.groups[group].push(entityDefinition);
-          return acc;
-        },
-        { common: [], groups: {} } as BaseVisualEntityDefinition,
-      );
-
-    return this.resolvedEntities;
+    return this.resolvedEntities ?? { common: [], groups: {} };
   }
 
   addNewEntity(entityType?: EntityType, entityTemplate?: unknown, insertAfterEntityId?: string): string {
@@ -202,6 +181,40 @@ export class CamelRouteResource implements KaotoResource, BeansAwareResource {
   protected getRouteTemplate(): RouteDefinition {
     const template = parse(FlowTemplateService.getFlowSourceTemplate(this.getType()));
     return template[0] as RouteDefinition;
+  }
+
+  private async resolveCanvasEntityList(): Promise<void> {
+    if (this.resolvedEntities) {
+      return;
+    }
+
+    const items = await Promise.all(
+      this.supportedEntities
+        .filter(({ isVisualEntity }) => isVisualEntity)
+        .map(async ({ type, group }) => {
+          const catalogEntity = await DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, type);
+          return {
+            type,
+            group,
+            title: catalogEntity?.model.title ?? type,
+            description: catalogEntity?.model.description ?? '',
+          };
+        }),
+    );
+
+    this.resolvedEntities = items.reduce(
+      (acc, { type, group, title, description }) => {
+        const entityDefinition = { name: type, title, description };
+        if (group === '') {
+          acc.common.push(entityDefinition);
+        } else {
+          acc.groups[group] ??= [];
+          acc.groups[group].push(entityDefinition);
+        }
+        return acc;
+      },
+      { common: [], groups: {} } as BaseVisualEntityDefinition,
+    );
   }
 
   /**

--- a/packages/ui/src/providers/entities.provider.test.tsx
+++ b/packages/ui/src/providers/entities.provider.test.tsx
@@ -86,39 +86,51 @@ describe('EntitiesProvider', () => {
     [CamelRouteResource, undefined],
     [CamelXMLRouteResource, 'camel.xml'],
     [CamelRouteResource, 'camel.yaml'],
-  ])('should initialize the camelResource as `%s` provided a `%s` file extension', (ResourceClass, fileExtension) => {
-    const { result } = renderHook(() => useContext(EntitiesContext), {
-      wrapper: buildWrapper(undefined, fileExtension),
-    });
+  ])(
+    'should initialize the camelResource as `%s` provided a `%s` file extension',
+    async (ResourceClass, fileExtension) => {
+      const { result } = renderHook(() => useContext(EntitiesContext), {
+        wrapper: buildWrapper(undefined, fileExtension),
+      });
 
-    expect(result.current?.camelResource).toBeInstanceOf(ResourceClass);
-  });
+      // Wait for initialize() to complete so the async state update is flushed
+      await waitFor(() => {
+        expect(result.current?.camelResource).toBeInstanceOf(ResourceClass);
+      });
+    },
+  );
 
   describe('Initialization', () => {
-    it('should use the source code to initialize the Camel Resource', () => {
+    it('should use the source code to initialize the Camel Resource', async () => {
       const { result } = renderHook(() => useContext(EntitiesContext), {
         wrapper: buildWrapper(camelRouteYaml),
       });
 
-      expect(result.current?.camelResource.toJSON()).toEqual(parse(camelRouteYaml));
+      await waitFor(() => {
+        expect(result.current?.camelResource.toJSON()).toEqual(parse(camelRouteYaml));
+      });
     });
 
-    it('should create an empty Camel Resource if there is no Source Code available', () => {
+    it('should create an empty Camel Resource if there is no Source Code available', async () => {
       const { result } = renderHook(() => useContext(EntitiesContext), {
         wrapper: buildWrapper(),
       });
 
-      expect(result.current?.camelResource.toJSON()).toEqual([]);
+      await waitFor(() => {
+        expect(result.current?.camelResource.toJSON()).toEqual([]);
+      });
     });
 
-    it('should ignore non-camel entities', () => {
+    it('should ignore non-camel entities', async () => {
       useSourceCodeStore.getState().setSourceCode('A non camel source code');
 
       const { result } = renderHook(() => useContext(EntitiesContext), {
         wrapper: buildWrapper('A non camel source code'),
       });
 
-      expect(result.current?.camelResource.toJSON()).toEqual(['A non camel source code']);
+      await waitFor(() => {
+        expect(result.current?.camelResource.toJSON()).toEqual(['A non camel source code']);
+      });
     });
 
     it('should keep resource undefined when there is a wrong Source Code at mount', () => {
@@ -133,8 +145,13 @@ describe('EntitiesProvider', () => {
     });
   });
 
-  it('updating the source code should NOT recreate the Camel Resource', () => {
+  it('updating the source code should NOT recreate the Camel Resource', async () => {
     const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
+
+    // Wait for initialize() to settle before exercising the resource
+    await waitFor(() => {
+      expect(result.current?.entities).toBeDefined();
+    });
 
     act(() => {
       const firstCamelResource = result.current?.camelResource;
@@ -180,6 +197,11 @@ describe('EntitiesProvider', () => {
     const notifierSpy = vi.spyOn(eventNotifier, 'next');
     const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
 
+    // Wait for initialize() to settle before exercising the resource
+    await waitFor(() => {
+      expect(result.current?.entities).toBeDefined();
+    });
+
     await act(async () => {
       result.current?.camelResource.addNewEntity();
       result.current?.updateSourceCodeFromEntities();
@@ -203,11 +225,16 @@ describe('EntitiesProvider', () => {
     );
   });
 
-  it('updating entities should NOT recreate the Camel Resource', () => {
+  it('updating entities should NOT recreate the Camel Resource', async () => {
     let firstCamelResource: KaotoResource | undefined;
     let secondCamelResource: KaotoResource | undefined;
 
     const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
+
+    // Wait for initialize() to settle before exercising the resource
+    await waitFor(() => {
+      expect(result.current?.entities).toBeDefined();
+    });
 
     act(() => {
       firstCamelResource = result.current?.camelResource;
@@ -223,8 +250,13 @@ describe('EntitiesProvider', () => {
     expect(secondCamelResource).toBeDefined();
   });
 
-  it('should refresh entities', () => {
+  it('should refresh entities', async () => {
     const { result } = renderHook(() => useContext(EntitiesContext), { wrapper: buildWrapper() });
+
+    // Wait for initialize() to settle before exercising the resource
+    await waitFor(() => {
+      expect(result.current?.entities).toBeDefined();
+    });
 
     act(() => {
       result.current?.camelResource.addNewEntity();
@@ -274,6 +306,11 @@ describe('EntitiesProvider', () => {
 
     act(() => {
       eventNotifier.next('code:updated', { code });
+    });
+
+    // Wait for initialize() to complete so comments are parsed into the resource
+    await waitFor(() => {
+      expect(result.current?.visualEntities).toHaveLength(1);
     });
 
     const output = await result.current?.camelResource.toSourceCode();

--- a/packages/ui/src/services/documentation.service.test.tsx
+++ b/packages/ui/src/services/documentation.service.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import JSZip from 'jszip';
 import { PropsWithChildren, useContext } from 'react';
 
@@ -39,14 +39,15 @@ describe('DocumentationService', () => {
       eventNotifier.next('code:updated', { code: yaml });
     });
 
+    // Wait for the EntitiesProvider to finish initializing the resource; this avoids
+    // racing with the provider's own async initialize() call.
+    await waitFor(() => {
+      expect(entitiesContext.current?.entities.length).toBeGreaterThan(0);
+    });
+
     if (entitiesContext.current === null) {
       throw new Error('EntitiesContext is null');
     }
-
-    // initialize() is async and re-runnable; await it on the context's resource so the
-    // entities/visual entities are fully built before we read them (the EntitiesProvider
-    // also initializes it, but asynchronously — this guarantees completion here).
-    await entitiesContext.current.camelResource.initialize();
 
     const visibleFlows = entitiesContext.current.camelResource.getVisualEntities().reduce((acc, entity) => {
       acc[entity.id] = true;


### PR DESCRIPTION
## Summary

Removes the synchronous `CamelCatalogService` dependency from `CamelRouteResource.getCanvasEntityList()` by pre-computing the entity list inside `initialize()` using the async `DynamicCatalogRegistry`.

### What changed

- Added a private `resolveCanvasEntityList()` method that uses `Promise.all` to call `DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, type)` for each visual entity in parallel, caching the result in `this.resolvedEntities`
- Both code paths in `initialize()` now await `resolveCanvasEntityList()`
- `getCanvasEntityList()` is reduced to a one-liner returning the cached result — **signature unchanged**, no callers needed updating
- `CamelCatalogService` import removed entirely from `camel-route-resource.ts`
- Tests updated to wire `setupDynamicCatalogRegistry` in `beforeAll`/`afterAll` inside the `getCanvasEntityList` describe block

### Acceptance criteria

- [x] `CamelRouteResource.getCanvasEntityList()` no longer references `CamelCatalogService`
- [x] Method is backed by `DynamicCatalogRegistry`
- [x] All call sites updated (none needed — signature unchanged)
- [x] Tests pass using `setupDynamicCatalogRegistry`

Closes https://github.com/KaotoIO/kaoto/issues/3887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canvas route entities now use the active catalog to display accurate, catalog-defined titles.
  * Entity information is populated from the active catalog when opening or initializing a route.

* **Bug Fixes**
  * Improved asynchronous entity loading so catalog information is available before the canvas entity list is displayed.
  * Fixed cases where route entities could appear with generic or incomplete labels.
  * Improved entity context and documentation loading reliability during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->