### PR TITLE
fix(vscode): Editor tabs show a permanent dashed underline

### DIFF
--- a/packages/ui/src/multiplying-architecture/KaotoEditor.scss
+++ b/packages/ui/src/multiplying-architecture/KaotoEditor.scss
@@ -37,6 +37,13 @@ html body {
   > div[role='region'] {
     flex-grow: 0;
     flex-shrink: 0;
+
+    // Each Tab is wrapped in a react-router <Link>, i.e. an <a>. PatternFly 6 base styles
+    // underline every anchor by default and that decoration propagates to the tab text.
+    // Tabs are navigation controls, not inline links, so drop it here.
+    a {
+      text-decoration: none;
+    }
   }
 
   // Tab content for Design canvas is not scrollable


### PR DESCRIPTION
Fixes https://github.com/KaotoIO/kaoto/issues/3873

BEFORE:
<img width="568" height="148" alt="Screenshot 2026-09-02 at 17 36 29" src="https://github.com/user-attachments/assets/e4458e8d-db7c-4d5e-befa-75c08aac1da7" />


AFTER:
<img width="636" height="129" alt="Screenshot 2026-09-08 at 18 04 29" src="https://github.com/user-attachments/assets/f3423c2f-21c1-45f4-9edf-058e6e933ec3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Scoped link styling in the editor’s tab navigation to remove default underlines.
  * Preserved default underline styling for unrelated links elsewhere in the document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->