### PR TITLE
Fix Nav tests to match single side nav Open Project link

### DIFF
--- a/packages/kaoto-web/src/components/Nav/Nav.scss
+++ b/packages/kaoto-web/src/components/Nav/Nav.scss
@@ -3,3 +3,7 @@
   inline-size: auto;
   display: block;
 }
+
+.cds--side-nav__header-navigation {
+  display: block;
+}

--- a/packages/kaoto-web/src/components/Nav/Nav.test.tsx
+++ b/packages/kaoto-web/src/components/Nav/Nav.test.tsx
@@ -40,18 +40,17 @@ describe('Nav', () => {
     expect(screen.getByRole('button', { name: /close menu/i })).toBeInTheDocument();
   });
 
-  it('renders the Open Project link in both the header and side nav', () => {
+  it('renders the Open Project link in the side nav', () => {
     renderNav();
-    const links = screen.getAllByRole('link', { name: /open project/i });
-    expect(links).toHaveLength(2);
-    links.forEach((link) => expect(link).toHaveAttribute('href', '/projects/project50'));
+    const link = screen.getByRole('link', { name: /open project/i });
+    expect(link).toHaveAttribute('href', '/projects/project50');
   });
 
   it('closes the side nav when the Open Project link in the side nav is clicked', async () => {
     renderNav();
     await userEvent.click(screen.getByRole('button', { name: /open menu/i }));
     expect(screen.getByRole('button', { name: /close menu/i })).toBeInTheDocument();
-    const [, sideNavLink] = screen.getAllByRole('link', { name: /open project/i });
+    const sideNavLink = screen.getByRole('link', { name: /open project/i });
     await userEvent.click(sideNavLink);
     expect(screen.getByRole('button', { name: /open menu/i })).toBeInTheDocument();
   });

--- a/packages/kaoto-web/src/components/Nav/Nav.tsx
+++ b/packages/kaoto-web/src/components/Nav/Nav.tsx
@@ -3,7 +3,6 @@ import {
   HeaderGlobalBar,
   HeaderMenuButton,
   HeaderMenuItem,
-  HeaderNavigation,
   HeaderSideNavItems,
   SideNav,
   SideNavItems,
@@ -48,12 +47,6 @@ export const Nav = () => {
         <RouterLink to="/" className="cds--header__name">
           <img src={logoKaoto} alt="Kaoto" className="cs--nav__logo" />
         </RouterLink>
-        <HeaderNavigation>
-          <HeaderMenuItem as={RouterLink} to={OPEN_PROJECT_PATH} isActive={location.pathname.startsWith('/projects/')}>
-            Open Project
-          </HeaderMenuItem>
-          <NavHeaderItems routesInHeader={routesInHeader} currentPath={location.pathname} />
-        </HeaderNavigation>
         <HeaderGlobalBar />
       </Header>
       <SideNav aria-label="Side navigation" expanded={isSideNavExpanded} isPersistent={false}>


### PR DESCRIPTION
## Summary

Removes the duplicate `Open Project` link that was rendered in the `HeaderNavigation` bar, keeping only the side nav link. Updates tests to expect a single link instead of two.

## Changes

- **`Nav.tsx`**: Remove `HeaderNavigation` block (and its `Open Project` `HeaderMenuItem`) from the header.
- **`Nav.scss`**: Add `.cds--side-nav__header-navigation { display: block }` to ensure the side nav item remains visible.
- **`Nav.test.tsx`**: Update tests to query a single `Open Project` link instead of two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the duplicate “Open Project” link and navigation items from the header, leaving them available in the side navigation.
  * Updated side-navigation behavior so its header navigation displays correctly.
* **Tests**
  * Updated navigation checks to reflect the single “Open Project” link and verify side-navigation closing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->