### PR TITLE
fix(ci): avoid unresolved matrix expressions and skipped placeholders in VS Code UI tests

### DIFF
--- a/.github/workflows/kaoto-vscode-ui-tests.yml
+++ b/.github/workflows/kaoto-vscode-ui-tests.yml
@@ -119,13 +119,12 @@ jobs:
 
   views:
     name: Views (${{ matrix.os }})
-    if: inputs.run-full-ui-tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ inputs.run-full-ui-tests && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('[]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -166,13 +165,12 @@ jobs:
 
   export:
     name: Project Export (${{ matrix.os }})
-    if: inputs.run-full-ui-tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ${{ inputs.run-full-ui-tests && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('[]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -212,10 +210,13 @@ jobs:
           storage-path: ${{ runner.temp }}/kaoto-tests
 
   deployment:
-    name: Deployment (ubuntu-latest)
-    if: inputs.run-deploy-tests
-    runs-on: ubuntu-latest
+    name: Deployment (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ inputs.run-deploy-tests && fromJSON('["ubuntu-latest"]') || fromJSON('[]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -244,5 +245,5 @@ jobs:
         uses: ./.github/actions/kaoto-vscode-upload-test-artifacts
         with:
           test-group: deployment
-          os-name: ubuntu-latest
+          os-name: ${{ matrix.os }}
           storage-path: ${{ runner.temp }}/kaoto-tests


### PR DESCRIPTION
<img width="304" height="357" alt="image" src="https://github.com/user-attachments/assets/ea4588e9-f4d8-4410-b64d-3b483b28bb07" />

## Motivation

When CI job selection triggers only a subset of the VS Code integration tests (such as during smoke testing where `run-full-ui-tests: false` and `run-deploy-tests: false`), matrix jobs skipped via top-level `if:` conditions cause GitHub Actions to display raw, unexpanded template strings in the workflow sidebar (e.g. `Views (${{ matrix.os }})` and `Project Export (${{ matrix.os }})`).

Furthermore, displaying skipped placeholder jobs adds visual clutter and confusion when running targeted test subsets.

## Summary of Changes

- Replaced top-level `if:` checks with dynamic matrix definitions using `fromJSON(...)` across the `views`, `export`, and `deployment` jobs in [`.github/workflows/kaoto-vscode-ui-tests.yml`](.github/workflows/kaoto-vscode-ui-tests.yml):
  - When disabled (`false`), the matrix resolves to `[]` (empty list), generating zero placeholder jobs in the UI.
  - When enabled (`true`), the matrix expands cleanly to the expected operating systems.
- Standardized the `deployment` job configuration to use `matrix.os` and dynamic evaluation, maintaining consistency across all integration test suites.

## Verification

- Ran `.github/scripts/ci-changes.test.mjs` unit tests.
- Verified workflow YAML syntax.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified UI and deployment test workflow labels for clearer identification in automated test runs.
  * Test execution behavior, runner configuration, and conditions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->