### PR TITLE
Migrate Citrus CamelCatalogService usages to DynamicCatalogRegistry (partial)

### DIFF
--- a/packages/ui/src/models/camel/camel-route-resource.test.ts
+++ b/packages/ui/src/models/camel/camel-route-resource.test.ts
@@ -664,6 +664,19 @@ describe('CamelRouteResource', () => {
       expect(routeEntity!.title).not.toBe(EntityType.Route);
       expect(routeEntity!.title.length).toBeGreaterThan(0);
     });
+
+    it('should resolve the entity list only once across multiple initialize() calls', async () => {
+      const resource = new CamelRouteResource();
+      await resource.initialize();
+      const firstList = resource.getCanvasEntityList();
+
+      // resolveCanvasEntityList() has a guard: if resolvedEntities is already set it returns early.
+      // A second initialize() must return the same object reference, not a newly built one.
+      await resource.initialize();
+      const secondList = resource.getCanvasEntityList();
+
+      expect(secondList).toBe(firstList);
+    });
   });
 
   describe('isVisualEntity classification', () => {

--- a/packages/ui/src/models/citrus/citrus-test-resource.test.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.test.ts
@@ -179,18 +179,20 @@ describe('CitrusTestResource', () => {
       expect(firstCall).toStrictEqual(secondCall);
     });
 
-    it('should include entity titles and descriptions from catalog', async () => {
+    it('should include entity name, title, and description', async () => {
       const resource = new CitrusTestResource(citrusTestJson);
       await resource.initialize();
 
       const entityList = resource.getCanvasEntityList();
 
-      // Check that entities have proper structure with name, title, and description
+      // The 'test' key does not exist in any Citrus catalog so title falls back to the entity type name
       const testEntity = entityList.common[0];
       expect(testEntity).toHaveProperty('name');
       expect(testEntity).toHaveProperty('title');
       expect(testEntity).toHaveProperty('description');
       expect(testEntity.name).toBe(EntityType.Test);
+      expect(testEntity.title).toBe(EntityType.Test);
+      expect(testEntity.description).toBe('');
     });
 
     it('should properly group entities', async () => {
@@ -204,6 +206,24 @@ describe('CitrusTestResource', () => {
 
       // Test should be in common (empty group)
       expect(entityList.common).toEqual([expect.objectContaining({ name: EntityType.Test })]);
+    });
+
+    it('should be populated after initialize() and re-populated on subsequent calls', async () => {
+      const resource = new CitrusTestResource(citrusTestJson);
+
+      // Before initialize() the list is undefined — getCanvasEntityList() would return undefined!
+      // This test verifies that initialize() is the trigger that makes it available.
+      await resource.initialize();
+      const firstList = resource.getCanvasEntityList();
+      expect(firstList).toBeDefined();
+      expect(firstList.common).toHaveLength(1);
+
+      // Unlike CamelRouteResource (which caches and skips on re-initialize),
+      // CitrusTestResource re-populates resolvedEntities on every initialize() call.
+      await resource.initialize();
+      const secondList = resource.getCanvasEntityList();
+      expect(secondList).toBeDefined();
+      expect(secondList).toStrictEqual(firstList);
     });
   });
 

--- a/packages/ui/src/models/citrus/citrus-test-resource.ts
+++ b/packages/ui/src/models/citrus/citrus-test-resource.ts
@@ -10,7 +10,7 @@ import { BaseEntity, EntityType } from '../entities';
 import { BaseVisualEntityDefinition, KaotoResource } from '../kaoto-resource';
 import { KaotoSchemaDefinition } from '../kaoto-schema';
 import { AddStepMode, BaseEntityConstructor, IVisualizationNodeData } from '../visualization/base-visual-entity';
-import { CamelCatalogService, CitrusTestVisualEntity } from '../visualization/flows';
+import { CitrusTestVisualEntity } from '../visualization/flows';
 import { NonVisualEntity } from '../visualization/flows/non-visual-entity';
 import { FlowTemplateService } from '../visualization/flows/support/flow-templates-service';
 import { Test } from './entities/Test';
@@ -59,40 +59,29 @@ export class CitrusTestResource implements KaotoResource {
   async initialize(): Promise<void> {
     if (!this.rawEntities) {
       this.entities = [];
-      return;
+    } else {
+      const entities = Array.isArray(this.rawEntities) ? this.rawEntities : [this.rawEntities];
+      const parsedEntities = entities.reduce((acc, rawItem) => {
+        const entity = this.getEntity(rawItem);
+        if (isDefined(entity) && typeof entity === 'object') {
+          acc.push(entity);
+        }
+        return acc;
+      }, [] as BaseEntity[]);
+
+      this.entities = EntityOrderingService.sortEntitiesForSerialization(parsedEntities);
     }
 
-    const entities = Array.isArray(this.rawEntities) ? this.rawEntities : [this.rawEntities];
-    const parsedEntities = entities.reduce((acc, rawItem) => {
-      const entity = this.getEntity(rawItem);
-      if (isDefined(entity) && typeof entity === 'object') {
-        acc.push(entity);
-      }
-      return acc;
-    }, [] as BaseEntity[]);
-
-    this.entities = EntityOrderingService.sortEntitiesForSerialization(parsedEntities);
-
-    // Fetch and cache endpoints schema
-    await this.fetchEndpointsSchema();
-  }
-
-  /**
-   * Gets the list of entity types that can be added to the canvas.
-   *
-   * Filters entities based on the current serializer type (some entities are YAML-only).
-   * Returns entity definitions organized into common entities and grouped entities.
-   *
-   * @returns Entity definitions with metadata for display in the visual editor
-   */
-  getCanvasEntityList(): BaseVisualEntityDefinition {
+    // Pre-populate the canvas entity list so getCanvasEntityList() stays synchronous.
+    // The lookup CamelCatalogService.getComponent(CatalogKind.TestAction, EntityType.Test) always
+    // returned undefined because the 'test' key does not exist in any Citrus catalog — the fallback
+    // (type as title, empty description) was always used. We therefore build the list directly here.
     this.resolvedEntities = this.supportedEntities.reduce(
       (acc, { type, group }) => {
-        const catalogEntity = CamelCatalogService.getComponent(CatalogKind.TestAction, type);
         const entityDefinition = {
           name: type,
-          title: catalogEntity?.title || type,
-          description: catalogEntity?.description || '',
+          title: type,
+          description: '',
         };
 
         if (group === '') {
@@ -107,7 +96,12 @@ export class CitrusTestResource implements KaotoResource {
       { common: [], groups: {} } as BaseVisualEntityDefinition,
     );
 
-    return this.resolvedEntities;
+    // Fetch and cache endpoints schema
+    await this.fetchEndpointsSchema();
+  }
+
+  getCanvasEntityList(): BaseVisualEntityDefinition {
+    return this.resolvedEntities ?? { common: [], groups: {} };
   }
 
   /**

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.test.ts
@@ -2,6 +2,9 @@ import catalogLibrary from '@kaoto/camel-catalog/index.json';
 import { CatalogLibrary } from '@kaoto/camel-catalog/types';
 import { cloneDeep } from 'lodash';
 
+import { DynamicCatalog } from '../../../dynamic-catalog/dynamic-catalog';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
+import { CamelProcessorsProvider } from '../../../dynamic-catalog/providers/camel-components.provider';
 import { camelRouteJson } from '../../../stubs/camel-route';
 import { citrusTestJson } from '../../../stubs/citrus-test';
 import { getFirstCitrusCatalogMap } from '../../../stubs/test-load-catalog';
@@ -187,15 +190,20 @@ describe('CitrusTestVisualEntity', () => {
     });
 
     it('should return root test schema from the catalog', async () => {
-      CamelCatalogService.setCatalogKey(CatalogKind.Entity, {
-        [CITRUS_TEST_ROOT_ENTITY_NAME]: {
-          propertiesSchema: {
-            name: 'Test',
-            description: 'desc',
-            properties: { name: {}, variables: {}, actions: { type: 'array' }, finally: { type: 'array' } },
-          },
-        } as unknown as ICamelProcessorDefinition,
-      });
+      DynamicCatalogRegistry.get().setCatalog(
+        CatalogKind.Entity,
+        new DynamicCatalog(
+          new CamelProcessorsProvider({
+            [CITRUS_TEST_ROOT_ENTITY_NAME]: {
+              propertiesSchema: {
+                name: 'Test',
+                description: 'desc',
+                properties: { name: {}, variables: {}, actions: { type: 'array' }, finally: { type: 'array' } },
+              },
+            } as unknown as ICamelProcessorDefinition,
+          }),
+        ),
+      );
       const result = await citrusTestEntity.fetchNodeSchema({
         primaryNodeId: { name: CITRUS_TEST_ROOT_ENTITY_NAME, catalogKind: CatalogKind.Entity },
       });

--- a/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
+++ b/packages/ui/src/models/visualization/flows/citrus-test-visual-entity.ts
@@ -2,6 +2,7 @@ import { isDefined } from '@kaoto/forms';
 import { cloneDeep } from 'lodash';
 
 import { getCamelRandomId } from '../../../camel-utils/camel-random-id';
+import { DynamicCatalogRegistry } from '../../../dynamic-catalog/dynamic-catalog-registry';
 import { getArrayProperty, getValue, setValue } from '../../../utils';
 import { DefinedComponent } from '../../camel/camel-catalog-index';
 import { CatalogKind } from '../../catalog-kind';
@@ -22,7 +23,6 @@ import {
 import { IClipboardContent } from '../clipboard';
 import { NodeIdentity } from '../node-identity';
 import { createVisualizationNode } from '../visualization-node';
-import { CamelCatalogService } from './camel-catalog.service';
 import { NodeEnrichmentService } from './nodes/node-enrichment.service';
 import { CitrusTestDefaultService } from './support/citrus-test-default.service';
 import { CitrusTestContainerSettings, CitrusTestSchemaService } from './support/citrus-test-schema.service';
@@ -177,8 +177,8 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     }
 
     if (ids.primaryNodeId.catalogKind === CatalogKind.Entity) {
-      // Root test group node — use the static catalog (same as getNodeSchema at root path)
-      return this.getRootTestSchema();
+      // Root test group node — use the dynamic catalog registry
+      return await this.getRootTestSchema();
     }
 
     // Test action / container nodes — use CitrusTestSchemaService (static catalog)
@@ -197,6 +197,7 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     }
     return actionModel ?? {};
   }
+
   getOmitFormFields(): string[] {
     return [];
   }
@@ -518,8 +519,11 @@ export class CitrusTestVisualEntity implements BaseVisualEntity {
     return vizNodes;
   }
 
-  private getRootTestSchema(): KaotoSchemaDefinition['schema'] {
-    const testRootDefinition = CamelCatalogService.getComponent(CatalogKind.Entity, CITRUS_TEST_ROOT_ENTITY_NAME);
+  private async getRootTestSchema(): Promise<KaotoSchemaDefinition['schema']> {
+    const testRootDefinition = await DynamicCatalogRegistry.get().getEntity(
+      CatalogKind.Entity,
+      CITRUS_TEST_ROOT_ENTITY_NAME,
+    );
     const schema = cloneDeep(testRootDefinition?.propertiesSchema ?? {});
 
     if (schema.properties) {


### PR DESCRIPTION
## Summary

Removes `CamelCatalogService.getComponent` calls from two of the three Citrus files identified in https://github.com/KaotoIO/kaoto/issues/3888.

### `CitrusTestVisualEntity.getRootTestSchema()`

Replaces `CamelCatalogService.getComponent(CatalogKind.Entity, ...)` with `DynamicCatalogRegistry.get().getEntity(CatalogKind.Entity, ...)` and makes the method `async`. The caller `fetchNodeSchema()` was already `async` so the change is fully contained to the private method.

### `CitrusTestResource.getCanvasEntityList()`

The `CamelCatalogService.getComponent(CatalogKind.TestAction, EntityType.Test)` call always returned `undefined` — the `'test'` key does not exist in any Citrus catalog file, so the fallback (entity type name as title, empty description) was always the effective result. The canvas entity list is now built directly in `initialize()` without any catalog lookup, and `getCanvasEntityList()` returns the pre-populated value synchronously, keeping the `KaotoResource` interface contract unchanged.

### Out of scope (follow-up)

`citrus-test-schema.service.ts` (the third file) is left for a follow-up — its `getTestActionDefinition()` is called from the synchronous `toJSON()` / `updateTestGroupModel()` chain, which requires a separate design decision before migrating.

Relates to https://github.com/KaotoIO/kaoto/issues/3888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Citrus test entities remain available when catalog metadata is missing.
  - Test entities now display consistent type-based titles and empty descriptions when catalog entries are unavailable.
  - Root test schema retrieval works with dynamically registered catalog information.
  - Citrus test initialization and endpoint schema loading behave consistently across configurations.
  - Entity lists remain stable and available after repeated initialization.

- **Tests**
  - Expanded coverage for fallback metadata, repeated initialization, cached entity lists, and dynamic catalog registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->