### PR TITLE
fix: stabilise flaky 'Toggle Source Code' Windows UI test

### DIFF
--- a/packages/kaoto-vscode/src/ui-test/editor/OpenTextualEditorCommand.test.ts
+++ b/packages/kaoto-vscode/src/ui-test/editor/OpenTextualEditorCommand.test.ts
@@ -59,7 +59,26 @@ describe('Toggle Source Code', function () {
 		expect(groupsNum).to.equal(2);
 
 		const editor = new TextEditor(await editorView.getEditorGroup(1));
-		expect(await editor.getTextAtLine(1)).contains('- route:');
+		// Ensure the editor is focused so the status bar updates its cursor position.
+		// On slow CI runners (especially Windows) the status bar may not reflect a
+		// valid "Ln X, Col Y" within the library's default 5 s timeout unless the
+		// editor is explicitly activated first.
+		await editor.click();
+
+		let text = '';
+		await editor.getDriver().wait(
+			async () => {
+				try {
+					text = await editor.getTextAtLine(1);
+					return true;
+				} catch {
+					return false;
+				}
+			},
+			10_000,
+			'Text editor was not ready within 10s',
+		);
+		expect(text).contains('- route:');
 	});
 
 	it('close text editor', async function () {


### PR DESCRIPTION
## Problem

The `open text editor to the side` test in `OpenTextualEditorCommand.test.ts` was failing intermittently on the Windows CI runner with:

```
TimeoutError: Status bar did not show a valid cursor position within 5000ms
```

### Root cause

The call chain is:
```
editor.getTextAtLine(1)
  → getText()
    → getCoordinates(timeout=5000)   ← timeout here
      → statusBar.getCurrentPosition()  polling for 'Ln X, Col Y'
```

The `getCoordinates()` method in `@redhat-developer/page-objects` polls the VS Code status bar for a valid cursor position. On slow Windows CI runners the status bar does not reflect the cursor position of the newly opened second editor group within the library's hard-coded 5 s default — causing a flaky failure.

## Fix

Two complementary changes in the failing test:

1. **`await editor.click()`** before reading text — explicitly focuses the editor so VS Code immediately updates the status bar cursor position.
2. **Retry loop around `getTextAtLine()`** (10 s timeout, same pattern as `waitForEditorGroupsLength`) — absorbs any remaining lag on slow runners without relying on fixed sleeps.

## Testing

- Lint and TypeScript compile clean (`yarn lint`, `yarn build:test:ui` in `packages/kaoto-vscode`).
- The fix cannot be verified fully locally (requires a running VS Code instance), but the logic mirrors the existing `waitForEditorGroupsLength` helper already used throughout this test file.
- The change is confined to the test file only — no production code is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for opening the textual editor beside the current view.
  * Added handling for activation delays and temporary errors before verifying route content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->