### PR TITLE
feat: Support nested steps for a2aSubTask EIP

### DIFF
--- a/packages/ui/src/models/visualization/flows/support/processor-steps.service.test.ts
+++ b/packages/ui/src/models/visualization/flows/support/processor-steps.service.test.ts
@@ -11,6 +11,7 @@ describe('ProcessorStepsService', () => {
       ['otherwise', false],
       ['doCatch', false],
       ['doFinally', false],
+      ['a2aSubTask', true],
       ['aggregate', true],
       ['onFallback', true],
       ['saga', true],
@@ -33,6 +34,7 @@ describe('ProcessorStepsService', () => {
       ['interceptSendToEndpoint', false],
       ['onException', false],
       ['onCompletion', false],
+      ['a2aSubTask', true],
       ['aggregate', true],
       ['onFallback', true],
       ['saga', true],
@@ -50,6 +52,7 @@ describe('ProcessorStepsService', () => {
       ['otherwise', [{ name: 'steps', type: 'branch' }]],
       ['doCatch', [{ name: 'steps', type: 'branch' }]],
       ['doFinally', [{ name: 'steps', type: 'branch' }]],
+      ['a2aSubTask', [{ name: 'steps', type: 'branch' }]],
       ['aggregate', [{ name: 'steps', type: 'branch' }]],
       [
         'circuitBreaker',

--- a/packages/ui/src/models/visualization/flows/support/processor-steps.service.ts
+++ b/packages/ui/src/models/visualization/flows/support/processor-steps.service.ts
@@ -51,6 +51,7 @@ export class ProcessorStepsService {
       /** choice */ case 'otherwise' as keyof ProcessorDefinition:
       /** doTry */ case 'doCatch':
       /** doTry */ case 'doFinally':
+      case 'a2aSubTask':
       case 'aggregate':
       case 'filter':
       case 'loadBalance':


### PR DESCRIPTION
## Summary

The `a2aSubTask` EIP (Agent-to-Agent Sub Task) supports nested steps, just like other container EIPs such as `aggregate`, `split`, `saga`, etc.

## Changes

- Added `a2aSubTask` to the `getProcessorStepsProperties` switch in `ProcessorStepsService` so the canvas renders it as a step-container with a `steps` branch.
- Added unit test cases for `a2aSubTask` in all three `ProcessorStepsService` test suites (`canHavePreviousStep`, `canReplaceStep`, `getProcessorStepsProperties`).

## References

- [a2aSubTask EIP documentation](https://camel.apache.org/components/4.22.x/eips/a2aSubTask-eip.html)

Closes https://github.com/KaotoIO/kaoto/issues/3893