### PR TITLE
e2e: cypress 16 migration

### DIFF
--- a/packages/ui-tests/cypress/e2e/datamapper/json-to-json.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/json-to-json.ts
@@ -22,13 +22,13 @@ describe('Test for DataMapper : JSON to JSON', () => {
 
   it('attach schema, import mappings, select a mapping, export mappings and reset mappings', () => {
     cy.openDataMapper();
-    cy.attachTargetBodySchema('datamapper/jsonSchema/ShipOrder.schema.json');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/jsonSchema/ShipOrder.schema.json');
     cy.addParameter('Account');
-    cy.attachParameterSchema('Account', 'datamapper/jsonSchema/Account.schema.json');
+    cy.attachParameterSchema('Account', 'cypress/fixtures/datamapper/jsonSchema/Account.schema.json');
     cy.addParameter('Cart');
-    cy.attachParameterSchema('Cart', 'datamapper/jsonSchema/Cart.schema.json');
+    cy.attachParameterSchema('Cart', 'cypress/fixtures/datamapper/jsonSchema/Cart.schema.json');
     cy.addParameter('OrderSequence');
-    cy.importMappings('datamapper/xslt/ShipOrderJson.xsl');
+    cy.importMappings('cypress/fixtures/datamapper/xslt/ShipOrderJson.xsl');
 
     cy.get('[data-testid^="node-source-fj-string-AccountId"]').click({ force: true });
 
@@ -47,11 +47,11 @@ describe('Test for DataMapper : JSON to JSON', () => {
 
   it('Establish mappings by DnD', () => {
     cy.openDataMapper();
-    cy.attachTargetBodySchema('datamapper/jsonSchema/ShipOrder.schema.json');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/jsonSchema/ShipOrder.schema.json');
     cy.addParameter('Account');
-    cy.attachParameterSchema('Account', 'datamapper/jsonSchema/Account.schema.json');
+    cy.attachParameterSchema('Account', 'cypress/fixtures/datamapper/jsonSchema/Account.schema.json');
     cy.addParameter('Cart');
-    cy.attachParameterSchema('Cart', 'datamapper/jsonSchema/Cart.schema.json');
+    cy.attachParameterSchema('Cart', 'cypress/fixtures/datamapper/jsonSchema/Cart.schema.json');
     cy.addParameter('OrderSequence');
 
     cy.engageMapping(
@@ -124,9 +124,9 @@ describe('Test for DataMapper : JSON to JSON', () => {
 
   it('attach parameter schema, engage mappings, detach parameter schema', () => {
     cy.openDataMapper();
-    cy.attachTargetBodySchema('datamapper/jsonSchema/ShipOrder.schema.json');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/jsonSchema/ShipOrder.schema.json');
     cy.addParameter('Account');
-    cy.attachParameterSchema('Account', 'datamapper/jsonSchema/Account.schema.json');
+    cy.attachParameterSchema('Account', 'cypress/fixtures/datamapper/jsonSchema/Account.schema.json');
 
     cy.engageMapping(
       ['document-doc-param-Account', 'node-source-fj-string-AccountId'],
@@ -188,8 +188,8 @@ describe('Test for DataMapper : JSON to JSON', () => {
     cy.selectIntegrationRuntime(catalogLabel);
     cy.openDesignPage();
     cy.openDataMapper();
-    cy.attachSourceBodySchema('datamapper/jsonSchema/ShipOrder.schema.json');
-    cy.attachTargetBodySchema('datamapper/jsonSchema/ShipOrder.schema.json');
+    cy.attachSourceBodySchema('cypress/fixtures/datamapper/jsonSchema/ShipOrder.schema.json');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/jsonSchema/ShipOrder.schema.json');
 
     cy.engageMapping(
       ['document-doc-sourceBody-Body', 'node-source-fj-string-OrderPerson'],
@@ -201,9 +201,9 @@ describe('Test for DataMapper : JSON to JSON', () => {
 
   it('attach parameter schema, engage mappings, delete parameter', () => {
     cy.openDataMapper();
-    cy.attachTargetBodySchema('datamapper/jsonSchema/ShipOrder.schema.json');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/jsonSchema/ShipOrder.schema.json');
     cy.addParameter('Account');
-    cy.attachParameterSchema('Account', 'datamapper/jsonSchema/Account.schema.json');
+    cy.attachParameterSchema('Account', 'cypress/fixtures/datamapper/jsonSchema/Account.schema.json');
 
     cy.engageMapping(
       ['document-doc-param-Account', 'node-source-fj-string-AccountId'],

--- a/packages/ui-tests/cypress/e2e/datamapper/multischema.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/multischema.ts
@@ -6,12 +6,12 @@ describe('Test for DataMapper : multiple schemas', () => {
   it('Datamapper - multiple schema', () => {
     cy.openDataMapper();
     cy.attachTargetBodySchema([
-      'datamapper/xsd/MultiIncludeMain.xsd',
-      'datamapper/xsd/MultiIncludeComponentA.xsd',
-      'datamapper/xsd/MultiIncludeComponentB.xsd',
+      'cypress/fixtures/datamapper/xsd/MultiIncludeMain.xsd',
+      'cypress/fixtures/datamapper/xsd/MultiIncludeComponentA.xsd',
+      'cypress/fixtures/datamapper/xsd/MultiIncludeComponentB.xsd',
     ]);
 
-    cy.attachSourceBodySchema('datamapper/xsd/Cart.xsd');
+    cy.attachSourceBodySchema('cypress/fixtures/datamapper/xsd/Cart.xsd');
 
     cy.engageMapping(
       ['document-doc-sourceBody-Body', 'node-source-fx-Title'],
@@ -38,7 +38,7 @@ describe('Test for DataMapper : multiple schemas', () => {
 
   it('Datamapper - multiple schema, missing required schemas', () => {
     cy.openDataMapper();
-    cy.addTargetBodySchema(['datamapper/xsd/MultiIncludeMain.xsd']);
+    cy.addTargetBodySchema(['cypress/fixtures/datamapper/xsd/MultiIncludeMain.xsd']);
 
     cy.get('[data-testid="attach-schema-modal"]')
       .should('be.visible')

--- a/packages/ui-tests/cypress/e2e/datamapper/xml-to-xml.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/xml-to-xml.ts
@@ -5,11 +5,11 @@ describe('Test for DataMapper : XML to XML', () => {
 
   it('attach schema, import mappings, select a mapping, export mappings and reset mappings', () => {
     cy.openDataMapper();
-    cy.attachSourceBodySchema('datamapper/xsd/ShipOrder.xsd');
-    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
+    cy.attachSourceBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
     cy.addParameter('Account');
-    cy.attachParameterSchema('Account', 'datamapper/xsd/Account.xsd');
-    cy.importMappings('datamapper/xslt/ShipOrderToShipOrder.xsl');
+    cy.attachParameterSchema('Account', 'cypress/fixtures/datamapper/xsd/Account.xsd');
+    cy.importMappings('cypress/fixtures/datamapper/xslt/ShipOrderToShipOrder.xsl');
 
     cy.get('[data-testid^="node-source-fx-OrderId"]').click({ force: true });
 
@@ -28,10 +28,10 @@ describe('Test for DataMapper : XML to XML', () => {
 
   it('Establish mappings by DnD', () => {
     cy.openDataMapper();
-    cy.attachSourceBodySchema('datamapper/xsd/Cart.xsd');
-    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
+    cy.attachSourceBodySchema('cypress/fixtures/datamapper/xsd/Cart.xsd');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
     cy.addParameter('Account');
-    cy.attachParameterSchema('Account', 'datamapper/xsd/Account.xsd');
+    cy.attachParameterSchema('Account', 'cypress/fixtures/datamapper/xsd/Account.xsd');
 
     cy.engageMapping(
       ['document-doc-param-Account', 'node-source-fx-AccountId'],
@@ -96,9 +96,9 @@ describe('Test for DataMapper : XML to XML', () => {
 
   it('attach parameter schema, engage mappings, detach parameter schema', () => {
     cy.openDataMapper();
-    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
     cy.addParameter('Account');
-    cy.attachParameterSchema('Account', 'datamapper/xsd/Account.xsd');
+    cy.attachParameterSchema('Account', 'cypress/fixtures/datamapper/xsd/Account.xsd');
 
     cy.engageMapping(
       ['document-doc-param-Account', 'node-source-fx-AccountId'],
@@ -135,9 +135,9 @@ describe('Test for DataMapper : XML to XML', () => {
 
   it('attach parameter schema, engage mappings, delete parameter', () => {
     cy.openDataMapper();
-    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
     cy.addParameter('Account');
-    cy.attachParameterSchema('Account', 'datamapper/xsd/Account.xsd');
+    cy.attachParameterSchema('Account', 'cypress/fixtures/datamapper/xsd/Account.xsd');
 
     cy.engageMapping(
       ['document-doc-param-Account', 'node-source-fx-AccountId'],
@@ -174,9 +174,9 @@ describe('Test for DataMapper : XML to XML', () => {
 
   it('import mappings with XPath if-else expression', () => {
     cy.openDataMapper();
-    cy.attachSourceBodySchema('datamapper/xsd/ShipOrder.xsd');
-    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
-    cy.importMappings('datamapper/xslt/ShipOrderWithIfElse.xsl');
+    cy.attachSourceBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
+    cy.importMappings('cypress/fixtures/datamapper/xslt/ShipOrderWithIfElse.xsl');
 
     cy.get('[data-testid^="node-source-fx-OrderPerson"]').should('exist');
     cy.get('[data-testid^="node-target-fx-OrderPerson"]').should('exist');
@@ -191,9 +191,9 @@ describe('Test for DataMapper : XML to XML', () => {
 
   it('import mappings with XPath arithmetic and logical operators', () => {
     cy.openDataMapper();
-    cy.attachSourceBodySchema('datamapper/xsd/ShipOrder.xsd');
-    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
-    cy.importMappings('datamapper/xslt/ShipOrderWithOperators.xsl');
+    cy.attachSourceBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
+    cy.importMappings('cypress/fixtures/datamapper/xslt/ShipOrderWithOperators.xsl');
 
     // Verify that fields used in operators are present
     cy.get('[data-testid^="node-source-fx-OrderPerson"]').should('exist');

--- a/packages/ui-tests/cypress/e2e/datamapper/xpath-editor.cy.ts
+++ b/packages/ui-tests/cypress/e2e/datamapper/xpath-editor.cy.ts
@@ -5,10 +5,10 @@ describe('Test for DataMapper : XPath Editor', () => {
     cy.openHomePage();
     cy.openDataMapper();
     // Use ShipOrder → ShipOrder as a symmetric source/target so all fields are available
-    cy.attachSourceBodySchema('datamapper/xsd/ShipOrder.xsd');
-    cy.attachTargetBodySchema('datamapper/xsd/ShipOrder.xsd');
+    cy.attachSourceBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
+    cy.attachTargetBodySchema('cypress/fixtures/datamapper/xsd/ShipOrder.xsd');
     // Import an existing XSLT mapping so fields already have XPath expressions to edit
-    cy.importMappings('datamapper/xslt/ShipOrderToShipOrder.xsl');
+    cy.importMappings('cypress/fixtures/datamapper/xslt/ShipOrderToShipOrder.xsl');
   });
 
   it('open XPath Editor via fx button and close it → modal opens and closes correctly', () => {

--- a/packages/ui-tests/cypress/e2e/xmlSupport/basicXml.cy.ts
+++ b/packages/ui-tests/cypress/e2e/xmlSupport/basicXml.cy.ts
@@ -50,7 +50,7 @@ describe('Tests for basic XML operations', () => {
     cy.openStepConfigurationTab('setHeader');
     cy.selectFormTab('All');
     cy.selectExpression('Simple');
-    cy.interactWithExpressionInputObject('simple.expression', `{{}{{}header.baz}}`);
+    cy.interactWithExpressionInputObject('simple.expression', `{{}{{}header.baz}}`, { delay: 50 });
     cy.interactWithExpressionInputObject('simple.id', 'simpleExpressionId');
     cy.interactWithExpressionInputObject('simple.resultType', 'java.lang.String');
 

--- a/packages/ui-tests/cypress/support/e2e.ts
+++ b/packages/ui-tests/cypress/support/e2e.ts
@@ -21,7 +21,7 @@ import './next-commands/design';
 import './next-commands/metadata';
 import './next-commands/datamapper';
 
-import registerCypressGrep from '@cypress/grep/src/support';
+import { register as registerCypressGrep } from '@cypress/grep';
 registerCypressGrep();
 
 Cypress.on('uncaught:exception', (_err, _runnable) => {

--- a/packages/ui-tests/cypress/support/next-commands/datamapper.ts
+++ b/packages/ui-tests/cypress/support/next-commands/datamapper.ts
@@ -4,7 +4,7 @@ Cypress.Commands.add('attachSourceBodySchema', (filePath: string) => {
     cy.get('[data-testid="attach-schema-modal-option-json"]').click();
   }
   cy.get('[data-testid="attach-schema-modal-btn-file"]').click();
-  cy.get('[data-testid="attach-schema-file-input"]').attachFile(filePath);
+  cy.get('[data-testid="attach-schema-file-input"]').selectFile(filePath, { force: true });
   cy.get('[data-testid="attach-schema-file-list"]').should('exist');
   cy.get('[data-testid="attach-schema-modal-btn-attach"]').click();
   // Verify schema was attached by checking for child nodes in source body
@@ -32,8 +32,7 @@ Cypress.Commands.add('addTargetBodySchema', (filePath: string | string[]) => {
   cy.get('[data-testid="attach-schema-modal-btn-file"]').click();
 
   // Attach each file
-  cy.get('[data-testid="attach-schema-file-input"]').attachFile(filePaths);
-
+  cy.get('[data-testid="attach-schema-file-input"]').selectFile(filePaths, { force: true });
   cy.get('[data-testid="attach-schema-file-list"]').should('exist');
 
   // Check file type based on the first file
@@ -64,7 +63,7 @@ Cypress.Commands.add('attachParameterSchema', (name: string, filePath: string) =
     cy.get('[data-testid="attach-schema-modal-option-json"]').click();
   }
   cy.get('[data-testid="attach-schema-modal-btn-file"]').click();
-  cy.get('[data-testid="attach-schema-file-input"]').attachFile(filePath);
+  cy.get('[data-testid="attach-schema-file-input"]').selectFile(filePath, { force: true });
 
   cy.get('[data-testid="attach-schema-file-list"]').should('exist');
   if (filePath.endsWith('json')) {
@@ -88,7 +87,7 @@ Cypress.Commands.add('detachParameterSchema', (name: string) => {
 Cypress.Commands.add('importMappings', (filePath: string) => {
   cy.get('[data-testid="dm-debug-main-menu-button"]').click();
   cy.get('[data-testid="dm-debug-import-mappings-button"]').click();
-  cy.get('[data-testid="dm-debug-import-mappings-file-input"]').attachFile(filePath);
+  cy.get('[data-testid="dm-debug-import-mappings-file-input"]').selectFile(filePath, { force: true });
 });
 
 Cypress.Commands.add('exportMappings', () => {

--- a/packages/ui-tests/package.json
+++ b/packages/ui-tests/package.json
@@ -23,7 +23,7 @@
     "chromatic": "chromatic --build-script-name 'build:storybook' --exit-zero-on-changes --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "devDependencies": {
-    "@cypress/grep": "^4.1.0",
+    "@cypress/grep": "^7.0.0",
     "@eslint/js": "^9.10.0",
     "@storybook/addon-docs": "^10.2.14",
     "@storybook/addon-links": "^10.2.14",
@@ -32,7 +32,7 @@
     "@storybook/testing-library": "^0.2.2",
     "@types/eslint__js": "^8.42.3",
     "chromatic": "^11.0.0",
-    "cypress": "^14.3.3",
+    "cypress": "^16.0.0",
     "cypress-file-upload": "^5.0.8",
     "cypress-real-events": "^1.15.0",
     "eslint": "^9.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1902,22 +1902,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cypress/grep@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "@cypress/grep@npm:4.1.1"
+"@cypress/grep@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@cypress/grep@npm:7.0.0"
   dependencies:
     debug: "npm:^4.3.4"
     find-test-names: "npm:^1.28.18"
     globby: "npm:^11.0.4"
   peerDependencies:
-    cypress: ">=10"
-  checksum: 10/3d0d01a9c014c51cd0d289a0235540f754b8426cbef3a85bd206adfb5b5b23f4f77e0ec497477e7b091b75ba9f4f040046dd35a358fb2c1a95f73ef535d61d41
+    cypress: ">=15.10.0"
+  checksum: 10/7c612610fd2ca79ef278e1269a9d4dcecd15d7dd7bf59dd124fc6847b0f67bf007d373e30094fe7113b772bbf65bf5f4d0b7f78c3649740d8217511adaafe3af
   languageName: node
   linkType: hard
 
-"@cypress/request@npm:^3.0.9":
-  version: 3.0.9
-  resolution: "@cypress/request@npm:3.0.9"
+"@cypress/request@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@cypress/request@npm:4.0.1"
   dependencies:
     aws-sign2: "npm:~0.7.0"
     aws4: "npm:^1.8.0"
@@ -1932,12 +1932,11 @@ __metadata:
     json-stringify-safe: "npm:~5.0.1"
     mime-types: "npm:~2.1.19"
     performance-now: "npm:^2.1.0"
-    qs: "npm:6.14.0"
+    qs: "npm:^6.15.2"
     safe-buffer: "npm:^5.1.2"
     tough-cookie: "npm:^5.0.0"
     tunnel-agent: "npm:^0.6.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10/735bd15b9bfb2ac950f4ca715c4ea944c3686fab5f48649c6f6ce62e5d2186df51a96c22fb6e4839dc5d16033ceeece03ca9fa621c9232fb96ad567846a4158c
+  checksum: 10/7facc78b2940f5f7d12bc1f31c07fbf78bb71ce32c304551fccd265c77f564f093c3a1dd871048d744525f84013ae291de7654c93ffcbec54cab2a0b15e0d20f
   languageName: node
   linkType: hard
 
@@ -3921,7 +3920,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kaoto/kaoto-tests@workspace:packages/ui-tests"
   dependencies:
-    "@cypress/grep": "npm:^4.1.0"
+    "@cypress/grep": "npm:^7.0.0"
     "@eslint/js": "npm:^9.10.0"
     "@kaoto/camel-catalog": "npm:^0.9.11"
     "@kaoto/forms": "npm:^1.8.0"
@@ -3933,7 +3932,7 @@ __metadata:
     "@storybook/testing-library": "npm:^0.2.2"
     "@types/eslint__js": "npm:^8.42.3"
     chromatic: "npm:^11.0.0"
-    cypress: "npm:^14.3.3"
+    cypress: "npm:^16.0.0"
     cypress-file-upload: "npm:^5.0.8"
     cypress-real-events: "npm:^1.15.0"
     eslint: "npm:^9.10.0"
@@ -8063,6 +8062,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/tmp@npm:^0.2.3":
+  version: 0.2.6
+  resolution: "@types/tmp@npm:0.2.6"
+  checksum: 10/e14a094c10569d3b56805552b21417860ef21060d969000d5d5b53604a78c2bdac216f064b03797d4b07a081e0141dd3ab22bc36923e75300eb1c023f7252cc7
+  languageName: node
+  linkType: hard
+
 "@types/tough-cookie@npm:*":
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
@@ -8164,15 +8170,6 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "npm:*"
   checksum: 10/47bcd4476a4194ea11617ea71cba8a1eddf5505fc39c44336c1a08d452a0de4486aedbc13f47a017c8efbcb5a8aa358d976880663732ebcbc6dbcbbecadb0581
-  languageName: node
-  linkType: hard
-
-"@types/yauzl@npm:^2.9.1":
-  version: 2.10.3
-  resolution: "@types/yauzl@npm:2.10.3"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10/5ee966ea7bd6b2802f31ad4281c92c4c0b6dfa593c378a2582c58541fa113bec3d70eb0696b34ad95e8e6861a884cba6c3e351285816693ed176222f840a8c08
   languageName: node
   linkType: hard
 
@@ -9760,14 +9757,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:^4.1.1":
-  version: 4.1.3
-  resolution: "ansi-colors@npm:4.1.3"
-  checksum: 10/43d6e2fc7b1c6e4dc373de708ee76311ec2e0433e7e8bd3194e7ff123ea6a747428fc61afdcf5969da5be3a5f0fd054602bec56fc0ebe249ce2fcde6e649e3c2
-  languageName: node
-  linkType: hard
-
-"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.0, ansi-escapes@npm:^4.3.2":
+"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.2":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
@@ -9838,6 +9828,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^6.2.3":
+  version: 6.2.3
+  resolution: "ansi-styles@npm:6.2.3"
+  checksum: 10/c49dad7639f3e48859bd51824c93b9eb0db628afc243c51c3dd2410c4a15ede1a83881c6c7341aa2b159c4f90c11befb38f2ba848c07c66c9f9de4bcd7cb9f30
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^3.0.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
@@ -9862,10 +9859,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arch@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "arch@npm:2.2.0"
-  checksum: 10/e35dbc6d362297000ab90930069576ba165fe63cd52383efcce14bd66c1b16a91ce849e1fd239964ed029d5e0bdfc32f68e9c7331b7df6c84ddebebfdbf242f7
+"arch@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "arch@npm:3.0.0"
+  checksum: 10/9af0c58900980c300737945881859df6dd2a4e4d07f697c77704a7ba85a701aa60aa7c3a3ce1eb57ef76fda726ebccf1e2a9ddd763c89fe82c961d55b4b9c374
   languageName: node
   linkType: hard
 
@@ -10934,7 +10931,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cachedir@npm:^2.3.0":
+"cachedir@npm:^2.4.0":
   version: 2.4.0
   resolution: "cachedir@npm:2.4.0"
   checksum: 10/43198514eaa61f65b5535ed29ad651f22836fba3868ed58a6a87731f05462f317d39098fa3ac778801c25455483c9b7f32a2fcad1f690a978947431f12a0f4d0
@@ -11163,7 +11160,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"check-more-types@npm:2.24.0, check-more-types@npm:^2.24.0":
+"check-more-types@npm:2.24.0":
   version: 2.24.0
   resolution: "check-more-types@npm:2.24.0"
   checksum: 10/67c5288443bd73a81638e1185f8c5410d0edf6458c086149ef1cda95c07535b5dd5c11c426dc3ee8f0de0f3244aa2d4f2ba1937aaa8a94995589cdcce0bbccb9
@@ -11294,6 +11291,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chrome-remote-interface@npm:0.33.3":
+  version: 0.33.3
+  resolution: "chrome-remote-interface@npm:0.33.3"
+  dependencies:
+    commander: "npm:2.11.x"
+    ws: "npm:^7.2.0"
+  bin:
+    chrome-remote-interface: bin/client.js
+  checksum: 10/65d07afc8f97fad6326bd94f0c4ef004d76b16841015c72d09aefbfa4df62b47407067a01c886535a706c36b23070b40fc3edb96444665438efa1d4f65cc3db8
+  languageName: node
+  linkType: hard
+
 "chrome-trace-event@npm:^1.0.2":
   version: 1.0.4
   resolution: "chrome-trace-event@npm:1.0.4"
@@ -11371,15 +11380,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "cli-cursor@npm:3.1.0"
-  dependencies:
-    restore-cursor: "npm:^3.1.0"
-  checksum: 10/2692784c6cd2fd85cfdbd11f53aea73a463a6d64a77c3e098b2b4697a20443f430c220629e1ca3b195ea5ac4a97a74c2ee411f3807abf6df2b66211fec0c0a29
-  languageName: node
-  linkType: hard
-
 "cli-cursor@npm:^5.0.0":
   version: 5.0.0
   resolution: "cli-cursor@npm:5.0.0"
@@ -11409,16 +11409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-truncate@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "cli-truncate@npm:2.1.0"
-  dependencies:
-    slice-ansi: "npm:^3.0.0"
-    string-width: "npm:^4.2.0"
-  checksum: 10/976f1887de067a8cd6ec830a7a8508336aebe6cec79b521d98ed13f67ef073b637f7305675b6247dd22f9e9cf045ec55fe746c7bdb288fbe8db0dfdc9fd52e55
-  languageName: node
-  linkType: hard
-
 "cli-truncate@npm:^4.0.0":
   version: 4.0.0
   resolution: "cli-truncate@npm:4.0.0"
@@ -11426,6 +11416,16 @@ __metadata:
     slice-ansi: "npm:^5.0.0"
     string-width: "npm:^7.0.0"
   checksum: 10/d5149175fd25ca985731bdeec46a55ec237475cf74c1a5e103baea696aceb45e372ac4acbaabf1316f06bd62e348123060f8191ffadfeedebd2a70a2a7fb199d
+  languageName: node
+  linkType: hard
+
+"cli-truncate@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "cli-truncate@npm:5.2.0"
+  dependencies:
+    slice-ansi: "npm:^8.0.0"
+    string-width: "npm:^8.2.0"
+  checksum: 10/b789b6c2caff1560259aedeb6aaafcf41167d478df418d718a8c92edd6bc5a0ece272b8fb7e7911fbd31cef7b1ac8a30f2b21d90c3174b55a018fe3f2604a137
   languageName: node
   linkType: hard
 
@@ -11606,7 +11606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.16, colorette@npm:^2.0.20":
+"colorette@npm:^2.0.20":
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 10/0b8de48bfa5d10afc160b8eaa2b9938f34a892530b2f7d7897e0458d9535a066e3998b49da9d21161c78225b272df19ae3a64d6df28b4c9734c0e55bbd02406f
@@ -11650,6 +11650,13 @@ __metadata:
   version: 2.0.3
   resolution: "comma-separated-tokens@npm:2.0.3"
   checksum: 10/e3bf9e0332a5c45f49b90e79bcdb4a7a85f28d6a6f0876a94f1bb9b2bfbdbbb9292aac50e1e742d8c0db1e62a0229a106f57917e2d067fca951d81737651700d
+  languageName: node
+  linkType: hard
+
+"commander@npm:2.11.x":
+  version: 2.11.0
+  resolution: "commander@npm:2.11.0"
+  checksum: 10/d8940de4ce2886aa32ae27a1533d10ce46da8c6dcd965075462a6b8d17b01f596ec329e1430f84a123e52675403f0c2b11a6a5d144eb46146da9ae974edbc2c0
   languageName: node
   linkType: hard
 
@@ -12263,41 +12270,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:^14.3.3":
-  version: 14.5.4
-  resolution: "cypress@npm:14.5.4"
+"cypress@npm:^16.0.0":
+  version: 16.0.0
+  resolution: "cypress@npm:16.0.0"
   dependencies:
-    "@cypress/request": "npm:^3.0.9"
+    "@cypress/request": "npm:^4.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
     "@types/sinonjs__fake-timers": "npm:8.1.1"
     "@types/sizzle": "npm:^2.3.2"
-    arch: "npm:^2.2.0"
+    "@types/tmp": "npm:^0.2.3"
+    arch: "npm:^3.0.0"
     blob-util: "npm:^2.0.2"
     bluebird: "npm:^3.7.2"
     buffer: "npm:^5.7.1"
-    cachedir: "npm:^2.3.0"
+    cachedir: "npm:^2.4.0"
     chalk: "npm:^4.1.0"
-    check-more-types: "npm:^2.24.0"
+    chrome-remote-interface: "npm:0.33.3"
     ci-info: "npm:^4.1.0"
-    cli-cursor: "npm:^3.1.0"
     cli-table3: "npm:0.6.1"
     commander: "npm:^6.2.1"
     common-tags: "npm:^1.8.0"
-    dayjs: "npm:^1.10.4"
+    dayjs: "npm:^1.11.23"
     debug: "npm:^4.3.4"
-    enquirer: "npm:^2.3.6"
     eventemitter2: "npm:6.4.7"
     execa: "npm:4.1.0"
     executable: "npm:^4.1.1"
-    extract-zip: "npm:2.0.1"
-    figures: "npm:^3.2.0"
     fs-extra: "npm:^9.1.0"
-    getos: "npm:^3.2.1"
     hasha: "npm:5.2.2"
     is-installed-globally: "npm:~0.4.0"
-    lazy-ass: "npm:^1.6.0"
-    listr2: "npm:^3.8.3"
-    lodash: "npm:^4.17.21"
+    listr2: "npm:^9.0.5"
+    lodash: "npm:^4.17.23"
     log-symbols: "npm:^4.0.0"
     minimist: "npm:^1.2.8"
     ospath: "npm:^1.2.2"
@@ -12305,15 +12307,15 @@ __metadata:
     process: "npm:^0.11.10"
     proxy-from-env: "npm:1.0.0"
     request-progress: "npm:^3.0.0"
-    semver: "npm:^7.7.1"
     supports-color: "npm:^8.1.1"
-    tmp: "npm:~0.2.3"
+    systeminformation: "npm:^5.31.1"
+    tmp: "npm:~0.2.4"
     tree-kill: "npm:1.2.2"
     untildify: "npm:^4.0.0"
-    yauzl: "npm:^2.10.0"
+    yauzl: "npm:^3.3.1"
   bin:
     cypress: bin/cypress
-  checksum: 10/7ddd789f58c633c75181d31dedf75056910dea146b093d4d935802cb17924648a0b7a6f736cb484baf75c105df6c9fbaa54780ed328a98ff2e114d8abcea4168
+  checksum: 10/6d20f74df488647be466d90b21c1d6ed10b91e9ea5a0ab538d9ecd52a6318099720c468234fc4fe48cba1a7807d1d55e108e9f9522886af297ea6671e6b35b52
   languageName: node
   linkType: hard
 
@@ -12802,10 +12804,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.10.4":
-  version: 1.11.11
-  resolution: "dayjs@npm:1.11.11"
-  checksum: 10/f03948b172fbeed229837965988d1d5bac99c72a31c28731a457303259439f2f36289186489ae140adbeb10f591a926908c8de5d81eb449a2edbf5cbd6e9e30c
+"dayjs@npm:^1.11.23":
+  version: 1.11.23
+  resolution: "dayjs@npm:1.11.23"
+  checksum: 10/61d29544ca1553369f75541b5abf9c1bb6a978991498923a2d5721c9df3eca513b2c15ff5534de6930dc553de5d6f2b8f8047149f3528df906b21f51df637463
   languageName: node
   linkType: hard
 
@@ -13681,16 +13683,6 @@ __metadata:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.3.3"
   checksum: 10/a804e28990c151523a27750df06b27768e1f3b39a1138ec110d012be22177e647100a3a3345faa5e91951ad7866bfaa03c454fe267e002f361bde3601cb639a8
-  languageName: node
-  linkType: hard
-
-"enquirer@npm:^2.3.6":
-  version: 2.4.1
-  resolution: "enquirer@npm:2.4.1"
-  dependencies:
-    ansi-colors: "npm:^4.1.1"
-    strip-ansi: "npm:^6.0.1"
-  checksum: 10/b3726486cd98f0d458a851a03326a2a5dd4d84f37ff94ff2a2960c915e0fc865865da3b78f0877dc36ac5c1189069eca603e82ec63d5bc6b0dd9985bf6426d7a
   languageName: node
   linkType: hard
 
@@ -15117,23 +15109,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:2.0.1":
-  version: 2.0.1
-  resolution: "extract-zip@npm:2.0.1"
-  dependencies:
-    "@types/yauzl": "npm:^2.9.1"
-    debug: "npm:^4.1.1"
-    get-stream: "npm:^5.1.0"
-    yauzl: "npm:^2.10.0"
-  dependenciesMeta:
-    "@types/yauzl":
-      optional: true
-  bin:
-    extract-zip: cli.js
-  checksum: 10/8cbda9debdd6d6980819cc69734d874ddd71051c9fe5bde1ef307ebcedfe949ba57b004894b585f758b7c9eeeea0e3d87f2dda89b7d25320459c2c9643ebb635
-  languageName: node
-  linkType: hard
-
 "extsprintf@npm:1.3.0":
   version: 1.3.0
   resolution: "extsprintf@npm:1.3.0"
@@ -15313,15 +15288,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10/db3e34fa483b5873b73f248e818f8a8b59a6427fd8b1436cd439c195fdf11e8659419404826059a642b57d18075c856d06d6a50a1413b714f12f833a9341ead3
-  languageName: node
-  linkType: hard
-
 "fdir@npm:^6.4.3":
   version: 6.4.3
   resolution: "fdir@npm:6.4.3"
@@ -15343,15 +15309,6 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10/14ca1c9f0a0e8f4f2e9bf4e8551065a164a09545dae548c12a18d238b72e51e5a7b39bd8e5494b56463a0877672d0a6c1ef62c6fa0677db1b0c847773be939b1
-  languageName: node
-  linkType: hard
-
-"figures@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "figures@npm:3.2.0"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.5"
-  checksum: 10/a3bf94e001be51d3770500789157f067218d4bc681a65e1f69d482de15120bcac822dceb1a7b3803f32e4e3a61a46df44f7f2c8ba95d6375e7491502e0dd3d97
   languageName: node
   linkType: hard
 
@@ -15914,7 +15871,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-east-asian-width@npm:^1.5.0":
+"get-east-asian-width@npm:^1.3.1, get-east-asian-width@npm:^1.5.0":
   version: 1.6.0
   resolution: "get-east-asian-width@npm:1.6.0"
   checksum: 10/3e5370b5df1f0020db711d8a3f9ee2cbfc9c7542daa99a699e9d7b9acf66e7868b89084741565a45d30d80afedf6e1218e0fb8bef7a583924a449c2816777380
@@ -16011,7 +15968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.0.0, get-stream@npm:^5.1.0":
+"get-stream@npm:^5.0.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
@@ -17487,6 +17444,15 @@ __metadata:
   dependencies:
     get-east-asian-width: "npm:^1.0.0"
   checksum: 10/8dfb2d2831b9e87983c136f5c335cd9d14c1402973e357a8ff057904612ed84b8cba196319fabedf9aefe4639e14fe3afe9d9966d1d006ebeb40fe1fed4babe5
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "is-fullwidth-code-point@npm:5.1.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.3.1"
+  checksum: 10/4700d8a82cb71bd2a2955587b2823c36dc4660eadd4047bfbd070821ddbce8504fc5f9b28725567ecddf405b1e06c6692c9b719f65df6af9ec5262bc11393a6a
   languageName: node
   linkType: hard
 
@@ -19176,7 +19142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lazy-ass@npm:1.6.0, lazy-ass@npm:^1.6.0":
+"lazy-ass@npm:1.6.0":
   version: 1.6.0
   resolution: "lazy-ass@npm:1.6.0"
   checksum: 10/3969ebef060b6f665fc78310ec769f7d2945db2d5af2b6663eda1bc9ec45c845deba9c4a3f75f124ce2c76fedf56514a063ee5c2affc8bc94963fbbddb442a88
@@ -19414,27 +19380,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"listr2@npm:^3.8.3":
-  version: 3.14.0
-  resolution: "listr2@npm:3.14.0"
-  dependencies:
-    cli-truncate: "npm:^2.1.0"
-    colorette: "npm:^2.0.16"
-    log-update: "npm:^4.0.0"
-    p-map: "npm:^4.0.0"
-    rfdc: "npm:^1.3.0"
-    rxjs: "npm:^7.5.1"
-    through: "npm:^2.3.8"
-    wrap-ansi: "npm:^7.0.0"
-  peerDependencies:
-    enquirer: ">= 2.3.0 < 3"
-  peerDependenciesMeta:
-    enquirer:
-      optional: true
-  checksum: 10/cebbd692330279ea82f05468cbb0a16f5b40015a6163e0a2fb04ef168da8e2d6c54e129148e90112d92e7f9ecb85a56e6b88d867a58a8ebdf36e0c98df49ae5c
-  languageName: node
-  linkType: hard
-
 "listr2@npm:^8.2.5":
   version: 8.3.3
   resolution: "listr2@npm:8.3.3"
@@ -19446,6 +19391,20 @@ __metadata:
     rfdc: "npm:^1.4.1"
     wrap-ansi: "npm:^9.0.0"
   checksum: 10/92f1bb60e9a0f4fed9bff89fbab49d80fc889d29cf47c0a612f5a62a036dead49d3f697d3a79e36984768529bd3bfacb3343859eafceba179a8e66c034d99300
+  languageName: node
+  linkType: hard
+
+"listr2@npm:^9.0.5":
+  version: 9.0.5
+  resolution: "listr2@npm:9.0.5"
+  dependencies:
+    cli-truncate: "npm:^5.0.0"
+    colorette: "npm:^2.0.20"
+    eventemitter3: "npm:^5.0.1"
+    log-update: "npm:^6.1.0"
+    rfdc: "npm:^1.4.1"
+    wrap-ansi: "npm:^9.0.0"
+  checksum: 10/b78ffd60443aed9a8e0fc9162eb941ea4d63210700d61a895eb29348f23fc668327e26bbca87a9e6a6208e7fa96c475fe1f1c6c19b46f376f547e0cba3b935ae
   languageName: node
   linkType: hard
 
@@ -19585,7 +19544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.18.1, lodash@npm:~4.18.1":
+"lodash@npm:^4.17.23, lodash@npm:^4.18.1, lodash@npm:~4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
@@ -19609,18 +19568,6 @@ __metadata:
     chalk: "npm:^5.3.0"
     is-unicode-supported: "npm:^1.3.0"
   checksum: 10/510cdda36700cbcd87a2a691ea08d310a6c6b449084018f7f2ec4f732ca5e51b301ff1327aadd96f53c08318e616276c65f7fe22f2a16704fb0715d788bc3c33
-  languageName: node
-  linkType: hard
-
-"log-update@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "log-update@npm:4.0.0"
-  dependencies:
-    ansi-escapes: "npm:^4.3.0"
-    cli-cursor: "npm:^3.1.0"
-    slice-ansi: "npm:^4.0.0"
-    wrap-ansi: "npm:^6.2.0"
-  checksum: 10/ae2f85bbabc1906034154fb7d4c4477c79b3e703d22d78adee8b3862fa913942772e7fa11713e3d96fb46de4e3cabefbf5d0a544344f03b58d3c4bff52aa9eb2
   languageName: node
   linkType: hard
 
@@ -23213,15 +23160,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.14.0":
-  version: 6.14.0
-  resolution: "qs@npm:6.14.0"
-  dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10/a60e49bbd51c935a8a4759e7505677b122e23bf392d6535b8fc31c1e447acba2c901235ecb192764013cd2781723dc1f61978b5fdd93cc31d7043d31cdc01974
-  languageName: node
-  linkType: hard
-
 "qs@npm:^6.10.0, qs@npm:^6.10.5":
   version: 6.12.1
   resolution: "qs@npm:6.12.1"
@@ -24056,16 +23994,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"restore-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "restore-cursor@npm:3.1.0"
-  dependencies:
-    onetime: "npm:^5.1.0"
-    signal-exit: "npm:^3.0.2"
-  checksum: 10/f877dd8741796b909f2a82454ec111afb84eb45890eb49ac947d87991379406b3b83ff9673a46012fca0d7844bb989f45cc5b788254cf1a39b6b5a9659de0630
-  languageName: node
-  linkType: hard
-
 "restore-cursor@npm:^5.0.0":
   version: 5.1.0
   resolution: "restore-cursor@npm:5.1.0"
@@ -24111,7 +24039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rfdc@npm:^1.3.0, rfdc@npm:^1.4.1":
+"rfdc@npm:^1.4.1":
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 10/2f3d11d3d8929b4bfeefc9acb03aae90f971401de0add5ae6c5e38fec14f0405e6a4aad8fdb76344bfdd20c5193110e3750cbbd28ba86d73729d222b6cf4a729
@@ -24372,7 +24300,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.4.0, rxjs@npm:^7.5.1":
+"rxjs@npm:^7.4.0":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:
@@ -24811,15 +24739,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.7.1":
-  version: 7.7.1
-  resolution: "semver@npm:7.7.1"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/4cfa1eb91ef3751e20fc52e47a935a0118d56d6f15a837ab814da0c150778ba2ca4f1a4d9068b33070ea4273629e615066664c2cfcd7c272caf7a8a0f6518b2c
-  languageName: node
-  linkType: hard
-
 "semver@npm:^7.7.3, semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
@@ -25201,17 +25120,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"slice-ansi@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "slice-ansi@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    astral-regex: "npm:^2.0.0"
-    is-fullwidth-code-point: "npm:^3.0.0"
-  checksum: 10/5ec6d022d12e016347e9e3e98a7eb2a592213a43a65f1b61b74d2c78288da0aded781f665807a9f3876b9daa9ad94f64f77d7633a0458876c3a4fdc4eb223f24
-  languageName: node
-  linkType: hard
-
 "slice-ansi@npm:^4.0.0":
   version: 4.0.0
   resolution: "slice-ansi@npm:4.0.0"
@@ -25240,6 +25148,16 @@ __metadata:
     ansi-styles: "npm:^6.2.1"
     is-fullwidth-code-point: "npm:^5.0.0"
   checksum: 10/10313dd3cf7a2e4b265f527b1684c7c568210b09743fd1bd74f2194715ed13ffba653dc93a5fa79e3b1711518b8990a732cb7143aa01ddafe626e99dfa6474b2
+  languageName: node
+  linkType: hard
+
+"slice-ansi@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "slice-ansi@npm:8.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    is-fullwidth-code-point: "npm:^5.1.0"
+  checksum: 10/6a7e146852047e26dd5857b35c767e52906549c580cce0ad2287cc32f54f5a582494f674817fc9ac21b2e4ac1ddeaa85b3dee409782681b465330278890c73a8
   languageName: node
   linkType: hard
 
@@ -25732,7 +25650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^8.2.1":
+"string-width@npm:^8.2.0, string-width@npm:^8.2.1":
   version: 8.2.2
   resolution: "string-width@npm:8.2.2"
   dependencies:
@@ -26396,6 +26314,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"systeminformation@npm:^5.31.1":
+  version: 5.33.10
+  resolution: "systeminformation@npm:5.33.10"
+  bin:
+    systeminformation: lib/cli.js
+  checksum: 10/2c3d85d90da2410b362f444919f8e476d2cebfae4c6a371e34f127b7012f75c9d0b2204473cc4c59a1615b1ea415b8ec213a4d3c069bd992f9384a26a5e8aa30
+  conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
+  languageName: node
+  linkType: hard
+
 "tabbable@npm:^6.0.0, tabbable@npm:^6.3.0":
   version: 6.4.0
   resolution: "tabbable@npm:6.4.0"
@@ -26644,7 +26572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.1":
+"through@npm:2, through@npm:~2.3, through@npm:~2.3.1":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10/5da78346f70139a7d213b65a0106f3c398d6bc5301f9248b5275f420abc2c4b1e77c2abc72d218dedc28c41efb2e7c312cb76a7730d04f9c2d37d247da3f4198
@@ -26766,17 +26694,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.3, tmp@npm:^0.2.7":
+"tmp@npm:^0.2.3, tmp@npm:^0.2.7, tmp@npm:~0.2.4":
   version: 0.2.7
   resolution: "tmp@npm:0.2.7"
   checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
-  languageName: node
-  linkType: hard
-
-"tmp@npm:~0.2.3":
-  version: 0.2.3
-  resolution: "tmp@npm:0.2.3"
-  checksum: 10/7b13696787f159c9754793a83aa79a24f1522d47b87462ddb57c18ee93ff26c74cbb2b8d9138f571d2e0e765c728fb2739863a672b280528512c6d83d511c6fa
   languageName: node
   linkType: hard
 
@@ -27735,15 +27656,6 @@ __metadata:
   bin:
     uuid: dist-node/bin/uuid
   checksum: 10/2742b24d1e00257e60612572e4d28679423469998cafbaf1fe9f1482e3edf9c40754b31bfdb3d08d71b29239f227a304588f75210b3b48f2609f0673f1feccef
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10/9a5f7aa1d6f56dd1e8d5f2478f855f25c645e64e26e347a98e98d95781d5ed20062d6cca2eecb58ba7c84bc3910be95c0451ef4161906abaab44f9cb68ffbdd1
   languageName: node
   linkType: hard
 
@@ -28842,6 +28754,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:^7.2.0":
+  version: 7.5.13
+  resolution: "ws@npm:7.5.13"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/0873c813ce75c466b026ce0a4ce9a8b5b5f1dc9ef0dd7ae9690fa4025c66afb165d3a45550357080b29d66a0e3028cd13c72ccefc83ce10723b4822a574ebc99
+  languageName: node
+  linkType: hard
+
 "ws@npm:^8.11.0":
   version: 8.21.0
   resolution: "ws@npm:8.21.0"
@@ -29150,17 +29077,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
-  dependencies:
-    buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10/1e4c311050dc0cf2ee3dbe8854fe0a6cde50e420b3e561a8d97042526b4cf7a0718d6c8d89e9e526a152f4a9cec55bcea9c3617264115f48bd6704cf12a04445
-  languageName: node
-  linkType: hard
-
-"yauzl@npm:^3.2.1":
+"yauzl@npm:^3.2.1, yauzl@npm:^3.3.1":
   version: 3.4.0
   resolution: "yauzl@npm:3.4.0"
   dependencies:


### PR DESCRIPTION
e2e: migrate Cypress test suite to Cypress 16

### What changed
- **Cypress 16 upgrade** (`^14.3.3` → `^16.0.0`) and **`@cypress/grep` upgrade** (`^4.1.0` → `^7.0.0`) in `package.json` / `yarn.lock`
- **`cypress-file-upload` removed**: all `.attachFile()` calls replaced with Cypress 16's built-in `.selectFile()` across `datamapper.ts`; fixture paths updated to include the `cypress/fixtures/` prefix as now required by `selectFile`
- **Expression field typing fixed** (`basicXml.cy.ts`): added `delay: 50` default in `interactWithExpressionInputObject` to prevent a race condition on model-driven controlled textareas where fast typing caused all but the last character to be dropped



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated DataMapper end-to-end tests to reliably locate schema and mapping fixtures.
  - Improved test file-upload handling for schemas and mappings.
  - Stabilized XML expression field interactions with a brief input delay.
  - Updated test support for current Cypress reporting and execution behavior.

- **Chores**
  - Refreshed the UI testing setup to maintain compatibility with the latest test tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->