### PR TITLE
feat(ci,vscode): kaoto-vscode extension GH actions release pipeline

### DIFF
--- a/.github/scripts/check-version.mjs
+++ b/.github/scripts/check-version.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Validates that all project package.json files carry the expected version.
+ *
+ * Usage: node scripts/check-version.mjs <expected-version>
+ * Example: node scripts/check-version.mjs 2.12.0
+ *
+ * Exits 0 when all versions match, 1 when any disagree.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+const PACKAGES = [
+  'package.json',
+  'packages/kaoto-vscode/package.json',
+  'packages/kaoto-web/package.json',
+  'packages/ui-tests/package.json',
+  'packages/ui/package.json',
+];
+
+const expected = process.argv[2];
+
+if (!expected) {
+  console.error('Usage: node scripts/check-version.mjs <expected-version>');
+  process.exit(1);
+}
+
+let failed = false;
+
+for (const rel of PACKAGES) {
+  const file = resolve(ROOT, rel);
+  const { version } = JSON.parse(readFileSync(file, 'utf8'));
+  if (version !== expected) {
+    console.error(`✗ ${rel}: expected "${expected}", found "${version}"`);
+    failed = true;
+  } else {
+    console.log(`✓ ${rel}: ${version}`);
+  }
+}
+
+if (failed) {
+  console.error('\nVersion mismatch — update all package.json files before releasing.');
+  process.exit(1);
+}
+
+console.log('\nAll versions match.');

--- a/.github/workflows/kaoto-vscode-release-pipeline.yml
+++ b/.github/workflows/kaoto-vscode-release-pipeline.yml
@@ -222,10 +222,10 @@ jobs:
         env:
           VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
           VSIX_NAME: ${{ needs.release.outputs.vsix_name }}
-        run: yarn workspace vscode-kaoto vsce publish -p "${VSCE_TOKEN}" --packagePath "packages/kaoto-vscode/${VSIX_NAME}"
+        run: yarn workspace vscode-kaoto vsce publish -p "${VSCE_TOKEN}" --packagePath "${VSIX_NAME}"
 
       - name: '📤 Publish to Open-VSX'
         env:
           OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
           VSIX_NAME: ${{ needs.release.outputs.vsix_name }}
-        run: yarn workspace vscode-kaoto ovsx publish -p "${OVSX_TOKEN}" "packages/kaoto-vscode/${VSIX_NAME}"
+        run: yarn workspace vscode-kaoto ovsx publish -p "${OVSX_TOKEN}" "${VSIX_NAME}"

