### PR TITLE
refactor(DataMapper): replace useState/useEffect with useMemo for document tree creation

### DIFF
--- a/packages/ui/src/components/Document/Parameters.tsx
+++ b/packages/ui/src/components/Document/Parameters.tsx
@@ -9,7 +9,6 @@ import { Virtuoso } from 'react-virtuoso';
 import { useConnectionPortSync } from '../../hooks/useConnectionPortSync.hook';
 import { useDataMapper } from '../../hooks/useDataMapper';
 import { DocumentType, IDocument } from '../../models/datamapper/document';
-import { DocumentTree } from '../../models/datamapper/document-tree';
 import { DocumentNodeData } from '../../models/datamapper/visualization';
 import { TreeUIService } from '../../services/visualization/tree-ui.service';
 import { useDocumentTreeStore } from '../../store/document-tree.store';
@@ -112,11 +111,7 @@ const ParameterPanel: FunctionComponent<ParameterPanelProps> = ({
 }) => {
   const { mappingTree } = useDataMapper();
   const parameterNodeData = useMemo(() => new DocumentNodeData(document), [document]);
-  const [parameterTree, setParameterTree] = useState<DocumentTree | undefined>(undefined);
-
-  useEffect(() => {
-    setParameterTree(TreeUIService.createTree(parameterNodeData));
-  }, [parameterNodeData]);
+  const parameterTree = useMemo(() => TreeUIService.createTree(parameterNodeData), [parameterNodeData]);
 
   // Optimize: Select only the expansion state for this document
   const documentExpansionState = useDocumentTreeStore((state) => state.expansionState[parameterNodeData.id] || {});

--- a/packages/ui/src/components/View/SourcePanel.tsx
+++ b/packages/ui/src/components/View/SourcePanel.tsx
@@ -1,13 +1,12 @@
 import './SourcePanel.scss';
 
 import { Label } from '@patternfly/react-core';
-import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useMemo } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 import { useConnectionPortSync } from '../../hooks/useConnectionPortSync.hook';
 import { useDataMapper } from '../../hooks/useDataMapper';
 import { DocumentType } from '../../models/datamapper/document';
-import { DocumentTree } from '../../models/datamapper/document-tree';
 import { DocumentNodeData } from '../../models/datamapper/visualization';
 import { TreeUIService } from '../../services/visualization/tree-ui.service';
 import { useDocumentTreeStore } from '../../store/document-tree.store';
@@ -34,11 +33,7 @@ export const SourcePanel: FunctionComponent<SourcePanelProps> = ({ isReadOnly = 
 
   // Create tree for source body
   const sourceBodyNodeData = useMemo(() => new DocumentNodeData(sourceBodyDocument), [sourceBodyDocument]);
-  const [sourceBodyTree, setSourceBodyTree] = useState<DocumentTree | undefined>(undefined);
-
-  useEffect(() => {
-    setSourceBodyTree(TreeUIService.createTree(sourceBodyNodeData));
-  }, [sourceBodyNodeData]);
+  const sourceBodyTree = useMemo(() => TreeUIService.createTree(sourceBodyNodeData), [sourceBodyNodeData]);
 
   // Optimize: Select only the expansion state for this document
   const documentExpansionState = useDocumentTreeStore((state) => state.expansionState[sourceBodyNodeData.id] || {});

--- a/packages/ui/src/components/View/TargetPanel.tsx
+++ b/packages/ui/src/components/View/TargetPanel.tsx
@@ -1,13 +1,12 @@
 import './TargetPanel.scss';
 
 import { Label } from '@patternfly/react-core';
-import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useMemo } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 import { useConnectionPortSync } from '../../hooks/useConnectionPortSync.hook';
 import { useDataMapper } from '../../hooks/useDataMapper';
 import { DocumentType } from '../../models/datamapper/document';
-import { DocumentTree } from '../../models/datamapper/document-tree';
 import { MappingActionKind } from '../../models/datamapper/mapping-action';
 import { TargetDocumentNodeData } from '../../models/datamapper/visualization';
 import { MappingActionRegistryService } from '../../services/visualization/mapping-action-registry.service';
@@ -39,11 +38,7 @@ export const TargetPanel: FunctionComponent = () => {
     () => new TargetDocumentNodeData(targetBodyDocument, structuralMappingTree),
     [targetBodyDocument, structuralMappingTree],
   );
-  const [targetBodyTree, setTargetBodyTree] = useState<DocumentTree | undefined>(undefined);
-
-  useEffect(() => {
-    setTargetBodyTree(TreeUIService.createTree(targetBodyNodeData));
-  }, [targetBodyNodeData]);
+  const targetBodyTree = useMemo(() => TreeUIService.createTree(targetBodyNodeData), [targetBodyNodeData]);
 
   // Optimize: Select only the expansion state for this document
   const documentExpansionState = useDocumentTreeStore((state) => state.expansionState[targetBodyNodeData.id] || {});


### PR DESCRIPTION
Resolves: [#3833](https://github.com/KaotoIO/kaoto/issues/3833)

In ParameterPanel, SourcePanel, and TargetPanel, the document tree was computed inside a useEffect and stored in local state. This caused an unnecessary extra render cycle: the component first rendered with undefined tree state, then re-rendered after the effect fired.

Replace the useState + useEffect pattern with a single useMemo call so the tree is computed synchronously during render whenever its dependency (the node data) changes. This eliminates the intermediate undefined state, removes one render pass per document, and simplifies the code.

Also remove the now-unused DocumentTree import and useState import in the affected files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the responsiveness and consistency of parameter, source, and target panels by deriving displayed tree data immediately when inputs change.
  * Removed unnecessary intermediate state handling for these panel views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->