--- a/.github/workflows/kaoto-vscode-release-pipeline.yml
+++ b/.github/workflows/kaoto-vscode-release-pipeline.yml
@@ -1,0 +1,231 @@
+name: 🏷️ VS Code Kaoto Release Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        type: string
+        description: |
+          The tag version to release without prefix (e.g. 2.12.0)
+        required: true
+      snapshot:
+        type: boolean
+        description: |
+          Snapshot release? Creates a pre-release tagged <tag_version>-SNAPSHOT-<short-sha>.
+          Skips SBOM generation and marketplace publish.
+        required: false
+        default: true
+      run_ui_tests:
+        type: boolean
+        description: |
+          Run full UI + deploy tests (minikube) before packaging?
+        required: false
+        default: true
+
+jobs:
+  release:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.compute.outputs.release_tag }}
+      vsix_name: ${{ steps.compute.outputs.vsix_name }}
+
+    steps:
+      - name: '🛰️ Checkout source code'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+          persist-credentials: false
+
+      - name: '🔍 Validate version consistency'
+        env:
+          TAG_VERSION: ${{ github.event.inputs.tag_version }}
+        run: node .github/scripts/check-version.mjs "${TAG_VERSION}"
+
+      - name: '🔧 Setup tools'
+        uses: ./.github/actions/kaoto-vscode-setup-tools
+        with:
+          allow-unprivileged-userns: 'true'
+
+      - name: '🔧 Install dependencies'
+        run: yarn install --immutable --mode=skip-build
+
+      - name: '🔧 Build UI lib'
+        run: yarn workspace @kaoto/kaoto build:lib
+
+      - name: '🔧 Build and lint extension'
+        run: yarn workspace vscode-kaoto build:prod
+
+      - name: '🧪 Run unit tests'
+        run: xvfb-run -a yarn workspace vscode-kaoto test:unit
+
+      - name: '🔢 Compute VSIX filename and release tag'
+        id: compute
+        # Security: use environment variables to prevent script injection from user-supplied tag_version input
+        env:
+          TAG_VERSION: ${{ github.event.inputs.tag_version }}
+          SNAPSHOT: ${{ github.event.inputs.snapshot }}
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          if [ "$SNAPSHOT" = "true" ]; then
+            RELEASE_TAG="${TAG_VERSION}-SNAPSHOT-${SHORT_SHA}"
+          else
+            RELEASE_TAG="${TAG_VERSION}"
+          fi
+          VSIX_NAME="vscode-kaoto-${RELEASE_TAG}.vsix"
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "vsix_name=${VSIX_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: '📦 Build release VSIX'
+        env:
+          VSIX_NAME: ${{ steps.compute.outputs.vsix_name }}
+        run: yarn workspace vscode-kaoto build:vsix --out "${VSIX_NAME}"
+
+      - name: '📤 Upload VSIX artifact'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vscode-kaoto-vsix-release
+          path: packages/kaoto-vscode/${{ steps.compute.outputs.vsix_name }}
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: '📋 Generate SBOM'
+        if: ${{ !inputs.snapshot }}
+        run: yarn workspace vscode-kaoto sbom:generate
+
+      - name: '📤 Upload SBOM artifact'
+        if: ${{ !inputs.snapshot }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vscode-kaoto-sbom
+          path: packages/kaoto-vscode/manifest.json
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: '📤 Upload unit test logs on failure'
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unit-test-logs
+          path: packages/kaoto-vscode/.vscode-test/user-data/logs/*
+          include-hidden-files: true
+          retention-days: 7
+
+  ui-tests:
+    needs: release
+    if: ${{ inputs.run_ui_tests }}
+    uses: ./.github/workflows/kaoto-vscode-ui-tests.yml
+    with:
+      vsix-artifact-name: vscode-kaoto-vsix-release
+      vsix-file: ${{ needs.release.outputs.vsix_name }}
+      run-full-ui-tests: true
+      run-deploy-tests: true
+
+  tag-and-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - release
+      - ui-tests
+    # Create tag and release only after UI tests pass (or when UI tests are skipped)
+    if: |
+      needs.release.result == 'success' &&
+      (needs.ui-tests.result == 'success' || needs.ui-tests.result == 'skipped')
+
+    steps:
+      - name: '🛰️ Checkout source code'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+          persist-credentials: false
+
+      - name: '📥 Download VSIX artifact'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vscode-kaoto-vsix-release
+
+      - name: '📥 Download SBOM artifact'
+        if: ${{ !inputs.snapshot }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vscode-kaoto-sbom
+
+      - name: '🏷️ Create and push git tag'
+        id: tag_version
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ needs.release.outputs.release_tag }}
+          create_annotated_tag: true
+          tag_prefix: ''
+
+      - name: '🚀 Create GitHub Release (with SBOM)'
+        if: ${{ !inputs.snapshot }}
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          tag: ${{ needs.release.outputs.release_tag }}
+          name: Release ${{ needs.release.outputs.release_tag }}
+          prerelease: false
+          artifacts: >-
+            ${{ needs.release.outputs.vsix_name }},
+            manifest.json
+
+      - name: '🚀 Create GitHub Pre-Release (snapshot)'
+        if: ${{ inputs.snapshot }}
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          tag: ${{ needs.release.outputs.release_tag }}
+          name: Release ${{ needs.release.outputs.release_tag }}
+          prerelease: true
+          artifacts: ${{ needs.release.outputs.vsix_name }}
+
+  publish:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    needs:
+      - release
+      - tag-and-release
+    # Run when: not a snapshot, AND tag-and-release succeeded
+    if: |
+      !inputs.snapshot &&
+      needs.tag-and-release.result == 'success'
+
+    steps:
+      - name: '🛰️ Checkout source code'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: '🔧 Setup Node.js'
+        uses: ./.github/actions/kaoto-vscode-setup-tools
+        # Node.js + yarn cache needed to resolve locally installed vsce and ovsx binaries
+
+      - name: '🔧 Install dependencies'
+        run: yarn install --immutable --mode=skip-build
+        # Installs @vscode/vsce and ovsx from devDependencies so they can be invoked below
+
+      - name: '📥 Download VSIX from release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.release.outputs.release_tag }}
+          VSIX_NAME: ${{ needs.release.outputs.vsix_name }}
+        run: |
+          gh release download "${RELEASE_TAG}" \
+            --pattern "${VSIX_NAME}" \
+            --dir packages/kaoto-vscode \
+            --repo "${{ github.repository }}"
+
+      - name: '📤 Publish to VS Code Marketplace'
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+          VSIX_NAME: ${{ needs.release.outputs.vsix_name }}
+        run: yarn workspace vscode-kaoto vsce publish -p "${VSCE_TOKEN}" --packagePath "packages/kaoto-vscode/${VSIX_NAME}"
+
+      - name: '📤 Publish to Open-VSX'
+        env:
+          OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
+          VSIX_NAME: ${{ needs.release.outputs.vsix_name }}
+        run: yarn workspace vscode-kaoto ovsx publish -p "${OVSX_TOKEN}" "packages/kaoto-vscode/${VSIX_NAME}"

--- a/.github/workflows/kaoto-vscode-ui-tests.yml
+++ b/.github/workflows/kaoto-vscode-ui-tests.yml
@@ -7,6 +7,11 @@ on:
         description: Name of the VSIX artifact to download
         required: true
         type: string
+      vsix-file:
+        description: Filename of the VSIX inside the artifact (defaults to kaoto-ci.vsix)
+        required: false
+        type: string
+        default: kaoto-ci.vsix
       run-full-ui-tests:
         description: Run all four integration test groups (views + export in addition to settings + editor)
         required: true
@@ -51,7 +56,7 @@ jobs:
         env:
           KAOTO_DISABLE_WHATS_NEW: 'true'
           TEST_RESOURCES: ${{ runner.temp }}/kaoto-tests
-          VSIX_FILE: kaoto-ci.vsix
+          VSIX_FILE: ${{ inputs.vsix-file }}
         run: |
           if [ "$RUNNER_OS" = Linux ]; then
             xvfb-run -a yarn workspace vscode-kaoto test:ui:vsix:settings
@@ -97,7 +102,7 @@ jobs:
         env:
           KAOTO_DISABLE_WHATS_NEW: 'true'
           TEST_RESOURCES: ${{ runner.temp }}/kaoto-tests
-          VSIX_FILE: kaoto-ci.vsix
+          VSIX_FILE: ${{ inputs.vsix-file }}
         run: |
           if [ "$RUNNER_OS" = Linux ]; then
             xvfb-run -a yarn workspace vscode-kaoto test:ui:vsix:editor
@@ -144,7 +149,7 @@ jobs:
         env:
           KAOTO_DISABLE_WHATS_NEW: 'true'
           TEST_RESOURCES: ${{ runner.temp }}/kaoto-tests
-          VSIX_FILE: kaoto-ci.vsix
+          VSIX_FILE: ${{ inputs.vsix-file }}
         run: |
           if [ "$RUNNER_OS" = Linux ]; then
             xvfb-run -a yarn workspace vscode-kaoto test:ui:vsix:views
@@ -191,7 +196,7 @@ jobs:
         env:
           KAOTO_DISABLE_WHATS_NEW: 'true'
           TEST_RESOURCES: ${{ runner.temp }}/kaoto-tests
-          VSIX_FILE: kaoto-ci.vsix
+          VSIX_FILE: ${{ inputs.vsix-file }}
         run: |
           if [ "$RUNNER_OS" = Linux ]; then
             xvfb-run -a yarn workspace vscode-kaoto test:ui:vsix:export
@@ -230,7 +235,7 @@ jobs:
         env:
           KAOTO_DISABLE_WHATS_NEW: 'true'
           TEST_RESOURCES: ${{ runner.temp }}/kaoto-tests
-          VSIX_FILE: kaoto-ci.vsix
+          VSIX_FILE: ${{ inputs.vsix-file }}
         run: |
           eval "$(minikube -p minikube docker-env)"
           xvfb-run -a yarn workspace vscode-kaoto test:ui:vsix:deploy

--- a/packages/kaoto-vscode/package.json
+++ b/packages/kaoto-vscode/package.json
@@ -84,6 +84,7 @@
     "mocha-jenkins-reporter": "^0.4.8",
     "node-fetch": "2",
     "os-browserify": "^0.3.0",
+    "ovsx": "^1.1.1",
     "path-browserify": "^1.0.1",
     "prettier": "3.7.4",
     "rimraf": "^6.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3132,6 +3132,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/checkbox@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "@inquirer/checkbox@npm:4.3.2"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/4ac5dd2679981e23f066c51c605cb1c63ccda9ea6e1ad895e675eb26702aaf6cf961bf5ca3acd832efba5edcf9883b6742002c801673d2b35c123a7fa7db7b23
+  languageName: node
+  linkType: hard
+
 "@inquirer/confirm@npm:^5.0.0":
   version: 5.1.13
   resolution: "@inquirer/confirm@npm:5.1.13"
@@ -3144,6 +3162,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10/80a45f59b81b985e1edd3f8249c71b00e216d3ad553204ea44f7da83194dd833287e3c569f92e2a09c2bcf83b8e35a4134b1050ed7b0fccfe5f588ca985a38bd
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^5.1.21":
+  version: 5.1.21
+  resolution: "@inquirer/confirm@npm:5.1.21"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/a107aa0073965ea510affb9e5b55baf40333503d600970c458c07770cd4e0eee01efc4caba66f0409b0fadc9550d127329622efb543cffcabff3ad0e7f865372
   languageName: node
   linkType: hard
 
@@ -3224,6 +3257,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/editor@npm:^4.2.23":
+  version: 4.2.23
+  resolution: "@inquirer/editor@npm:4.2.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/external-editor": "npm:^1.0.3"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/f91b9aadba6ea28a0f4ea5f075af421e076262aebbd737e1b9779f086fa9d559d064e9942a581544645d1dcf56d6b685e8063fe46677880fbca73f6de4e4e7c5
+  languageName: node
+  linkType: hard
+
 "@inquirer/expand@npm:^4.0.23":
   version: 4.0.23
   resolution: "@inquirer/expand@npm:4.0.23"
@@ -3237,6 +3286,21 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10/73ad1d6376e5efe2a452c33494d6d16ee2670c638ae470a795fdff4acb59a8e032e38e141f87b603b6e96320977519b375dac6471d86d5e3087a9c1db40e3111
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@inquirer/external-editor@npm:1.0.3"
+  dependencies:
+    chardet: "npm:^2.1.1"
+    iconv-lite: "npm:^0.7.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/c95d7237a885b32031715089f92820525731d4d3c2bd7afdb826307dc296cc2b39e7a644b0bb265441963348cca42e7785feb29c3aaf18fd2b63131769bf6587
   languageName: node
   linkType: hard
 
@@ -3273,6 +3337,93 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10/713aaa4c94263299fbd7adfd65378f788cac1b5047f2b7e1ea349ca669db6c7c91b69ab6e2f6660cdbc28c7f7888c5c77ab4433bd149931597e43976d1ba5f34
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^3.0.23":
+  version: 3.0.23
+  resolution: "@inquirer/number@npm:3.0.23"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/50694807b71746e15ed69d100aae3c8014d83c90aa660e8a179fe0db1046f26d727947542f64e24cc8b969a61659cb89fe36208cc2b59c1816382b598e686dd2
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^4.0.23":
+  version: 4.0.23
+  resolution: "@inquirer/password@npm:4.0.23"
+  dependencies:
+    "@inquirer/ansi": "npm:^1.0.2"
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/97364970b01c85946a4a50ad876c53ef0c1857a9144e24fad65e5dfa4b4e5dd42564fbcdfa2b49bb049a25d127efbe0882cb18afcdd47b166ebd01c6c4b5e825
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^7.10.1, @inquirer/prompts@npm:^7.8.6":
+  version: 7.10.1
+  resolution: "@inquirer/prompts@npm:7.10.1"
+  dependencies:
+    "@inquirer/checkbox": "npm:^4.3.2"
+    "@inquirer/confirm": "npm:^5.1.21"
+    "@inquirer/editor": "npm:^4.2.23"
+    "@inquirer/expand": "npm:^4.0.23"
+    "@inquirer/input": "npm:^4.3.1"
+    "@inquirer/number": "npm:^3.0.23"
+    "@inquirer/password": "npm:^4.0.23"
+    "@inquirer/rawlist": "npm:^4.1.11"
+    "@inquirer/search": "npm:^3.2.2"
+    "@inquirer/select": "npm:^4.4.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/b3e3386edd255e4e91c7908050674f8a2e69b043883c00feec2f87d697be37bc6e8cd4a360e7e3233a9825ae7ea044a2ac63d5700926d27f9959013d8566f890
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "@inquirer/rawlist@npm:4.1.11"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/0d8f6484cfc20749190e95eecfb2d034bafb3644ec4907b84b1673646f5dd71730e38e35565ea98dfd240d8851e3cff653edafcc4e0af617054b127b407e3229
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@inquirer/search@npm:3.2.2"
+  dependencies:
+    "@inquirer/core": "npm:^10.3.2"
+    "@inquirer/figures": "npm:^1.0.15"
+    "@inquirer/type": "npm:^3.0.10"
+    yoctocolors-cjs: "npm:^2.1.3"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/abaed2df7763633ff4414b58d1c87233b69ed3cd2ac77629f0d54b72b8b585dc4806c7a2a8261daba58af5b0a2147e586d079fdc82060b6bcf56b75d3d03f3a7
   languageName: node
   linkType: hard
 
@@ -4511,6 +4662,135 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/keyring-darwin-arm64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-darwin-arm64@npm:1.3.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-darwin-x64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-darwin-x64@npm:1.3.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-freebsd-x64@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-freebsd-x64@npm:1.3.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm-gnueabihf@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-arm-gnueabihf@npm:1.3.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm64-gnu@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-arm64-gnu@npm:1.3.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-arm64-musl@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-arm64-musl@npm:1.3.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-riscv64-gnu@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-riscv64-gnu@npm:1.3.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-x64-gnu@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-x64-gnu@npm:1.3.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-linux-x64-musl@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-linux-x64-musl@npm:1.3.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-arm64-msvc@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-win32-arm64-msvc@npm:1.3.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-ia32-msvc@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-win32-ia32-msvc@npm:1.3.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring-win32-x64-msvc@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring-win32-x64-msvc@npm:1.3.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@napi-rs/keyring@npm:^1.2.0":
+  version: 1.3.0
+  resolution: "@napi-rs/keyring@npm:1.3.0"
+  dependencies:
+    "@napi-rs/keyring-darwin-arm64": "npm:1.3.0"
+    "@napi-rs/keyring-darwin-x64": "npm:1.3.0"
+    "@napi-rs/keyring-freebsd-x64": "npm:1.3.0"
+    "@napi-rs/keyring-linux-arm-gnueabihf": "npm:1.3.0"
+    "@napi-rs/keyring-linux-arm64-gnu": "npm:1.3.0"
+    "@napi-rs/keyring-linux-arm64-musl": "npm:1.3.0"
+    "@napi-rs/keyring-linux-riscv64-gnu": "npm:1.3.0"
+    "@napi-rs/keyring-linux-x64-gnu": "npm:1.3.0"
+    "@napi-rs/keyring-linux-x64-musl": "npm:1.3.0"
+    "@napi-rs/keyring-win32-arm64-msvc": "npm:1.3.0"
+    "@napi-rs/keyring-win32-ia32-msvc": "npm:1.3.0"
+    "@napi-rs/keyring-win32-x64-msvc": "npm:1.3.0"
+  dependenciesMeta:
+    "@napi-rs/keyring-darwin-arm64":
+      optional: true
+    "@napi-rs/keyring-darwin-x64":
+      optional: true
+    "@napi-rs/keyring-freebsd-x64":
+      optional: true
+    "@napi-rs/keyring-linux-arm-gnueabihf":
+      optional: true
+    "@napi-rs/keyring-linux-arm64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-arm64-musl":
+      optional: true
+    "@napi-rs/keyring-linux-riscv64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-x64-gnu":
+      optional: true
+    "@napi-rs/keyring-linux-x64-musl":
+      optional: true
+    "@napi-rs/keyring-win32-arm64-msvc":
+      optional: true
+    "@napi-rs/keyring-win32-ia32-msvc":
+      optional: true
+    "@napi-rs/keyring-win32-x64-msvc":
+      optional: true
+  checksum: 10/bfef7fe1dfcfc29a5cf0988ce3dad06a19850351598b6a8f2b8ccd6a8f64540a80f66ae3eb018112bdabb366dbb421c026c418756ffe93d2ea19518aa87c0440
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^1.1.3":
   version: 1.1.3
   resolution: "@napi-rs/wasm-runtime@npm:1.1.3"
@@ -4532,6 +4812,145 @@ __metadata:
     "@emnapi/core": ^1.7.1
     "@emnapi/runtime": ^1.7.1
   checksum: 10/1db3dc7eeb981306b09360487bd8ce4dfa5588d273bd8ea9f07dccca1b4ade57b675414180fc9bb66966c6c50b17208b0263194993e2f7f92cc7af28bda4d1af
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-android-arm-eabi@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-android-arm-eabi@npm:1.10.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-android-arm64@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-android-arm64@npm:1.10.7"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-darwin-arm64@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-darwin-arm64@npm:1.10.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-darwin-x64@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-darwin-x64@npm:1.10.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-freebsd-x64@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-freebsd-x64@npm:1.10.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-arm-gnueabihf@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-linux-arm-gnueabihf@npm:1.10.7"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-arm64-gnu@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-linux-arm64-gnu@npm:1.10.7"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-arm64-musl@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-linux-arm64-musl@npm:1.10.7"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-x64-gnu@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-linux-x64-gnu@npm:1.10.7"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-linux-x64-musl@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-linux-x64-musl@npm:1.10.7"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-win32-arm64-msvc@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-win32-arm64-msvc@npm:1.10.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-win32-ia32-msvc@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-win32-ia32-msvc@npm:1.10.7"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32-win32-x64-msvc@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@node-rs/crc32-win32-x64-msvc@npm:1.10.7"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/crc32@npm:^1.7.0":
+  version: 1.10.7
+  resolution: "@node-rs/crc32@npm:1.10.7"
+  dependencies:
+    "@node-rs/crc32-android-arm-eabi": "npm:1.10.7"
+    "@node-rs/crc32-android-arm64": "npm:1.10.7"
+    "@node-rs/crc32-darwin-arm64": "npm:1.10.7"
+    "@node-rs/crc32-darwin-x64": "npm:1.10.7"
+    "@node-rs/crc32-freebsd-x64": "npm:1.10.7"
+    "@node-rs/crc32-linux-arm-gnueabihf": "npm:1.10.7"
+    "@node-rs/crc32-linux-arm64-gnu": "npm:1.10.7"
+    "@node-rs/crc32-linux-arm64-musl": "npm:1.10.7"
+    "@node-rs/crc32-linux-x64-gnu": "npm:1.10.7"
+    "@node-rs/crc32-linux-x64-musl": "npm:1.10.7"
+    "@node-rs/crc32-win32-arm64-msvc": "npm:1.10.7"
+    "@node-rs/crc32-win32-ia32-msvc": "npm:1.10.7"
+    "@node-rs/crc32-win32-x64-msvc": "npm:1.10.7"
+  dependenciesMeta:
+    "@node-rs/crc32-android-arm-eabi":
+      optional: true
+    "@node-rs/crc32-android-arm64":
+      optional: true
+    "@node-rs/crc32-darwin-arm64":
+      optional: true
+    "@node-rs/crc32-darwin-x64":
+      optional: true
+    "@node-rs/crc32-freebsd-x64":
+      optional: true
+    "@node-rs/crc32-linux-arm-gnueabihf":
+      optional: true
+    "@node-rs/crc32-linux-arm64-gnu":
+      optional: true
+    "@node-rs/crc32-linux-arm64-musl":
+      optional: true
+    "@node-rs/crc32-linux-x64-gnu":
+      optional: true
+    "@node-rs/crc32-linux-x64-musl":
+      optional: true
+    "@node-rs/crc32-win32-arm64-msvc":
+      optional: true
+    "@node-rs/crc32-win32-ia32-msvc":
+      optional: true
+    "@node-rs/crc32-win32-x64-msvc":
+      optional: true
+  checksum: 10/f2955ae90197d35e2f25aba1b82713b4f89565d5b06255803bcdefb7f8c916bd3c5dc1260430e843ad29e33dfab5acd85a7894b3a8c4f77c6b61ea3db5c60a8c
   languageName: node
   linkType: hard
 
@@ -8742,7 +9161,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vscode/vsce@npm:^3.9.2":
+"@vscode/vsce@npm:^3.7.1, @vscode/vsce@npm:^3.9.2":
   version: 3.9.2
   resolution: "@vscode/vsce@npm:3.9.2"
   dependencies:
@@ -10721,6 +11140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chardet@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "chardet@npm:2.2.0"
+  checksum: 10/78d1e5ba7bdc7db23511a194eedca805918df90a511f9c57f9cc7c1fc03702ed4ad053e485a766ace930362869269c4a731feaf460ae24bd3ed7d190cde8087d
+  languageName: node
+  linkType: hard
+
 "check-error@npm:^1.0.3":
   version: 1.0.3
   resolution: "check-error@npm:1.0.3"
@@ -10879,6 +11305,13 @@ __metadata:
   version: 0.1.0
   resolution: "chunk-data@npm:0.1.0"
   checksum: 10/3ab3f7b7da54481bafed8f83f2d9f844b8f43f37c01f7b8079c440e10a5373b6572023743472f49304e20e6b750c8c830c42e3eff3413c073c4ba5448d64eed7
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ci-info@npm:2.0.0"
+  checksum: 10/3b374666a85ea3ca43fa49aa3a048d21c9b475c96eb13c133505d2324e7ae5efd6a454f41efe46a152269e9b6a00c9edbe63ec7fa1921957165aae16625acd67
   languageName: node
   linkType: hard
 
@@ -11628,6 +12061,22 @@ __metadata:
   dependencies:
     node-fetch: "npm:^2.6.12"
   checksum: 10/ac8c4ca87d2ac0e17a19b6a293a67ee8934881aee5ec9a5a8323c30e9a9a60a0f5291d3c0d633ec2a2f970cbc60978d628804dfaf03add92d7e720b6d37f392c
+  languageName: node
+  linkType: hard
+
+"cross-keychain@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "cross-keychain@npm:1.1.0"
+  dependencies:
+    "@inquirer/prompts": "npm:^7.8.6"
+    "@napi-rs/keyring": "npm:^1.2.0"
+    meow: "npm:^14.0.0"
+  dependenciesMeta:
+    "@napi-rs/keyring":
+      optional: true
+  bin:
+    cross-keychain: dist/cli.js
+  checksum: 10/8292e835373e29606e79eede335fbf90d3f9152d02ba2a3c91537cf6f3a8d9160b79ca6e8ddae0899a0b017aecffc1428f356a0b59f748e96afab2a1b1773c27
   languageName: node
   linkType: hard
 
@@ -15811,7 +16260,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globalthis@npm:^1.0.3, globalthis@npm:^1.0.4":
+"globalthis@npm:^1.0.2, globalthis@npm:^1.0.3, globalthis@npm:^1.0.4":
   version: 1.0.4
   resolution: "globalthis@npm:1.0.4"
   dependencies:
@@ -16498,21 +16947,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:^0.7.0, iconv-lite@npm:~0.7.0":
+  version: 0.7.3
+  resolution: "iconv-lite@npm:0.7.3"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10/b88a3f4527795c96854743bcdcdd03e0083ff5f1c072cb13d3e27c67cd276efd9a2a364922cb836538e976456f82323d645f7ea91d5bc8da1f000dc16742a0aa
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:^0.7.2":
   version: 0.7.2
   resolution: "iconv-lite@npm:0.7.2"
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10/24c937b532f868e938386b62410b303b7c767ce3d08dc2829cbe59464d5a26ef86ae5ad1af6b34eec43ddfea39e7d101638644b0178d67262fa87015d59f983a
-  languageName: node
-  linkType: hard
-
-"iconv-lite@npm:~0.7.0":
-  version: 0.7.3
-  resolution: "iconv-lite@npm:0.7.3"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10/b88a3f4527795c96854743bcdcdd03e0083ff5f1c072cb13d3e27c67cd276efd9a2a364922cb836538e976456f82323d645f7ea91d5bc8da1f000dc16742a0aa
   languageName: node
   linkType: hard
 
@@ -16893,6 +17342,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-ci@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-ci@npm:2.0.0"
+  dependencies:
+    ci-info: "npm:^2.0.0"
+  bin:
+    is-ci: bin.js
+  checksum: 10/77b869057510f3efa439bbb36e9be429d53b3f51abd4776eeea79ab3b221337fe1753d1e50058a9e2c650d38246108beffb15ccfd443929d77748d8c0cc90144
+  languageName: node
+  linkType: hard
+
 "is-core-module@npm:^2.13.0, is-core-module@npm:^2.8.1":
   version: 2.13.1
   resolution: "is-core-module@npm:2.13.1"
@@ -17101,6 +17561,15 @@ __metadata:
   version: 2.0.0
   resolution: "is-interactive@npm:2.0.0"
   checksum: 10/e8d52ad490bed7ae665032c7675ec07732bbfe25808b0efbc4d5a76b1a1f01c165f332775c63e25e9a03d319ebb6b24f571a9e902669fc1e40b0a60b5be6e26c
+  languageName: node
+  linkType: hard
+
+"is-it-type@npm:^5.1.2":
+  version: 5.1.3
+  resolution: "is-it-type@npm:5.1.3"
+  dependencies:
+    globalthis: "npm:^1.0.2"
+  checksum: 10/2f59dd836b9d7019330f2aa13483e31edc3d732b73f5185452fd9f6af078691e23960d966326d34c78d792aaf6746f06a7941f4f24680e8e18d13d5a10472384
   languageName: node
   linkType: hard
 
@@ -19693,7 +20162,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"meow@npm:^14.1.0":
+"meow@npm:^14.0.0, meow@npm:^14.1.0":
   version: 14.1.0
   resolution: "meow@npm:14.1.0"
   checksum: 10/c6a22b3912a6bc849dee0d6475cd8bb63b9307e26919ca3ace28dc1aaf3d30257071de32bba496f7b5eec3e62b03a6b7731e3d04d18efb3c3103b829aad52ca5
@@ -21486,6 +21955,26 @@ __metadata:
   version: 1.4.3
   resolution: "outvariant@npm:1.4.3"
   checksum: 10/3a7582745850cb344d49641867a4c080858c54f4091afd91b9c0765ba6e471c2bc841348f0fff344845ddd0a4db42fd5d68c6f7ebaf32d4b676a3a9987b2488a
+  languageName: node
+  linkType: hard
+
+"ovsx@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "ovsx@npm:1.1.1"
+  dependencies:
+    "@inquirer/prompts": "npm:^7.10.1"
+    "@vscode/vsce": "npm:^3.7.1"
+    commander: "npm:^6.2.1"
+    cross-keychain: "npm:^1.1.0"
+    follow-redirects: "npm:^1.16.0"
+    is-ci: "npm:^2.0.0"
+    leven: "npm:^3.1.0"
+    semver: "npm:^7.6.0"
+    tmp: "npm:^0.2.3"
+    yauzl-promise: "npm:^4.0.0"
+  bin:
+    ovsx: bin/ovsx
+  checksum: 10/0898e3788379974eaa693082f1ed87c272a03d7e90a499b58e0b7f67de0dda0a7d1da5ccec3da65c8b96ea2514bad78194cf8443497edaabb889ac9966ca10ef
   languageName: node
   linkType: hard
 
@@ -24648,6 +25137,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-invariant@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "simple-invariant@npm:2.0.1"
+  checksum: 10/a480b2ca9e9ede4e437d9606b38c4ae2fcf3be836a682687bef05810890f73cdbbc3c451c66a1de21fc44644a816118818ed4065ff16b691c25b7a16cdea7478
+  languageName: node
+  linkType: hard
+
 "simple-swizzle@npm:^0.2.2":
   version: 0.2.4
   resolution: "simple-swizzle@npm:0.2.4"
@@ -27706,6 +28202,7 @@ __metadata:
     mocha-jenkins-reporter: "npm:^0.4.8"
     node-fetch: "npm:2"
     os-browserify: "npm:^0.3.0"
+    ovsx: "npm:^1.1.1"
     path-browserify: "npm:^1.0.1"
     prettier: "npm:3.7.4"
     react: "npm:^19.2.4"
@@ -28639,6 +29136,17 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^22.0.0"
   checksum: 10/5af36234871390386b31cac99f00e79fcbc2ead858a61b30a8ca381c5fde5df8af0b407c36b000d3f774bcbe4aec5833f2f1c915f6ddc49ce97b78176b651801
+  languageName: node
+  linkType: hard
+
+"yauzl-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "yauzl-promise@npm:4.0.0"
+  dependencies:
+    "@node-rs/crc32": "npm:^1.7.0"
+    is-it-type: "npm:^5.1.2"
+    simple-invariant: "npm:^2.0.1"
+  checksum: 10/c948777ac973b43ebc2012ed6c02a1f50953f6eab57427117b4ffacbe99a24b548e584a62787def0eefebdad0e483e856a3bcf5979690e830031d765fbd75a74
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #3902

---

## VS Code Kaoto Release Pipeline — GitHub Actions

Replaces the downstream Jenkins release pipeline (`packages/kaoto-vscode/Jenkinsfile`) with an equivalent `workflow_dispatch`-triggered GitHub Actions workflow. Also simplifies the release process from 5 PRs to 3.

### What changed

| File | Change |
|---|---|
| `.github/workflows/kaoto-vscode-release-pipeline.yml` | New release pipeline (see below) |
| `.github/workflows/kaoto-vscode-ui-tests.yml` | Added optional `vsix-file` input (default: `kaoto-ci.vsix`) — all existing CI callers unaffected |
| `.github/scripts/check-version.mjs` | New version consistency script |
| `packages/kaoto-vscode/package.json` | Added `ovsx` devDependency |
| `packages/kaoto-vscode/Jenkinsfile` | Deleted — superseded |

### New release pipeline

Triggered manually via **Actions → VS Code Kaoto Release Pipeline → Run workflow**. The GitHub UI branch picker is the hotfix mechanism — no extra ref input needed.

**Inputs:**

| Input | Default | Description |
|---|---|---|
| `tag_version` | required | Version to release, e.g. `2.12.0` — must match all `package.json` files |
| `snapshot` | **`true`** | Creates a pre-release tagged `<version>-SNAPSHOT-<sha>`, skips SBOM and marketplace publish |
| `run_ui_tests` | **`true`** | Runs full UI + deploy tests (minikube) before creating the tag and release |

Safe-by-default: accepting defaults produces a snapshot pre-release with UI tests. A full marketplace publish requires explicitly unchecking `snapshot`.

**Job flow:**

```
release  →  ui-tests (if run_ui_tests)  →  tag-and-release  →  publish (if not snapshot)
```

| Job | Responsibility |
|---|---|
| `release` | Validates versions, builds, runs unit tests, packages VSIX, generates SBOM, uploads both as artifacts |
| `ui-tests` | Optional — full UI + deploy tests (minikube) against the built VSIX |
| `tag-and-release` | Creates git tag and GitHub Release **only after UI tests pass or are skipped** — VSIX and SBOM attached as release assets |
| `publish` | Downloads VSIX from the release and publishes to VS Code Marketplace and Open-VSX |

The tag and release are created only after all gating checks pass — if UI tests fail, no tag or release is created.

### Version consistency check

`.github/scripts/check-version.mjs` is run as the first step of the `release` job. It takes `tag_version` as input, checks all five project `package.json` files, reports every mismatch, and fails immediately if any disagree. This enforces the simplified release process:

**Before** (5 PRs): `version-RC` bump → validation → `version` bump → validation → `next-dev` bump  
**After** (3 steps): bump all `package.json` to release version → dispatch pipeline → bump to `next-dev`

### Security

- All secrets and user-supplied inputs pass through environment variables, never inline in shell expressions (injection prevention)
- `@vscode/vsce` and `ovsx` are invoked as locally installed devDependencies via `yarn workspace` — no `npx` on-demand fetching (resolves SonarCloud `javascript/package-manager-install` findings)

### Required secrets

Before the first publish run, two secrets must be configured in the repository:

- `VSCE_TOKEN` — VS Code Marketplace Personal Access Token
- `OVSX_TOKEN` — Open-VSX registry token

### Mapping from Jenkins

| Jenkins stage | GH Actions equivalent |
|---|---|
| Checkout + build requirements | `actions/checkout` + `kaoto-vscode-setup-tools` |
| `yarn build:prod` + unit tests | inline steps in `release` job |
| UI tests (Xvnc + OpenShift cluster) | optional `ui-tests` job with minikube |
| Package VSIX + SFTP staging | `build:vsix` + GitHub Release asset |
| Generate SBOM | `sbom:generate` (skipped for snapshots) |
| Manual approval gate (5-day) | removed — safe defaults + team triggers deliberately |
| Publish to marketplaces | `publish` job (`vsce` + `ovsx`) |
| SFTP stable promotion | removed — GitHub Release is canonical |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated release process for the VS Code extension.
  * Releases can be published to both the Visual Studio Code Marketplace and Open VSX.
  * Snapshot releases and downloadable VSIX packages are supported.
  * Standard releases include a software bill of materials.

* **Quality Improvements**
  * Added automated version consistency checks across project packages.
  * UI tests can validate different extension package files during releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->